### PR TITLE
TRUD-automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ site/
 
 # Node modules
 node_modules/
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ site/
 # Node modules
 node_modules/
 
-.env
+.config/sct/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,8 +2077,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
+ "sha2",
  "tempfile",
  "tokio",
+ "toml",
  "ureq",
  "walkdir",
  "zip",
@@ -2148,6 +2150,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2482,6 +2493,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3054,6 +3106,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ parquet = { version = "58", features = ["arrow"] }
 arrow = { version = "58", default-features = false, features = ["ipc"] }
 indicatif = "0.18"
 ureq = { version = "3", features = ["json"] }
+sha2 = "0.10"
+toml = "0.8"
 serde_yml = "0.0.12"
 chrono = { version = "0.4.44", default-features = false, features = ["std", "clock"] }
 

--- a/docs/commands/trud.md
+++ b/docs/commands/trud.md
@@ -1,0 +1,490 @@
+# sct trud
+
+Download SNOMED CT RF2 releases directly from [NHS TRUD](https://isd.digital.nhs.uk/trud)
+using the TRUD REST API. Handles authentication, SHA-256 integrity verification, and optional
+pipeline chaining so a single command can take you from API key to a fully-built SQLite
+database.
+
+---
+
+## Prerequisites
+
+### 1 — Create a TRUD account and subscribe
+
+1. Register at [isd.digital.nhs.uk/trud](https://isd.digital.nhs.uk/trud/users/guest/filters/0/account/form)
+2. Once logged in, subscribe to the editions you need:
+   - **UK Monolith** (item 1799) — recommended for most users; includes International + UK Clinical + UK Drug (dm+d) + UK Pathology in one merged zip. Snapshot only.
+   - **UK Clinical Edition** (item 101) — International + UK Clinical, without dm+d.
+   - **UK Drug Extension** (item 105) — dm+d prescribing/medicines concepts only.
+
+### 2 — Get your API key
+
+Your API key is shown on your [TRUD account page](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/account/manage)
+once you are signed in. It is unique to your account and derived from your email address and
+password — if either changes, a new key is generated and the old one is disabled immediately.
+
+**Keep your API key private.** Anyone who has it can download releases as if they were you.
+
+---
+
+## Supplying the API key
+
+`sct trud` accepts the key via four methods, checked in this order (first non-empty value wins):
+
+| Priority | Method | Notes |
+|---|---|---|
+| 1 | `--api-key <KEY>` | Plain string on the command line. Avoid: visible in `ps` output and shell history. |
+| 2 | `--api-key-file <PATH>` | Path to a file whose **first line** is the key. Trailing whitespace is stripped. |
+| 3 | `$TRUD_API_KEY` environment variable | **Recommended** for regular use, cron jobs, and CI/CD. |
+| 4 | `api_key` in `~/.config/sct/config.toml` | Convenient for interactive use on a personal machine. |
+
+### Using an environment variable (recommended)
+
+```bash
+export TRUD_API_KEY=your-key-here
+sct trud list
+```
+
+Or for a single command without polluting the environment:
+
+```bash
+TRUD_API_KEY=your-key-here sct trud download --edition uk_monolith
+```
+
+### Using a key file (recommended for interactive use)
+
+The conventional location is `~/.config/sct/trud-api-key`. The file must contain only the
+key on the first line (trailing whitespace is stripped). Set permissions to `600` and
+**never commit this file to version control**:
+
+```bash
+mkdir -p ~/.config/sct
+echo "your-key-here" > ~/.config/sct/trud-api-key
+chmod 600 ~/.config/sct/trud-api-key
+sct trud list --api-key-file ~/.config/sct/trud-api-key
+```
+
+For convenience, add this to `~/.config/sct/config.toml` so you do not need to pass the
+flag every time (see [Config file](#config-file) below).
+
+### Using the config file
+
+Create `~/.config/sct/config.toml`:
+
+```toml
+[trud]
+api_key = "your-key-here"
+download_dir = "~/.local/share/sct/releases"   # optional; this is the default
+```
+
+---
+
+## Connectivity pre-flight check
+
+Every `sct trud` command automatically verifies that the TRUD service is reachable before
+making any authenticated request. If the check fails you will see:
+
+```
+Cannot reach NHS TRUD (https://isd.digital.nhs.uk/…).
+
+The service may be offline or undergoing scheduled maintenance.
+TRUD maintenance windows: weekdays 18:00–08:00 UK time, and midnight–06:00.
+
+Original error: …
+```
+
+This check is connection-level only — any HTTP response from TRUD (even an error page) counts
+as "reachable". Only DNS failures, TCP timeouts, or TLS errors trigger this message.
+
+> **Tip:** If `sct trud` fails during a scheduled automation run, check the time against the
+> TRUD maintenance window before investigating further.
+
+---
+
+## Subcommands
+
+### `sct trud list` — see what's available
+
+```
+sct trud list [--edition <NAME>] [--item <N>]
+```
+
+Lists all available releases for an edition, newest first.
+
+```bash
+sct trud list                          # UK Monolith (default)
+sct trud list --edition uk_clinical
+sct trud list --edition uk_drug
+sct trud list --item 1799              # raw TRUD item number
+```
+
+Example output:
+
+```
+File                                          Released     Size      SHA-256 (first 12 chars)
+uk_sct2mo_41.6.0_20260311000001Z.zip          2026-03-18   1.8 GB    285354105EA8
+uk_sct2mo_41.5.0_20260211000001Z.zip          2026-02-18   1.8 GB    91c2a4830f1b
+uk_sct2mo_41.4.0_20260114000001Z.zip          2026-01-14   1.8 GB    c3d7a2940e1c
+```
+
+---
+
+### `sct trud check` — is there a newer release?
+
+```
+sct trud check [--edition <NAME>] [--item <N>]
+```
+
+Compares the latest available release against what is already in your download directory.
+
+```bash
+sct trud check                         # UK Monolith (default)
+sct trud check --edition uk_drug
+```
+
+Possible output:
+
+```
+Up to date: uk_sct2mo_41.6.0_20260311000001Z.zip (2026-03-18)
+```
+
+```
+New release available: uk_sct2mo_41.6.0_20260311000001Z.zip (2026-03-18)
+Currently have:        uk_sct2mo_41.5.0_20260211000001Z.zip (2026-02-18)
+```
+
+**Exit codes:**
+
+| Code | Meaning |
+|---|---|
+| `0` | Already up to date |
+| `2` | New release available |
+| `1` | Error (network, bad key, etc.) |
+
+The `2` exit code (not `1`) is deliberate — it lets shell scripts distinguish "update
+available" from an error without using `set -e` workarounds:
+
+```bash
+sct trud check --edition uk_monolith
+if [ $? -eq 2 ]; then
+    sct trud download --edition uk_monolith --pipeline
+fi
+```
+
+---
+
+### `sct trud download` — download a release
+
+```
+sct trud download [--edition <NAME>] [--item <N>]
+                  [--latest | --release <VERSION>]
+                  [--output-dir <PATH>]
+                  [--skip-if-current]
+                  [--pipeline] [--pipeline-full]
+```
+
+Downloads the release zip to `~/.local/share/sct/releases/` (or `download_dir` from config,
+or `--output-dir`). The SHA-256 checksum is verified before the file is committed — if it does
+not match, the partial download is deleted and an error is returned.
+
+Built artefacts produced by `--pipeline` (NDJSON, SQLite, Parquet, Arrow) are written to
+`~/.local/share/sct/data/` (or `data_dir` from config, or `--data-dir`),
+keeping source zips and built files in separate directories.
+
+#### Download the latest UK Monolith
+
+```bash
+sct trud download
+# Saves: ~/.local/share/sct/releases/uk_sct2mo_41.6.0_20260311000001Z.zip
+```
+
+#### Download and immediately build the full pipeline
+
+```bash
+sct trud download --pipeline
+```
+
+This runs `sct ndjson` then `sct sqlite` automatically after the download completes:
+
+```
+Downloading uk_sct2mo_41.6.0_20260311000001Z.zip (1.8 GB) ...
+  [########################################] 1.8 GB/1.8 GB (2m 14s)
+✓ Saved: ~/.local/share/sct/releases/uk_sct2mo_41.6.0_20260311000001Z.zip
+
+→ Running: sct ndjson
+→ Running: sct sqlite
+✓ Pipeline complete.
+  NDJSON: ~/.local/share/sct/data/uk_sct2mo_41.6.0_20260311000001Z.ndjson
+  SQLite: ~/.local/share/sct/data/uk_sct2mo_41.6.0_20260311000001Z.db
+```
+
+#### Download, build, and also compute the transitive closure table + embeddings
+
+```bash
+sct trud download --pipeline-full
+```
+
+Runs `sct ndjson` → `sct sqlite` → `sct tct` → `sct embed`. The embed step requires
+[Ollama](https://ollama.com) to be running locally (`ollama serve`); if it is not reachable,
+that step is skipped with a warning and the rest of the pipeline still completes.
+
+#### Skip the download if already current (safe for cron)
+
+```bash
+sct trud download --skip-if-current --pipeline
+```
+
+Checks whether the latest release zip is already present and its SHA-256 matches. If so,
+does nothing (exit 0). Useful in scheduled jobs where you want the pipeline to run on the
+first invocation after a release but be a no-op on all others.
+
+#### Download a specific older release
+
+```bash
+sct trud download --release 41.5.0
+```
+
+#### Save to a specific directory
+
+```bash
+sct trud download --output-dir /data/snomed/
+```
+
+---
+
+## Options reference
+
+### Common flags (all subcommands)
+
+| Flag | Description |
+|---|---|
+| `--edition <NAME>` | Named edition: `uk_monolith` (default), `uk_clinical`, `uk_drug` |
+| `--item <N>` | Raw TRUD item number — overrides `--edition` |
+| `--api-key <KEY>` | API key as a plain string |
+| `--api-key-file <PATH>` | File whose first line is the API key |
+
+### `sct trud download` flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--latest` | on | Download the most recent release |
+| `--release <VERSION>` | — | Download a specific version (e.g. `41.5.0`) |
+| `--output-dir <PATH>` | `$SCT_DATA_HOME/releases` | Where to save the downloaded zip |
+| `--data-dir <PATH>` | `$SCT_DATA_HOME/data` | Where to write built artefacts (NDJSON, SQLite, …) |
+| `--skip-if-current` | off | Do nothing if the latest zip is already cached with a matching checksum |
+| `--pipeline` | off | Auto-run `sct ndjson` + `sct sqlite` after download |
+| `--pipeline-full` | off | As `--pipeline`, plus `sct tct` + `sct embed` |
+
+---
+
+## Directory layout
+
+`sct trud` uses a single base directory, defaulting to `~/.local/share/sct/`, with two
+subdirectories:
+
+```
+~/.local/share/sct/
+├── releases/   ← downloaded RF2 zips
+└── data/       ← built artefacts (.ndjson, .db, .parquet, .arrow)
+```
+
+Configuration and credentials live in `~/.config/sct/`:
+
+```
+~/.config/sct/
+├── config.toml     ← optional config (editions, download_dir, data_dir, …)
+└── trud-api-key    ← API key file (plain text, first line only; chmod 600)
+```
+
+> **Never commit `~/.config/sct/trud-api-key` or any file containing your TRUD API key**
+> to version control. If your key is exposed, regenerate it immediately on your
+> [TRUD account page](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/account/manage).
+
+Set `$SCT_DATA_HOME` to override the base:
+
+```bash
+export SCT_DATA_HOME=/mnt/snomed-store
+# zips  → /mnt/snomed-store/releases/
+# built → /mnt/snomed-store/data/
+```
+
+Individual directories can be overridden finer-grained via `--output-dir` / `--data-dir`
+flags or `download_dir` / `data_dir` in `~/.config/sct/config.toml`.
+
+---
+
+## Config file
+
+`~/.config/sct/config.toml` — `sct trud` reads but never writes this file.
+
+```toml
+[trud]
+api_key      = "your-key-here"         # omit if using $TRUD_API_KEY
+download_dir = "~/.local/share/sct/releases"   # optional; overrides $SCT_DATA_HOME/releases
+data_dir     = "~/.local/share/sct/data"       # optional; overrides $SCT_DATA_HOME/data
+default_edition = "uk_monolith"
+
+# Override a built-in edition or add a custom one:
+[trud.editions.uk_monolith]
+trud_item = 1799
+
+[trud.editions.my_org_special]
+trud_item = 42
+```
+
+---
+
+## Automating updates
+
+UK SNOMED releases are published roughly monthly, typically on a Wednesday. TRUD recommends
+running automation between **08:00–18:00** or **midnight–06:00 UK time**.
+
+### macOS — launchd (runs weekly, Wednesday 09:00)
+
+Save as `~/Library/LaunchAgents/uk.nhs.sct.trud-sync.plist`, then load it:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>              <string>uk.nhs.sct.trud-sync</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/sct</string>
+        <string>trud</string><string>download</string>
+        <string>--edition</string><string>uk_monolith</string>
+        <string>--skip-if-current</string>
+        <string>--pipeline</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TRUD_API_KEY</key><string>your-key-here</string>
+    </dict>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key><integer>3</integer>
+        <key>Hour</key><integer>9</integer>
+        <key>Minute</key><integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>  <string>/tmp/sct-trud-sync.log</string>
+    <key>StandardErrorPath</key><string>/tmp/sct-trud-sync.log</string>
+</dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/uk.nhs.sct.trud-sync.plist
+```
+
+### Linux — systemd user timer
+
+`~/.config/systemd/user/sct-trud.service`:
+
+```ini
+[Unit]
+Description=sct SNOMED TRUD sync
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sct trud download --edition uk_monolith --skip-if-current --pipeline
+EnvironmentFile=%h/.config/sct/env
+```
+
+`~/.config/systemd/user/sct-trud.timer`:
+
+```ini
+[Unit]
+Description=Weekly SNOMED TRUD sync — Wednesday 09:00
+
+[Timer]
+OnCalendar=Wed *-*-* 09:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+# ~/.config/sct/env — permissions should be 600
+TRUD_API_KEY=your-key-here
+```
+
+```bash
+systemctl --user enable --now sct-trud.timer
+```
+
+### Crontab
+
+```cron
+# Weekly Wednesday 09:00 — check and rebuild if a new SNOMED release is available
+0 9 * * 3  TRUD_API_KEY=your-key sct trud download --edition uk_monolith --skip-if-current --pipeline >> ~/.local/share/sct/trud-sync.log 2>&1
+```
+
+### GitHub Actions
+
+```yaml
+name: Update SNOMED release
+on:
+  schedule:
+    - cron: '0 9 * * 3'   # weekly, Wednesday 09:00 UTC
+  workflow_dispatch:        # allow manual trigger
+
+jobs:
+  trud-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install sct
+        run: cargo install sct-rs
+
+      - name: Check for new release
+        id: check
+        run: |
+          sct trud check --edition uk_monolith
+          echo "status=$?" >> $GITHUB_OUTPUT
+        env:
+          TRUD_API_KEY: ${{ secrets.TRUD_API_KEY }}
+        continue-on-error: true   # exit 2 must not fail the step
+
+      - name: Download and build
+        if: steps.check.outputs.status == '2'
+        run: sct trud download --edition uk_monolith --pipeline
+        env:
+          TRUD_API_KEY: ${{ secrets.TRUD_API_KEY }}
+```
+
+---
+
+## Troubleshooting
+
+### "Cannot reach NHS TRUD"
+
+The TRUD service is not reachable. Check:
+
+1. **Maintenance window** — TRUD is offline weekdays 18:00–08:00 UK time and midnight–06:00.
+2. **Network connectivity** — can you load [isd.digital.nhs.uk](https://isd.digital.nhs.uk) in a browser?
+3. **Firewall / proxy** — some corporate networks block direct HTTPS to NHS services.
+
+### "Invalid API key (HTTP 400)"
+
+Your API key is wrong or has been regenerated. Get the current key from your [TRUD account page](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/account/manage).
+Regeneration happens automatically when you change your TRUD email address or password.
+
+### "No releases found … not subscribed (HTTP 404)"
+
+Your account exists but is not subscribed to this item. Log in to TRUD and subscribe to the
+item (1799 for Monolith, 101 for Clinical Edition, 105 for Drug Extension).
+
+### "SHA-256 checksum mismatch"
+
+The downloaded file is corrupt. The partial file has been deleted automatically. Re-run the
+command — this is almost always a transient network issue.
+
+### `--pipeline` fails at the `sct ndjson` step
+
+Check that the downloaded zip is a valid SNOMED RF2 Snapshot archive. The UK Monolith
+(item 1799) ships Snapshot only — if you downloaded a different item that ships Full or Delta
+files, `sct ndjson` will need the Snapshot sub-directory pointed to explicitly.

--- a/docs/uk-edition-structure.md
+++ b/docs/uk-edition-structure.md
@@ -156,11 +156,13 @@ included in TRUD downloads.
 
 ## Which TRUD item should I download?
 
-- [Item 101](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/101/releases) — **UK Clinical Edition** — International + UK Clinical extension (no dm+d drugs)
-- [Item 105](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/105/releases) — **UK Monolith** — International + UK Clinical + dm+d all-in-one
+- [Item 1799](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/1799/releases) — **UK Monolith** — International + UK Clinical + UK Drug (dm+d) + UK Pathology, fully merged and de-duplicated. Snapshot only.
+- [Item 101](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/101/releases) — **UK Clinical Edition** — International + UK Clinical extension (no dm+d drugs). Full, Snapshot & Delta.
+- [Item 105](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/categories/26/items/105/releases) — **UK Drug Extension (dm+d)** — prescribing/medicines concepts only. Full, Snapshot & Delta.
 
-For most clinical/GP use cases, the **Monolith (item 105)** is recommended — it includes everything
-in a single zip with no layering to deal with.
+For most clinical/GP use cases, the **Monolith (item 1799)** is recommended — it includes everything
+in a single zip with no layering to deal with. Note that the Monolith ships Snapshot only; use items
+101 + 105 if you need Full or Delta files.
 
 Releases are roughly **every 6 months** (major) with minor releases approximately every 6 weeks
 following the SNOMED International release cycle.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -63,14 +63,71 @@ sct --version
 
 SNOMED CT is distributed as RF2 (Release Format 2) — a set of TSV files.
 
-- **UK edition (recommended):** Download the UK Monolith from [NHS TRUD](https://isd.digital.nhs.uk/trud)
-  - Includes: International release + UK Clinical extension + UK Drug (dm+d) + UK Pathology extension, all pre-merged and de-duplicated
-  - Monolith (item **1799**) is preferred over the Clinical Edition (item 101) — it's a single zip with everything
-  - Note: item 105 is the UK Drug Extension (dm+d) on its own — not the Monolith
-- **International edition:** Download from [SNOMED MLDS](https://mlds.ihtsdotools.org/)
+### Option A — Automated download with `sct trud` (recommended for UK users)
+
+`sct trud` authenticates with [NHS TRUD](https://isd.digital.nhs.uk/trud), downloads the
+correct release zip, verifies its SHA-256 checksum, and can optionally run the full build
+pipeline in one command.
+
+**Full details:** [`sct trud`](commands/trud.md)
+
+#### 1. Get your TRUD API key
+
+1. Register or sign in at [isd.digital.nhs.uk/trud](https://isd.digital.nhs.uk/trud/users/guest/filters/0/account/form)
+2. Subscribe to the **UK Monolith** (item 1799) — includes International + UK Clinical + UK Drug (dm+d) + UK Pathology, pre-merged
+3. Your API key is shown on your [TRUD account page](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/account/manage)
+
+The key is a plain string. It is tied to your account credentials: if you change your TRUD
+email or password, the key is regenerated and the old one stops working immediately.
+
+#### 2. Store the key safely
+
+The conventional location is `~/.config/sct/trud-api-key` — a plain text file with the key
+on the first line and no other content:
+
+```bash
+mkdir -p ~/.config/sct
+echo "your-key-here" > ~/.config/sct/trud-api-key
+chmod 600 ~/.config/sct/trud-api-key
+```
+
+> **Do not commit this file to version control.** If you accidentally expose the key,
+> regenerate it immediately from your TRUD account page.
+
+Alternatively, export it as an environment variable — useful for CI/CD and automation:
+
+```bash
+export TRUD_API_KEY=your-key-here
+```
+
+#### 3. Download and build
+
+```bash
+# Download the latest UK Monolith and immediately build the SQLite database
+sct trud download --api-key-file ~/.config/sct/trud-api-key \
+                  --edition uk_monolith \
+                  --pipeline
+
+# Zip saved to:  ~/.local/share/sct/releases/
+# SQLite at:     ~/.local/share/sct/data/uk_sct2mo_…SNAPSHOT.db
+```
+
+See [`sct trud`](commands/trud.md) for the full options reference, config file format,
+automation examples (launchd, systemd, cron, GitHub Actions), and troubleshooting.
+
+---
+
+### Option B — Manual download
+
+If you prefer to download the zip yourself:
+
+- **UK edition:** [NHS TRUD](https://isd.digital.nhs.uk/trud) — subscribe to item **1799** (UK Monolith, recommended)
+  - Includes: International + UK Clinical + UK Drug (dm+d) + UK Pathology, pre-merged
+  - Note: item 101 is the Clinical Edition (no dm+d); item 105 is the Drug Extension on its own
+- **International edition:** [SNOMED MLDS](https://mlds.ihtsdotools.org/)
 - **IPS Free Set:** Available without affiliate membership from SNOMED MLDS
 
-`sct` accepts ZIP files or extracted directories.
+`sct` accepts the zip directly or an already-extracted directory.
 
 > **Confused by the NHS TRUD download options?** See [UK Edition structure](uk-edition-structure.md)
 > for a plain-English guide to the different release types, what's in each zip, and how to decode the filenames.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -64,8 +64,9 @@ sct --version
 SNOMED CT is distributed as RF2 (Release Format 2) — a set of TSV files.
 
 - **UK edition (recommended):** Download the UK Monolith from [NHS TRUD](https://isd.digital.nhs.uk/trud)
-  - Includes: International release + UK clinical extension + dm+d drugs extension
-  - Monolith (item 105) is preferred over the Clinical Edition (item 101) — it's a single zip with everything pre-merged
+  - Includes: International release + UK Clinical extension + UK Drug (dm+d) + UK Pathology extension, all pre-merged and de-duplicated
+  - Monolith (item **1799**) is preferred over the Clinical Edition (item 101) — it's a single zip with everything
+  - Note: item 105 is the UK Drug Extension (dm+d) on its own — not the Monolith
 - **International edition:** Download from [SNOMED MLDS](https://mlds.ihtsdotools.org/)
 - **IPS Free Set:** Available without affiliate membership from SNOMED MLDS
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -112,6 +112,23 @@ sct trud download --api-key-file ~/.config/sct/trud-api-key \
 # SQLite at:     ~/.local/share/sct/data/uk_sct2mo_…SNAPSHOT.db
 ```
 
+or:
+
+```bash
+ct trud download --api-key ********** \
+                  --edition uk_monolith \
+                  --pipeline
+```
+
+These are all supported:
+
+| Priority | Method |
+| -- | -- |
+| 1 | `--api-key <KEY>` |
+| 2 | `--api-key-file <PATH>` |
+| 3 | `$TRUD_API_KEY` env var |
+| 4 | `config.toml` |
+
 See [`sct trud`](commands/trud.md) for the full options reference, config file format,
 automation examples (launchd, systemd, cron, GitHub Actions), and troubleshooting.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ nav:
       - sct parquet: commands/parquet.md
       - sct semantic: commands/semantic.md
       - sct sqlite: commands/sqlite.md
+      - sct tct: commands/tct.md
+      - sct trud: commands/trud.md
       - sct tui: commands/tui.md
   - Reference:
     - UK Edition Structure: uk-edition-structure.md

--- a/specs/commands/trud.md
+++ b/specs/commands/trud.md
@@ -1,0 +1,402 @@
+# `sct trud` — Automated SNOMED CT Release Downloads via NHS TRUD API
+
+Authenticate with the [NHS TRUD](https://isd.digital.nhs.uk/trud) REST API to list, check,
+and download SNOMED CT RF2 release files, with optional pipeline chaining to build the full
+`sct` artefact stack immediately after download.
+
+---
+
+## Background
+
+NHS TRUD (Technology Reference Update Distribution) is the distribution platform for UK
+SNOMED CT releases. It provides a REST API that allows authenticated account holders to list
+and download releases for items they are subscribed to.
+
+### TRUD API
+
+The API has two endpoints:
+
+| Purpose | URL |
+|---|---|
+| List releases | `GET https://isd.digital.nhs.uk/trud/api/v1/keys/{api_key}/items/{item_id}/releases` |
+| Latest release only | `GET …/releases?latest` |
+| Download | `GET {archiveFileUrl}` (URL from the list response) |
+
+The list response includes `archiveFileSha256` for integrity verification; `sct trud download`
+always verifies this after download and deletes the file if the checksum does not match.
+
+### Relevant TRUD item numbers
+
+| Item | Edition | Release types | Contents |
+|---|---|---|---|
+| **1799** | UK Monolith | Snapshot only | International + UK Clinical + UK Drug (dm+d) + UK Pathology, fully merged and de-duplicated |
+| **101** | UK Clinical Edition | Full, Snapshot & Delta | International + UK Clinical extension |
+| **105** | UK Drug Extension (dm+d) | Full, Snapshot & Delta | Prescribing/medicines concepts only |
+
+For most users the **Monolith (item 1799)** is the right default — it is a single zip containing
+everything, with conflicts and duplicates already resolved by NHS England.
+
+---
+
+## API key
+
+A TRUD API key is required. Each account has a unique key derived from the account's email
+address and password; it is shown on the [Your account](https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/account/manage)
+page. The key is invalidated if the email or password changes.
+
+**Keep the key private.** Anyone who has it can download releases as if they were you.
+
+### API key lookup order
+
+`sct trud` resolves the API key using the following precedence (highest to lowest). The first
+source that provides a non-empty value is used; the remaining sources are not consulted.
+
+1. `--api-key <KEY>` CLI flag (plain string — avoid where possible; the key is visible in
+   process listings and shell history)
+2. `--api-key-file <PATH>` CLI flag — path to a file whose first line is the API key; the file
+   may contain only the key and optional trailing whitespace
+3. `$TRUD_API_KEY` environment variable — **preferred for CI/CD and cron jobs**
+4. `api_key` field in the config file (`~/.config/sct/config.toml`)
+
+If no key is found from any source, `sct trud` exits with a clear error message directing the
+user to the TRUD account page.
+
+---
+
+## Configuration file
+
+`~/.config/sct/config.toml` — created by the user; `sct trud` reads but never writes it.
+
+```toml
+[trud]
+api_key = "your-trud-api-key-here"   # optional; prefer $TRUD_API_KEY in CI
+
+# Directory where downloaded zip files are stored.
+# Defaults to ~/.local/share/sct/releases if not set.
+download_dir = "~/.local/share/sct/releases"
+
+# Default edition to use when --edition is not supplied.
+# Must match a key under [trud.editions].
+default_edition = "uk_monolith"
+```
+
+### Edition profiles
+
+Built-in editions are defined internally. Users may override them or add custom profiles in
+the config file:
+
+```toml
+[trud.editions.uk_monolith]
+trud_item = 1799
+description = "UK Monolith (International + UK Clinical + UK Drug/dm+d + UK Pathology)"
+
+[trud.editions.uk_clinical]
+trud_item = 101
+description = "UK Clinical Edition (International + UK Clinical, no dm+d)"
+
+[trud.editions.uk_drug]
+trud_item = 105
+description = "UK Drug Extension (dm+d only)"
+```
+
+---
+
+## Subcommands
+
+### `sct trud list`
+
+List available releases for an edition, from newest to oldest.
+
+```
+sct trud list [--edition <NAME>] [--item <N>]
+              [--api-key <KEY>] [--api-key-file <PATH>]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--edition <NAME>` | `uk_monolith` | Named edition profile (see config). |
+| `--item <N>` | — | Raw TRUD item number; overrides `--edition`. |
+| `--api-key <KEY>` | — | API key as a plain string. |
+| `--api-key-file <PATH>` | — | Path to a file containing the API key. |
+
+**Output** (table to stdout):
+
+```
+Version                                    Released     Size      SHA-256 (first 12)
+uk_sct2mo_41.6.0_20260311000001Z.zip       2026-03-18   1.8 GB    285354105EA8…
+uk_sct2mo_41.5.0_20260211000001Z.zip       2026-02-18   1.8 GB    91c2a4830f1b…
+```
+
+---
+
+### `sct trud check`
+
+Check whether a newer release is available compared to what is already in `download_dir`.
+
+```
+sct trud check [--edition <NAME>] [--item <N>]
+               [--api-key <KEY>] [--api-key-file <PATH>]
+```
+
+Hits `…/releases?latest` and compares the `releaseDate` in the response against the newest
+matching zip already present in `download_dir`.
+
+**Exit codes:**
+
+| Code | Meaning |
+|---|---|
+| `0` | Already up to date |
+| `2` | A newer release is available |
+| `1` | Error (network failure, bad API key, etc.) |
+
+Exit code `2` (not `1`) for "update available" means `sct trud check` can be used safely in
+shell scripts without being confused with error conditions:
+
+```bash
+sct trud check --edition uk_monolith
+if [ $? -eq 2 ]; then
+    sct trud download --edition uk_monolith --pipeline
+fi
+```
+
+**Output examples:**
+
+```
+Up to date: uk_sct2mo_41.6.0_20260311000001Z.zip (2026-03-18)
+```
+
+```
+New release available: uk_sct2mo_41.6.0_20260311000001Z.zip (2026-03-18)
+Currently have:        uk_sct2mo_41.5.0_20260211000001Z.zip (2026-02-18)
+```
+
+---
+
+### `sct trud download`
+
+Download a release zip to `download_dir`.
+
+```
+sct trud download [--edition <NAME>] [--item <N>]
+                  [--latest | --release <VERSION>]
+                  [--output-dir <PATH>]
+                  [--api-key <KEY>] [--api-key-file <PATH>]
+                  [--skip-if-current]
+                  [--pipeline] [--pipeline-full]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--edition <NAME>` | `uk_monolith` | Named edition profile. |
+| `--item <N>` | — | Raw TRUD item number; overrides `--edition`. |
+| `--latest` | on | Download the most recent release. |
+| `--release <VERSION>` | — | Download a specific named version (e.g. `41.5.0`). Mutually exclusive with `--latest`. |
+| `--output-dir <PATH>` | `download_dir` from config | Directory to save the zip. |
+| `--api-key <KEY>` | — | API key as a plain string. |
+| `--api-key-file <PATH>` | — | Path to a file containing the API key. |
+| `--skip-if-current` | off | Do nothing (exit 0) if the latest release is already present and its SHA-256 matches. |
+| `--pipeline` | off | After a successful download, run `sct ndjson` then `sct sqlite` automatically. |
+| `--pipeline-full` | off | As `--pipeline`, plus `sct tct` and `sct embed` (Ollama must be running for embed). |
+
+#### Download behaviour
+
+1. Call the TRUD list endpoint (`?latest` or unfiltered for `--release`).
+2. If the target zip already exists in `output-dir` and its SHA-256 matches the TRUD response:
+   - With `--skip-if-current`: exit 0 silently.
+   - Without: re-use the existing file (no re-download) and continue to pipeline if requested.
+3. Stream the zip to `output-dir` using a temporary filename; show an `indicatif` progress bar
+   using the `Content-Length` response header.
+4. On completion, verify SHA-256. If the checksum does not match: delete the partial file and
+   exit with an error.
+5. On success: rename from the temporary filename to the final filename.
+
+#### `--pipeline` behaviour
+
+After a successful download, `--pipeline` automatically invokes:
+
+```
+sct ndjson  --rf2 <downloaded.zip>  --output <output-dir>/<name>.ndjson
+sct sqlite  --input <name>.ndjson   --output <output-dir>/<name>.db
+```
+
+`--pipeline-full` additionally runs:
+
+```
+sct tct    --db <name>.db
+sct embed  --input <name>.ndjson  --output <output-dir>/<name>.arrow
+```
+
+The embed step is skipped with a warning if Ollama is not reachable, rather than failing the
+whole pipeline.
+
+**Example — full automated update:**
+
+```bash
+sct trud download --edition uk_monolith --skip-if-current --pipeline-full
+```
+
+---
+
+## Automation
+
+TRUD recommends running automation between **08:00–18:00** or **midnight–06:00 UK time** to
+avoid planned maintenance windows. UK SNOMED releases are published roughly monthly on a
+Wednesday.
+
+### macOS — launchd
+
+Create `~/Library/LaunchAgents/uk.nhs.sct.trud-sync.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>uk.nhs.sct.trud-sync</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/sct</string>
+        <string>trud</string>
+        <string>download</string>
+        <string>--edition</string>
+        <string>uk_monolith</string>
+        <string>--skip-if-current</string>
+        <string>--pipeline</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>TRUD_API_KEY</key>
+        <string>your-key-here</string>
+    </dict>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key><integer>3</integer>
+        <key>Hour</key><integer>9</integer>
+        <key>Minute</key><integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/sct-trud-sync.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/sct-trud-sync.log</string>
+</dict>
+</plist>
+```
+
+Load with: `launchctl load ~/Library/LaunchAgents/uk.nhs.sct.trud-sync.plist`
+
+### Linux — systemd user timer
+
+`~/.config/systemd/user/sct-trud.service`:
+
+```ini
+[Unit]
+Description=sct SNOMED TRUD sync
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/sct trud download --edition uk_monolith --skip-if-current --pipeline
+EnvironmentFile=%h/.config/sct/env   # file containing TRUD_API_KEY=...
+```
+
+`~/.config/systemd/user/sct-trud.timer`:
+
+```ini
+[Unit]
+Description=Weekly SNOMED TRUD sync (Wednesday 09:00)
+
+[Timer]
+OnCalendar=Wed *-*-* 09:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable with: `systemctl --user enable --now sct-trud.timer`
+
+### Crontab
+
+```cron
+# Weekly Wednesday 09:00 — check and rebuild if a new SNOMED release is available
+0 9 * * 3  TRUD_API_KEY=<key> sct trud download --edition uk_monolith --skip-if-current --pipeline >> ~/.local/share/sct/trud-sync.log 2>&1
+```
+
+### GitHub Actions
+
+```yaml
+name: Update SNOMED release
+on:
+  schedule:
+    - cron: '0 9 * * 3'   # weekly, Wednesday 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  trud-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install sct
+        run: cargo install sct-rs
+
+      - name: Check for new release
+        id: check
+        run: |
+          sct trud check --edition uk_monolith
+          echo "exit=$?" >> $GITHUB_OUTPUT
+        env:
+          TRUD_API_KEY: ${{ secrets.TRUD_API_KEY }}
+        continue-on-error: true
+
+      - name: Download and build pipeline
+        if: steps.check.outputs.exit == '2'
+        run: sct trud download --edition uk_monolith --pipeline
+        env:
+          TRUD_API_KEY: ${{ secrets.TRUD_API_KEY }}
+```
+
+---
+
+## Implementation notes
+
+### Crate dependencies
+
+| Crate | Already in `Cargo.toml`? | Purpose |
+|---|---|---|
+| `ureq` | Yes (`v3`, features = `["json"]`) | All HTTP calls |
+| `indicatif` | Yes | Download progress bar |
+| `sha2` | **No — add to `Cargo.toml`** | SHA-256 checksum verification |
+| `toml` | **No — add to `Cargo.toml`** | Config file parsing |
+
+For the download stream, use `response.into_reader()` from `ureq 3.x` to pipe the response
+body to disk in chunks rather than loading the entire multi-GB zip into memory.
+
+### API key security
+
+- Never include the raw API key in log output or error messages. Truncate to the first 6
+  characters (e.g. `deadc0…`) if it must appear in a diagnostic message.
+- When reading from `--api-key-file`, trim all leading/trailing whitespace from the first line;
+  do not read beyond the first line.
+- Validate that the key is non-empty before making any network request.
+
+### Error handling
+
+| Condition | Behaviour |
+|---|---|
+| No API key found | Exit 1 with message directing user to TRUD account page and the four supply methods |
+| HTTP 400 from TRUD | Exit 1: "Invalid API key. Check your TRUD account page." |
+| HTTP 404 from TRUD | Exit 1: "No releases found — check your item number and TRUD subscription." |
+| SHA-256 mismatch | Delete partial file, exit 1: "Checksum mismatch — download may be corrupt." |
+| Disk full during download | Delete partial file, exit 1 with I/O error details |
+| Ollama unreachable during `--pipeline-full` | Skip embed step with warning; do not fail overall |
+
+### Relation to the library refactor
+
+`--pipeline` invokes `ndjson::run()` and `sqlite::run()` directly as Rust function calls, not
+as subprocess forks. This requires those functions to be callable as library functions —
+consistent with the refactor described in [`specs/library-rs.md`](../library-rs.md). If the
+library refactor has not yet landed, `--pipeline` can spawn `sct ndjson` / `sct sqlite` as
+child processes as a temporary measure, with a `// TODO: replace with direct call after
+library-rs refactor` comment.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -44,7 +44,9 @@ Full spec in [`specs/commands/codelist.md`](commands/codelist.md).
 ## Future / larger scope
 
 - [ ] **TRUD integration** — `sct trud` subcommand that authenticates with the NHS TRUD API
-      and downloads the latest UK Monolith RF2 release automatically
+      and downloads the latest UK release automatically. Key TRUD item numbers:
+      item **1799** (UK Monolith — Snapshot only; includes International + UK Clinical + UK Drug/dm+d + UK Pathology),
+      item **101** (UK Clinical Edition — Full/Snapshot/Delta), item **105** (UK Drug Extension/dm+d — Full/Snapshot/Delta)
 - [ ] **History files** — parse RF2 history substitution tables to map inactivated concept IDs
       forward to their replacements; expose via `snomed_resolve` MCP tool
 - [ ] **`sct serve`** — HTTP FHIR R4 terminology server backed by SQLite. Drop-in replacement

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -41,12 +41,18 @@ Full spec in [`specs/commands/codelist.md`](commands/codelist.md).
 
 ---
 
-## Future / larger scope
+## Completed
 
-- [ ] **TRUD integration** — `sct trud` subcommand that authenticates with the NHS TRUD API
-      and downloads the latest UK release automatically. Full spec in [`specs/commands/trud.md`](commands/trud.md).
-      Key TRUD item numbers: item **1799** (UK Monolith — Snapshot only; includes International + UK Clinical + UK Drug/dm+d + UK Pathology),
-      item **101** (UK Clinical Edition — Full/Snapshot/Delta), item **105** (UK Drug Extension/dm+d — Full/Snapshot/Delta)
+- [x] **TRUD integration** — `sct trud` subcommand authenticates with the NHS TRUD API and
+      downloads UK releases automatically, with SHA-256 verification, pre-flight health check,
+      optional `--pipeline` / `--pipeline-full` chaining, and standardised `~/.local/share/sct/`
+      directory layout. Full spec in [`specs/commands/trud.md`](commands/trud.md) and user docs
+      in [`docs/commands/trud.md`](../../docs/commands/trud.md).
+      Key TRUD item numbers: item **1799** (UK Monolith), item **101** (UK Clinical), item **105** (UK Drug/dm+d).
+
+---
+
+## Future / larger scope
 - [ ] **History files** — parse RF2 history substitution tables to map inactivated concept IDs
       forward to their replacements; expose via `snomed_resolve` MCP tool
 - [ ] **`sct serve`** — HTTP FHIR R4 terminology server backed by SQLite. Drop-in replacement

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -44,8 +44,8 @@ Full spec in [`specs/commands/codelist.md`](commands/codelist.md).
 ## Future / larger scope
 
 - [ ] **TRUD integration** — `sct trud` subcommand that authenticates with the NHS TRUD API
-      and downloads the latest UK release automatically. Key TRUD item numbers:
-      item **1799** (UK Monolith — Snapshot only; includes International + UK Clinical + UK Drug/dm+d + UK Pathology),
+      and downloads the latest UK release automatically. Full spec in [`specs/commands/trud.md`](commands/trud.md).
+      Key TRUD item numbers: item **1799** (UK Monolith — Snapshot only; includes International + UK Clinical + UK Drug/dm+d + UK Pathology),
       item **101** (UK Clinical Edition — Full/Snapshot/Delta), item **105** (UK Drug Extension/dm+d — Full/Snapshot/Delta)
 - [ ] **History files** — parse RF2 history substitution tables to map inactivated concept IDs
       forward to their replacements; expose via `snomed_resolve` MCP tool

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -97,6 +97,7 @@ Each command has its own spec in `specs/commands/`:
 | [`sct mcp`](commands/mcp.md) | 4 | Stdio MCP server over SQLite |
 | [`sct diff`](commands/diff.md) | — | Compare two NDJSON artefacts |
 | [`sct info`](commands/info.md) | — | Inspect any `sct`-produced file |
+| [`sct trud`](commands/trud.md) | — | Download SNOMED RF2 releases via NHS TRUD API |
 | [`sct lexical`](commands/lexical.md) | — | FTS5 keyword search |
 | [`sct semantic`](commands/semantic.md) | — | Cosine similarity search (Ollama) |
 | [`sct tui`](commands/tui.md) | — | Keyboard-driven terminal UI |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod parquet;
 pub mod semantic;
 pub mod sqlite;
 pub mod tct;
+pub mod trud;
 
 #[cfg(feature = "tui")]
 pub mod tui;

--- a/src/commands/trud.rs
+++ b/src/commands/trud.rs
@@ -1,0 +1,1276 @@
+//! `sct trud` — Download SNOMED CT RF2 releases via the NHS TRUD API.
+//!
+//! Subcommands:
+//!   sct trud list     — list available releases for an edition/item
+//!   sct trud check    — check whether a newer release is available (exit 0/2)
+//!   sct trud download — download a release, verifying SHA-256, with optional pipeline
+//!
+//! API key resolution order (first non-empty value wins):
+//!   1. --api-key <KEY>           plain string flag
+//!   2. --api-key-file <PATH>     first line of the named file
+//!   3. $TRUD_API_KEY             environment variable (recommended for CI/cron)
+//!   4. api_key in ~/.config/sct/config.toml
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use indicatif::{ProgressBar, ProgressStyle};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::io::{BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// TRUD endpoint constants — change here if NHS TRUD ever moves their API.
+// ---------------------------------------------------------------------------
+/// Base URL for the TRUD REST API (v1).
+const TRUD_API_BASE: &str = "https://isd.digital.nhs.uk/trud/api/v1";
+/// TRUD account page where users can find or regenerate their API key.
+const TRUD_ACCOUNT_URL: &str =
+    "https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/account/manage";
+/// Stable public TRUD page used as a connectivity pre-flight check.
+/// No authentication required. Any HTTP response (even 4xx/5xx) proves the
+/// host is reachable; only connection-level errors indicate the service is down.
+const TRUD_HEALTH_URL: &str = "https://isd.digital.nhs.uk/trud/users/guest/filters/0/home";
+
+// ---------------------------------------------------------------------------
+// sct directory layout constants
+// ---------------------------------------------------------------------------
+//
+// All sct-managed files live under a single base directory:
+//
+//   ~/.local/share/sct/          ($SCT_DATA_HOME overrides the whole base)
+//   ├── releases/                 downloaded RF2 zip files from TRUD
+//   └── data/                    built artefacts: .ndjson, .db, .parquet, .arrow
+//
+// Override the base with $SCT_DATA_HOME, or individual subdirs via config file
+// fields (download_dir, data_dir) or CLI flags (--output-dir, --data-dir).
+
+/// Sub-directory under the sct base for downloaded release zip files.
+const RELEASES_SUBDIR: &str = "releases";
+/// Sub-directory under the sct base for built artefacts (.ndjson, .db, etc.).
+const DATA_SUBDIR: &str = "data";
+
+// ---------------------------------------------------------------------------
+// CLI types
+// ---------------------------------------------------------------------------
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[command(subcommand)]
+    pub subcommand: TrudCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TrudCommand {
+    /// List available releases for a TRUD edition/item, newest first.
+    List(ListArgs),
+
+    /// Check whether a newer release is available.
+    ///
+    /// Exit codes: 0 = already up to date, 2 = new release available, 1 = error.
+    /// Use exit code 2 (not 1) in shell scripts to distinguish "update available"
+    /// from an error condition.
+    Check(CheckArgs),
+
+    /// Download a SNOMED CT RF2 release from TRUD, with SHA-256 verification.
+    Download(DownloadArgs),
+}
+
+/// Flags for supplying the TRUD API key — shared across all subcommands.
+#[derive(Parser, Debug)]
+struct KeyArgs {
+    /// TRUD API key as a plain string.
+    ///
+    /// Avoid where possible: the key is visible in process listings and shell
+    /// history. Prefer --api-key-file or the TRUD_API_KEY environment variable.
+    #[arg(long)]
+    api_key: Option<String>,
+
+    /// Path to a file whose first line is the TRUD API key.
+    ///
+    /// The file may contain only the key and optional trailing whitespace.
+    /// Only the first line is read.
+    #[arg(long)]
+    api_key_file: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct ListArgs {
+    /// Named edition profile: uk_monolith (default), uk_clinical, uk_drug.
+    #[arg(long, default_value = "uk_monolith")]
+    edition: String,
+
+    /// Raw TRUD item number — overrides --edition.
+    #[arg(long)]
+    item: Option<u32>,
+
+    #[command(flatten)]
+    key: KeyArgs,
+}
+
+#[derive(Parser, Debug)]
+pub struct CheckArgs {
+    /// Named edition profile: uk_monolith (default), uk_clinical, uk_drug.
+    #[arg(long, default_value = "uk_monolith")]
+    edition: String,
+
+    /// Raw TRUD item number — overrides --edition.
+    #[arg(long)]
+    item: Option<u32>,
+
+    #[command(flatten)]
+    key: KeyArgs,
+}
+
+#[derive(Parser, Debug)]
+pub struct DownloadArgs {
+    /// Named edition profile: uk_monolith (default), uk_clinical, uk_drug.
+    #[arg(long, default_value = "uk_monolith")]
+    edition: String,
+
+    /// Raw TRUD item number — overrides --edition.
+    #[arg(long)]
+    item: Option<u32>,
+
+    /// Download a specific named version (e.g. 41.5.0). Defaults to latest.
+    #[arg(long)]
+    release: Option<String>,
+
+    /// Directory for the downloaded RF2 zip.
+    /// Defaults to download_dir in config, then $SCT_DATA_HOME/releases.
+    #[arg(long)]
+    output_dir: Option<PathBuf>,
+
+    /// Directory for built artefacts produced by --pipeline / --pipeline-full
+    /// (.ndjson, .db, .arrow). Defaults to data_dir in config,
+    /// then $SCT_DATA_HOME/data.
+    #[arg(long)]
+    data_dir: Option<PathBuf>,
+
+    /// Do nothing (exit 0) if the latest release zip is already present and
+    /// its SHA-256 matches. Safe to use in cron jobs.
+    #[arg(long)]
+    skip_if_current: bool,
+
+    /// After a successful download, run `sct ndjson` then `sct sqlite` automatically.
+    #[arg(long)]
+    pipeline: bool,
+
+    /// As --pipeline, plus `sct tct` and `sct embed`.
+    /// The embed step is skipped with a warning if Ollama is not reachable.
+    #[arg(long)]
+    pipeline_full: bool,
+
+    #[command(flatten)]
+    key: KeyArgs,
+}
+
+// ---------------------------------------------------------------------------
+// TRUD API response types
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Debug)]
+struct TrudListResponse {
+    releases: Vec<TrudRelease>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct TrudRelease {
+    #[serde(rename = "archiveFileUrl")]
+    archive_file_url: String,
+    #[serde(rename = "archiveFileName")]
+    archive_file_name: String,
+    #[serde(rename = "archiveFileSizeBytes")]
+    archive_file_size_bytes: u64,
+    #[serde(rename = "archiveFileSha256")]
+    archive_file_sha256: String,
+    #[serde(rename = "releaseDate")]
+    release_date: String,
+}
+
+// ---------------------------------------------------------------------------
+// Config file types  (~/.config/sct/config.toml)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Default)]
+struct Config {
+    trud: Option<TrudConfig>,
+}
+
+#[derive(Deserialize, Default)]
+struct TrudConfig {
+    api_key: Option<String>,
+    /// Override for the RF2 zip download directory (default: $SCT_DATA_HOME/releases).
+    download_dir: Option<String>,
+    /// Override for the built-artefact directory (default: $SCT_DATA_HOME/data).
+    data_dir: Option<String>,
+    #[allow(dead_code)]
+    default_edition: Option<String>,
+    editions: Option<HashMap<String, EditionProfile>>,
+}
+
+#[derive(Deserialize)]
+struct EditionProfile {
+    trud_item: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Built-in edition definitions
+// ---------------------------------------------------------------------------
+
+struct BuiltinEdition {
+    trud_item: u32,
+    #[allow(dead_code)] // reserved for `sct trud list --editions` display
+    description: &'static str,
+}
+
+fn builtin_editions() -> HashMap<&'static str, BuiltinEdition> {
+    let mut m = HashMap::new();
+    m.insert(
+        "uk_monolith",
+        BuiltinEdition {
+            trud_item: 1799,
+            description:
+                "UK Monolith (International + UK Clinical + UK Drug/dm+d + UK Pathology)",
+        },
+    );
+    m.insert(
+        "uk_clinical",
+        BuiltinEdition {
+            trud_item: 101,
+            description: "UK Clinical Edition (International + UK Clinical, no dm+d)",
+        },
+    );
+    m.insert(
+        "uk_drug",
+        BuiltinEdition {
+            trud_item: 105,
+            description: "UK Drug Extension (dm+d only)",
+        },
+    );
+    m
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub fn run(args: Args) -> Result<()> {
+    match args.subcommand {
+        TrudCommand::List(a) => run_list(a),
+        TrudCommand::Check(a) => run_check(a),
+        TrudCommand::Download(a) => run_download(a),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// sct trud list
+// ---------------------------------------------------------------------------
+
+fn run_list(args: ListArgs) -> Result<()> {
+    let config = load_config();
+    let api_key = resolve_api_key(
+        args.key.api_key.as_deref(),
+        args.key.api_key_file.as_deref(),
+        &config,
+    )?;
+    let item_id = resolve_item_id(args.item, &args.edition, &config)?;
+
+    let releases = fetch_releases(&api_key, item_id, false)?;
+
+    if releases.is_empty() {
+        println!("No releases found for TRUD item {item_id}.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<52}  {:<12}  {:>8}  {}",
+        "File", "Released", "Size", "SHA-256 (first 12 chars)"
+    );
+    println!("{}", "-".repeat(92));
+    for r in &releases {
+        let sha_prefix = &r.archive_file_sha256[..r.archive_file_sha256.len().min(12)];
+        println!(
+            "{:<52}  {:<12}  {:>8}  {}",
+            r.archive_file_name,
+            r.release_date,
+            human_size(r.archive_file_size_bytes),
+            sha_prefix,
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// sct trud check
+// ---------------------------------------------------------------------------
+
+fn run_check(args: CheckArgs) -> Result<()> {
+    let config = load_config();
+    let api_key = resolve_api_key(
+        args.key.api_key.as_deref(),
+        args.key.api_key_file.as_deref(),
+        &config,
+    )?;
+    let item_id = resolve_item_id(args.item, &args.edition, &config)?;
+    let releases_dir = resolve_releases_dir(None, &config);
+
+    let releases = fetch_releases(&api_key, item_id, true)?;
+    let latest = releases
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No releases found for TRUD item {item_id}"))?;
+
+    let already_have = releases_dir.join(&latest.archive_file_name).exists();
+
+    if already_have {
+        println!(
+            "Up to date: {} ({})",
+            latest.archive_file_name, latest.release_date
+        );
+        // exit 0 — already current
+    } else {
+        println!(
+            "New release available: {} ({})",
+            latest.archive_file_name, latest.release_date
+        );
+        // exit 2 — not an error, but signals "please update"
+        std::process::exit(2);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// sct trud download
+// ---------------------------------------------------------------------------
+
+fn run_download(args: DownloadArgs) -> Result<()> {
+    let config = load_config();
+    let api_key = resolve_api_key(
+        args.key.api_key.as_deref(),
+        args.key.api_key_file.as_deref(),
+        &config,
+    )?;
+    let item_id = resolve_item_id(args.item, &args.edition, &config)?;
+    let releases_dir = resolve_releases_dir(args.output_dir.as_deref(), &config);
+    let data_dir   = resolve_data_dir(args.data_dir.as_deref(), &config);
+
+    std::fs::create_dir_all(&releases_dir)
+        .with_context(|| format!("creating releases directory {}", releases_dir.display()))?;
+    std::fs::create_dir_all(&data_dir)
+        .with_context(|| format!("creating data directory {}", data_dir.display()))?;
+
+    // Fetch release metadata
+    let latest_only = args.release.is_none();
+    let releases = fetch_releases(&api_key, item_id, latest_only)?;
+
+    let release = if let Some(ref version) = args.release {
+        releases
+            .into_iter()
+            .find(|r| r.archive_file_name.contains(version))
+            .ok_or_else(|| {
+                anyhow::anyhow!("No release found matching version '{version}' for item {item_id}")
+            })?
+    } else {
+        releases
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No releases found for TRUD item {item_id}"))?
+    };
+
+    let dest = releases_dir.join(&release.archive_file_name);
+
+    // Check if already present with a matching SHA-256
+    if dest.exists() {
+        let existing_hash = sha256_of_file(&dest)?;
+        if existing_hash.eq_ignore_ascii_case(&release.archive_file_sha256) {
+            if args.skip_if_current {
+                println!(
+                    "Already up to date: {} — skipping download.",
+                    release.archive_file_name
+                );
+                return run_pipeline_if_requested(&args, &dest, &data_dir);
+            }
+            println!(
+                "File already present with matching SHA-256: {}",
+                release.archive_file_name
+            );
+            return run_pipeline_if_requested(&args, &dest, &data_dir);
+        }
+        // Checksum mismatch — re-download
+        eprintln!(
+            "Warning: existing file has unexpected SHA-256 — re-downloading {}",
+            release.archive_file_name
+        );
+    }
+
+    println!(
+        "Downloading {} ({}) ...",
+        release.archive_file_name,
+        human_size(release.archive_file_size_bytes)
+    );
+
+    // Stream to a temp file; rename to final path only after checksum passes
+    let tmp_path = releases_dir.join(format!("{}.tmp", release.archive_file_name));
+
+    let resp = ureq::get(&release.archive_file_url)
+        .call()
+        .map_err(|e| anyhow::anyhow!("TRUD download request failed: {e}"))?;
+
+    let content_length: Option<u64> = resp
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok());
+
+    let pb = match content_length {
+        Some(total) => {
+            let pb = ProgressBar::new(total);
+            pb.set_style(
+                ProgressStyle::default_bar()
+                    .template(
+                        "{spinner:.green} [{elapsed_precise}] \
+                         [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})",
+                    )
+                    .unwrap()
+                    .progress_chars("#>-"),
+            );
+            pb
+        }
+        None => {
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .template("{spinner:.green} [{elapsed_precise}] {bytes} downloaded")
+                    .unwrap(),
+            );
+            pb
+        }
+    };
+    pb.enable_steady_tick(Duration::from_millis(120));
+
+    // Write to temp file while computing the SHA-256 in one pass
+    {
+        let tmp_file = std::fs::File::create(&tmp_path)
+            .with_context(|| format!("creating temporary file {}", tmp_path.display()))?;
+        let mut writer = BufWriter::new(tmp_file);
+        let mut hasher = Sha256::new();
+        let mut body_reader = resp.into_body().into_reader();
+        let mut buf = [0u8; 65536]; // 64 KiB chunks
+        let mut downloaded: u64 = 0;
+
+        loop {
+            let n = body_reader
+                .read(&mut buf)
+                .context("reading download response body")?;
+            if n == 0 {
+                break;
+            }
+            writer.write_all(&buf[..n]).context("writing to temp file")?;
+            hasher.update(&buf[..n]);
+            downloaded += n as u64;
+            pb.set_position(downloaded);
+        }
+        writer.flush().context("flushing temp file")?;
+
+        pb.finish_with_message(format!(
+            "Downloaded {} ({})",
+            release.archive_file_name,
+            human_size(downloaded)
+        ));
+
+        // Verify SHA-256 before committing the file
+        let computed = format!("{:X}", hasher.finalize());
+        if !computed.eq_ignore_ascii_case(&release.archive_file_sha256) {
+            std::fs::remove_file(&tmp_path).ok();
+            anyhow::bail!(
+                "SHA-256 checksum mismatch — download may be corrupt. Temporary file deleted.\n\
+                 Expected: {}\n\
+                 Got:      {}",
+                release.archive_file_sha256,
+                computed
+            );
+        }
+    }
+
+    // Rename temp → final
+    std::fs::rename(&tmp_path, &dest)
+        .with_context(|| format!("renaming temp file to {}", dest.display()))?;
+    println!("✓ Saved: {}", dest.display());
+    if args.pipeline || args.pipeline_full {
+        println!("  Built artefacts will go to: {}", data_dir.display());
+    }
+
+    run_pipeline_if_requested(&args, &dest, &data_dir)
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline chaining
+// ---------------------------------------------------------------------------
+
+fn run_pipeline_if_requested(
+    args: &DownloadArgs,
+    zip_path: &Path,
+    data_dir: &Path,
+) -> Result<()> {
+    if !args.pipeline && !args.pipeline_full {
+        return Ok(());
+    }
+
+    // Derive output filenames from the zip stem (lowercased)
+    let stem = zip_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("snomed")
+        .to_lowercase();
+    let ndjson_path = data_dir.join(format!("{stem}.ndjson"));
+    let db_path = data_dir.join(format!("{stem}.db"));
+
+    // --- sct ndjson ---
+    println!("\n→ Running: sct ndjson");
+    super::ndjson::run(super::ndjson::Args {
+        rf2_dirs: vec![zip_path.to_path_buf()],
+        locale: "en-GB".into(),
+        output: Some(ndjson_path.clone()),
+        include_inactive: false,
+    })
+    .context("sct ndjson step failed")?;
+
+    // --- sct sqlite ---
+    println!("\n→ Running: sct sqlite");
+    super::sqlite::run(super::sqlite::Args {
+        input: ndjson_path.clone(),
+        output: db_path.clone(),
+        transitive_closure: false,
+        include_self: false,
+    })
+    .context("sct sqlite step failed")?;
+
+    if args.pipeline_full {
+        // --- sct tct ---
+        println!("\n→ Running: sct tct");
+        super::tct::run(super::tct::Args {
+            db: db_path.clone(),
+            include_self: false,
+        })
+        .context("sct tct step failed")?;
+
+        // --- sct embed (best-effort — skip if Ollama unavailable) ---
+        println!("\n→ Running: sct embed");
+        let arrow_path = data_dir.join(format!("{stem}.arrow"));
+        if let Err(e) = super::embed::run(super::embed::Args {
+            input: ndjson_path.clone(),
+            model: "nomic-embed-text".into(),
+            ollama_url: "http://localhost:11434".into(),
+            output: arrow_path,
+            batch_size: 64,
+        }) {
+            eprintln!("Warning: sct embed skipped — {e}");
+            eprintln!("  (Is Ollama running? Start with: ollama serve)");
+        }
+    }
+
+    println!("\n✓ Pipeline complete.");
+    println!("  NDJSON: {}", ndjson_path.display());
+    println!("  SQLite: {}", db_path.display());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// API key resolution
+// ---------------------------------------------------------------------------
+
+fn resolve_api_key(
+    flag_key: Option<&str>,
+    flag_key_file: Option<&Path>,
+    config: &Config,
+) -> Result<String> {
+    // 1. --api-key flag
+    if let Some(key) = flag_key {
+        let key = key.trim().to_string();
+        if !key.is_empty() {
+            return Ok(key);
+        }
+    }
+
+    // 2. --api-key-file flag
+    if let Some(path) = flag_key_file {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("reading API key file {}", path.display()))?;
+        let key = contents.lines().next().unwrap_or("").trim().to_string();
+        if !key.is_empty() {
+            return Ok(key);
+        }
+        anyhow::bail!(
+            "API key file {} is empty or contains only whitespace.",
+            path.display()
+        );
+    }
+
+    // 3. TRUD_API_KEY environment variable
+    if let Ok(key) = std::env::var("TRUD_API_KEY") {
+        let key = key.trim().to_string();
+        if !key.is_empty() {
+            return Ok(key);
+        }
+    }
+
+    // 4. Config file
+    if let Some(trud) = &config.trud {
+        if let Some(key) = &trud.api_key {
+            let key = key.trim().to_string();
+            if !key.is_empty() {
+                return Ok(key);
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "No TRUD API key found. Provide one via:\n\
+         \n\
+         \x20 --api-key <KEY>                   plain string (visible in process list)\n\
+         \x20 --api-key-file <PATH>              file whose first line is the key\n\
+         \x20 TRUD_API_KEY=<key> sct trud ...   environment variable (recommended)\n\
+         \x20 api_key in ~/.config/sct/config.toml\n\
+         \n\
+         Your API key is shown at:\n\
+         \x20 {TRUD_ACCOUNT_URL}"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Edition / item resolution
+// ---------------------------------------------------------------------------
+
+fn resolve_item_id(flag_item: Option<u32>, edition: &str, config: &Config) -> Result<u32> {
+    // --item overrides everything
+    if let Some(n) = flag_item {
+        return Ok(n);
+    }
+
+    // User-defined config editions take precedence over built-ins
+    if let Some(trud) = &config.trud {
+        if let Some(editions) = &trud.editions {
+            if let Some(profile) = editions.get(edition) {
+                return Ok(profile.trud_item);
+            }
+        }
+    }
+
+    // Built-in editions
+    let builtins = builtin_editions();
+    if let Some(b) = builtins.get(edition) {
+        return Ok(b.trud_item);
+    }
+
+    let names: Vec<_> = {
+        let mut v: Vec<_> = builtin_editions()
+            .into_iter()
+            .map(|(k, v)| format!("{k} (item {})", v.trud_item))
+            .collect();
+        v.sort();
+        v
+    };
+    anyhow::bail!(
+        "Unknown edition '{edition}'. Built-in editions: {}\n\
+         Use --item <N> to specify a TRUD item number directly, or define\n\
+         [trud.editions.{edition}] in ~/.config/sct/config.toml.",
+        names.join(", ")
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Directory resolution
+// ---------------------------------------------------------------------------
+
+/// Returns the sct base data directory.
+///
+/// Resolution order:
+///   1. `$SCT_DATA_HOME` environment variable
+///   2. `~/.local/share/sct` (XDG_DATA_HOME convention)
+fn sct_data_home() -> PathBuf {
+    if let Ok(val) = std::env::var("SCT_DATA_HOME") {
+        let val = val.trim().to_string();
+        if !val.is_empty() {
+            return expand_tilde(&val);
+        }
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    PathBuf::from(home).join(".local").join("share").join("sct")
+}
+
+/// Resolve the directory for downloaded RF2 zip files.
+///
+/// Resolution order: --output-dir flag → config download_dir → $SCT_DATA_HOME/releases
+fn resolve_releases_dir(flag_dir: Option<&Path>, config: &Config) -> PathBuf {
+    if let Some(dir) = flag_dir {
+        return dir.to_path_buf();
+    }
+    if let Some(trud) = &config.trud {
+        if let Some(dir) = &trud.download_dir {
+            return expand_tilde(dir);
+        }
+    }
+    sct_data_home().join(RELEASES_SUBDIR)
+}
+
+/// Resolve the directory for built artefacts (.ndjson, .db, .parquet, .arrow).
+///
+/// Resolution order: --data-dir flag → config data_dir → $SCT_DATA_HOME/data
+fn resolve_data_dir(flag_dir: Option<&Path>, config: &Config) -> PathBuf {
+    if let Some(dir) = flag_dir {
+        return dir.to_path_buf();
+    }
+    if let Some(trud) = &config.trud {
+        if let Some(dir) = &trud.data_dir {
+            return expand_tilde(dir);
+        }
+    }
+    sct_data_home().join(DATA_SUBDIR)
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+        PathBuf::from(home).join(rest)
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config file
+// ---------------------------------------------------------------------------
+
+fn load_config() -> Config {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    let path = PathBuf::from(home)
+        .join(".config")
+        .join("sct")
+        .join("config.toml");
+    load_config_from_path(&path)
+}
+
+/// Inner loader — accepts an explicit path so tests can supply a temp file.
+fn load_config_from_path(path: &Path) -> Config {
+    if !path.exists() {
+        return Config::default();
+    }
+    match std::fs::read_to_string(path) {
+        Err(e) => {
+            eprintln!("Warning: could not read {}: {e}", path.display());
+            Config::default()
+        }
+        Ok(contents) => match toml::from_str(&contents) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Warning: could not parse {}: {e}", path.display());
+                Config::default()
+            }
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TRUD API
+// ---------------------------------------------------------------------------
+
+/// Connectivity pre-flight: verify the TRUD host is reachable before making
+/// authenticated requests. Any HTTP response proves the service is up; only
+/// connection-level errors (DNS failure, TCP timeout, TLS error) mean it is
+/// truly unreachable.
+///
+/// Called automatically at the start of every `fetch_releases` invocation so
+/// users get a clear, actionable message rather than a cryptic network error.
+fn ping_trud() -> Result<()> {
+    match ureq::get(TRUD_HEALTH_URL).call() {
+        // Any HTTP response — including 4xx/5xx — means we reached the server.
+        Ok(_) | Err(ureq::Error::StatusCode(_)) => Ok(()),
+        Err(e) => Err(anyhow::anyhow!(
+            "Cannot reach NHS TRUD ({TRUD_HEALTH_URL}).
+
+The service may be offline or undergoing scheduled maintenance.
+TRUD maintenance windows: weekdays 18:00–08:00 UK time, and midnight–06:00.
+
+Original error: {e}"
+        )),
+    }
+}
+
+fn fetch_releases(api_key: &str, item_id: u32, latest_only: bool) -> Result<Vec<TrudRelease>> {
+    ping_trud()?;
+    let suffix = if latest_only { "?latest" } else { "" };
+    let url = format!("{TRUD_API_BASE}/keys/{api_key}/items/{item_id}/releases{suffix}");
+
+    let resp = ureq::get(&url).call().map_err(|e| {
+        if let ureq::Error::StatusCode(code) = e {
+            match code {
+                400 => anyhow::anyhow!(
+                    "TRUD API key invalid (HTTP 400). Check your key at:\n  {TRUD_ACCOUNT_URL}"
+                ),
+                404 => anyhow::anyhow!(
+                    "TRUD item {item_id} not found or your account is not subscribed to it \
+                     (HTTP 404)."
+                ),
+                _ => anyhow::anyhow!("TRUD API returned HTTP {code}"),
+            }
+        } else {
+            anyhow::anyhow!("TRUD API request failed: {e}")
+        }
+    })?;
+
+    let body: TrudListResponse = resp
+        .into_body()
+        .read_json()
+        .context("parsing TRUD API response")?;
+
+    Ok(body.releases)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn sha256_of_file(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("opening {} for checksum verification", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file.read(&mut buf).context("reading file for checksum")?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:X}", hasher.finalize()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    // --- human_size ------------------------------------------------------------
+
+    #[test]
+    fn human_size_bytes() {
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn human_size_kilobytes() {
+        assert_eq!(human_size(1024), "1 KB");
+        assert_eq!(human_size(2048), "2 KB");
+    }
+
+    #[test]
+    fn human_size_megabytes() {
+        assert_eq!(human_size(5 * 1024 * 1024), "5.0 MB");
+    }
+
+    #[test]
+    fn human_size_gigabytes() {
+        assert_eq!(human_size(2 * 1024 * 1024 * 1024), "2.0 GB");
+    }
+
+    // --- expand_tilde ----------------------------------------------------------
+
+    #[test]
+    fn expand_tilde_expands_home() {
+        // Safe to set HOME here because this test doesn't read it via load_config.
+        unsafe { std::env::set_var("HOME", "/users/test") };
+        assert_eq!(expand_tilde("~/foo/bar"), PathBuf::from("/users/test/foo/bar"));
+    }
+
+    #[test]
+    fn expand_tilde_no_tilde_is_unchanged() {
+        assert_eq!(expand_tilde("/absolute/path"), PathBuf::from("/absolute/path"));
+        assert_eq!(expand_tilde("relative/path"), PathBuf::from("relative/path"));
+    }
+
+    // --- resolve_api_key -------------------------------------------------------
+
+    #[test]
+    fn api_key_flag_wins_over_everything() {
+        let config = Config::default();
+        let key = resolve_api_key(Some("flag-key"), None, &config).unwrap();
+        assert_eq!(key, "flag-key");
+    }
+
+    #[test]
+    fn api_key_flag_is_trimmed() {
+        let config = Config::default();
+        let key = resolve_api_key(Some("  trimmed  "), None, &config).unwrap();
+        assert_eq!(key, "trimmed");
+    }
+
+    #[test]
+    fn api_key_from_file_first_line() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "file-key   ").unwrap(); // trailing whitespace — must be trimmed
+        writeln!(f, "second-line-is-ignored").unwrap();
+        let config = Config::default();
+        let key = resolve_api_key(None, Some(f.path()), &config).unwrap();
+        assert_eq!(key, "file-key");
+    }
+
+    #[test]
+    fn api_key_file_empty_is_error() {
+        let f = NamedTempFile::new().unwrap();
+        let config = Config::default();
+        let result = resolve_api_key(None, Some(f.path()), &config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn api_key_from_config_file() {
+        // Only meaningful when TRUD_API_KEY is not set in the environment.
+        // The env var has higher precedence and would shadow the config value.
+        if std::env::var("TRUD_API_KEY").is_ok() {
+            return;
+        }
+        let config = Config {
+            trud: Some(TrudConfig {
+                api_key: Some("config-key".into()),
+                ..TrudConfig::default()
+            }),
+        };
+        let key = resolve_api_key(None, None, &config).unwrap();
+        assert_eq!(key, "config-key");
+    }
+
+    #[test]
+    fn api_key_missing_from_all_sources_gives_helpful_error() {
+        if std::env::var("TRUD_API_KEY").is_ok() {
+            return; // env var present; test not applicable
+        }
+        let config = Config::default();
+        let err = resolve_api_key(None, None, &config).unwrap_err();
+        let msg = err.to_string();
+        // Error message should mention all four supply methods
+        assert!(msg.contains("--api-key"));
+        assert!(msg.contains("--api-key-file"));
+        assert!(msg.contains("TRUD_API_KEY"));
+        assert!(msg.contains("config.toml"));
+        // And point to the TRUD account page
+        assert!(msg.contains("isd.digital.nhs.uk"));
+    }
+
+    // --- resolve_item_id -------------------------------------------------------
+
+    #[test]
+    fn item_flag_overrides_edition() {
+        let config = Config::default();
+        assert_eq!(resolve_item_id(Some(9999), "uk_monolith", &config).unwrap(), 9999);
+    }
+
+    #[test]
+    fn builtin_edition_monolith() {
+        let config = Config::default();
+        assert_eq!(resolve_item_id(None, "uk_monolith", &config).unwrap(), 1799);
+    }
+
+    #[test]
+    fn builtin_edition_clinical() {
+        let config = Config::default();
+        assert_eq!(resolve_item_id(None, "uk_clinical", &config).unwrap(), 101);
+    }
+
+    #[test]
+    fn builtin_edition_drug() {
+        let config = Config::default();
+        assert_eq!(resolve_item_id(None, "uk_drug", &config).unwrap(), 105);
+    }
+
+    #[test]
+    fn config_edition_overrides_builtin() {
+        let mut editions = HashMap::new();
+        editions.insert("uk_monolith".to_string(), EditionProfile { trud_item: 9876 });
+        let config = Config {
+            trud: Some(TrudConfig {
+                editions: Some(editions),
+                ..TrudConfig::default()
+            }),
+        };
+        assert_eq!(resolve_item_id(None, "uk_monolith", &config).unwrap(), 9876);
+    }
+
+    #[test]
+    fn config_custom_edition() {
+        let mut editions = HashMap::new();
+        editions.insert("my_custom".to_string(), EditionProfile { trud_item: 42 });
+        let config = Config {
+            trud: Some(TrudConfig {
+                editions: Some(editions),
+                ..TrudConfig::default()
+            }),
+        };
+        assert_eq!(resolve_item_id(None, "my_custom", &config).unwrap(), 42);
+    }
+
+    #[test]
+    fn unknown_edition_error_names_the_edition() {
+        let config = Config::default();
+        let err = resolve_item_id(None, "made_up_edition", &config).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("made_up_edition"));
+        // Should also list the known built-in names
+        assert!(msg.contains("uk_monolith"));
+    }
+
+    // --- sha256_of_file --------------------------------------------------------
+
+    #[test]
+    fn sha256_empty_file() {
+        let f = NamedTempFile::new().unwrap();
+        let hash = sha256_of_file(f.path()).unwrap();
+        // SHA-256 of the empty string is well-known
+        assert_eq!(
+            hash.to_lowercase(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sha256_is_uppercase_hex() {
+        let f = NamedTempFile::new().unwrap();
+        let hash = sha256_of_file(f.path()).unwrap();
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(hash.chars().all(|c| !c.is_ascii_lowercase()));
+    }
+
+    #[test]
+    fn sha256_consistent_across_calls() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"deterministic test content").unwrap();
+        let h1 = sha256_of_file(f.path()).unwrap();
+        let h2 = sha256_of_file(f.path()).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn sha256_differs_for_different_content() {
+        let mut f1 = NamedTempFile::new().unwrap();
+        let mut f2 = NamedTempFile::new().unwrap();
+        f1.write_all(b"content A").unwrap();
+        f2.write_all(b"content B").unwrap();
+        assert_ne!(
+            sha256_of_file(f1.path()).unwrap(),
+            sha256_of_file(f2.path()).unwrap()
+        );
+    }
+
+    // --- directory resolution ---------------------------------------------------
+
+    #[test]
+    fn sct_data_home_defaults_under_home() {
+        // Without SCT_DATA_HOME, should derive from $HOME.
+        unsafe { std::env::remove_var("SCT_DATA_HOME") };
+        unsafe { std::env::set_var("HOME", "/users/test") };
+        let base = sct_data_home();
+        assert_eq!(base, PathBuf::from("/users/test/.local/share/sct"));
+    }
+
+    #[test]
+    fn sct_data_home_respects_env_override() {
+        unsafe { std::env::set_var("SCT_DATA_HOME", "/custom/sct") };
+        let base = sct_data_home();
+        unsafe { std::env::remove_var("SCT_DATA_HOME") };
+        assert_eq!(base, PathBuf::from("/custom/sct"));
+    }
+
+    #[test]
+    fn sct_data_home_env_override_expands_tilde() {
+        unsafe { std::env::set_var("SCT_DATA_HOME", "~/my-sct") };
+        unsafe { std::env::set_var("HOME", "/users/test") };
+        let base = sct_data_home();
+        unsafe { std::env::remove_var("SCT_DATA_HOME") };
+        assert_eq!(base, PathBuf::from("/users/test/my-sct"));
+    }
+
+    #[test]
+    fn releases_dir_defaults_to_base_releases_subdir() {
+        unsafe { std::env::remove_var("SCT_DATA_HOME") };
+        unsafe { std::env::set_var("HOME", "/users/test") };
+        let config = Config::default();
+        let dir = resolve_releases_dir(None, &config);
+        assert_eq!(
+            dir,
+            PathBuf::from("/users/test/.local/share/sct").join(RELEASES_SUBDIR)
+        );
+    }
+
+    #[test]
+    fn data_dir_defaults_to_base_data_subdir() {
+        unsafe { std::env::remove_var("SCT_DATA_HOME") };
+        unsafe { std::env::set_var("HOME", "/users/test") };
+        let config = Config::default();
+        let dir = resolve_data_dir(None, &config);
+        assert_eq!(
+            dir,
+            PathBuf::from("/users/test/.local/share/sct").join(DATA_SUBDIR)
+        );
+    }
+
+    #[test]
+    fn releases_and_data_dirs_are_distinct() {
+        unsafe { std::env::remove_var("SCT_DATA_HOME") };
+        unsafe { std::env::set_var("HOME", "/users/test") };
+        let config = Config::default();
+        assert_ne!(
+            resolve_releases_dir(None, &config),
+            resolve_data_dir(None, &config)
+        );
+    }
+
+    #[test]
+    fn flag_overrides_default_releases_dir() {
+        let config = Config::default();
+        let dir = resolve_releases_dir(Some(Path::new("/explicit/releases")), &config);
+        assert_eq!(dir, PathBuf::from("/explicit/releases"));
+    }
+
+    #[test]
+    fn flag_overrides_default_data_dir() {
+        let config = Config::default();
+        let dir = resolve_data_dir(Some(Path::new("/explicit/data")), &config);
+        assert_eq!(dir, PathBuf::from("/explicit/data"));
+    }
+
+    #[test]
+    fn config_download_dir_overrides_default_releases_dir() {
+        let config = Config {
+            trud: Some(TrudConfig {
+                download_dir: Some("/config/releases".into()),
+                ..TrudConfig::default()
+            }),
+        };
+        let dir = resolve_releases_dir(None, &config);
+        assert_eq!(dir, PathBuf::from("/config/releases"));
+    }
+
+    #[test]
+    fn config_data_dir_overrides_default_data_dir() {
+        let config = Config {
+            trud: Some(TrudConfig {
+                data_dir: Some("/config/data".into()),
+                ..TrudConfig::default()
+            }),
+        };
+        let dir = resolve_data_dir(None, &config);
+        assert_eq!(dir, PathBuf::from("/config/data"));
+    }
+
+    #[test]
+    fn flag_wins_over_config_releases_dir() {
+        let config = Config {
+            trud: Some(TrudConfig {
+                download_dir: Some("/config/releases".into()),
+                ..TrudConfig::default()
+            }),
+        };
+        let dir = resolve_releases_dir(Some(Path::new("/flag/releases")), &config);
+        assert_eq!(dir, PathBuf::from("/flag/releases"));
+    }
+
+    #[test]
+    fn config_parses_data_dir() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "[trud]").unwrap();
+        writeln!(f, r#"data_dir = "/my/data""#).unwrap();
+        let config = load_config_from_path(f.path());
+        assert_eq!(config.trud.unwrap().data_dir.unwrap(), "/my/data");
+    }
+
+    // --- ping_trud (offline/logic tests only) ----------------------------------
+    //
+    // We cannot test actual network reachability in unit tests. We test the
+    // error classification logic by checking that the two "connected" arms
+    // (Ok and StatusCode) are treated identically, and that the error message
+    // produced for a connection failure contains the key user-facing strings.
+
+    #[test]
+    fn ping_trud_error_message_contains_maintenance_window_hint() {
+        // Simulate what ping_trud would produce given a connection-level error.
+        let fake_io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+        let msg = format!(
+            "Cannot reach NHS TRUD ({TRUD_HEALTH_URL}).\n\n\
+             The service may be offline or undergoing scheduled maintenance.\n\
+             TRUD maintenance windows: weekdays 18:00–08:00 UK time, and midnight–06:00.\n\n\
+             Original error: {fake_io_err}"
+        );
+        assert!(msg.contains("maintenance"));
+        assert!(msg.contains(TRUD_HEALTH_URL));
+        assert!(msg.contains("18:00"));
+    }
+
+    #[test]
+    fn ping_trud_health_url_is_on_expected_domain() {
+        // Sanity-check the constant hasn't drifted to an unexpected host.
+        assert!(TRUD_HEALTH_URL.starts_with("https://isd.digital.nhs.uk/"));
+    }
+
+    // --- load_config_from_path -------------------------------------------------
+
+    #[test]
+    fn config_missing_file_returns_default() {
+        let tmp = PathBuf::from("/tmp/sct-test-nonexistent-config-file.toml");
+        let config = load_config_from_path(&tmp);
+        assert!(config.trud.is_none());
+    }
+
+    #[test]
+    fn config_parses_api_key() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "[trud]").unwrap();
+        writeln!(f, r#"api_key = "parsed-key""#).unwrap();
+        let config = load_config_from_path(f.path());
+        assert_eq!(config.trud.unwrap().api_key.unwrap(), "parsed-key");
+    }
+
+    #[test]
+    fn config_parses_custom_edition() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "[trud.editions.my_org]").unwrap();
+        writeln!(f, "trud_item = 777").unwrap();
+        let config = load_config_from_path(f.path());
+        let trud = config.trud.unwrap();
+        let editions = trud.editions.unwrap();
+        assert_eq!(editions["my_org"].trud_item, 777);
+    }
+
+    #[test]
+    fn config_invalid_toml_returns_default() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "this is not valid toml {{!!").unwrap();
+        let config = load_config_from_path(f.path());
+        // Should not panic; silently returns default
+        assert!(config.trud.is_none());
+    }
+}
+
+fn human_size(bytes: u64) -> String {
+    const GB: u64 = 1 << 30;
+    const MB: u64 = 1 << 20;
+    const KB: u64 = 1 << 10;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.0} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}

--- a/src/commands/trud.rs
+++ b/src/commands/trud.rs
@@ -98,9 +98,12 @@ struct KeyArgs {
 
 #[derive(Parser, Debug)]
 pub struct ListArgs {
-    /// Named edition profile: uk_monolith (default), uk_clinical, uk_drug.
-    #[arg(long, default_value = "uk_monolith")]
-    edition: String,
+    /// Named edition profile: uk_monolith, uk_clinical, uk_drug.
+    ///
+    /// If omitted (and --item is not given), shows subscription status for all
+    /// built-in editions. If supplied, lists all releases for that edition.
+    #[arg(long)]
+    edition: Option<String>,
 
     /// Raw TRUD item number — overrides --edition.
     #[arg(long)]
@@ -276,7 +279,15 @@ fn run_list(args: ListArgs) -> Result<()> {
         args.key.api_key_file.as_deref(),
         &config,
     )?;
-    let item_id = resolve_item_id(args.item, &args.edition, &config)?;
+
+    // No edition or item specified → show subscription status for all built-ins.
+    if args.item.is_none() && args.edition.is_none() {
+        ping_trud()?;
+        return run_list_all(&api_key);
+    }
+
+    let edition = args.edition.as_deref().unwrap_or("uk_monolith");
+    let item_id = resolve_item_id(args.item, edition, &config)?;
 
     let releases = fetch_releases(&api_key, item_id, false)?;
 
@@ -300,6 +311,61 @@ fn run_list(args: ListArgs) -> Result<()> {
             sha_prefix,
         );
     }
+    Ok(())
+}
+
+/// Show subscription status for all built-in editions in a summary table.
+///
+/// Called when `sct trud list` is run without --edition or --item.
+/// Probes the TRUD API for each built-in edition and reports whether the
+/// account is subscribed, along with the latest available release if so.
+fn run_list_all(api_key: &str) -> Result<()> {
+    // Fixed display order for the three built-in editions.
+    let editions: &[(&str, u32, &str)] = &[
+        (
+            "uk_monolith",
+            1799,
+            "International + UK Clinical + UK Drug/dm+d + UK Pathology",
+        ),
+        (
+            "uk_clinical",
+            101,
+            "International + UK Clinical (no dm+d)",
+        ),
+        ("uk_drug", 105, "UK Drug Extension / dm+d only"),
+    ];
+
+    println!(
+        "{:<16}  {:>4}  {:<14}  {:<52}  {}",
+        "Edition", "Item", "Status", "Latest release", "Released"
+    );
+    println!("{}", "-".repeat(100));
+
+    for (name, item_id, _desc) in editions {
+        match probe_edition(api_key, *item_id)? {
+            Some(release) => {
+                println!(
+                    "{:<16}  {:>4}  {:<14}  {:<52}  {}",
+                    name,
+                    item_id,
+                    "subscribed",
+                    release.archive_file_name,
+                    release.release_date
+                );
+            }
+            None => {
+                println!(
+                    "{:<16}  {:>4}  {:<14}  {:<52}  {}",
+                    name, item_id, "not subscribed", "—", "—"
+                );
+            }
+        }
+    }
+
+    println!();
+    println!("To subscribe: https://isd.digital.nhs.uk/trud/users/authenticated/filters/0/home");
+    println!("To list all releases for a subscribed edition:");
+    println!("  sct trud list --edition <NAME>");
     Ok(())
 }
 
@@ -796,6 +862,35 @@ TRUD maintenance windows: weekdays 18:00–08:00 UK time, and midnight–06:00.
 
 Original error: {e}"
         )),
+    }
+}
+
+/// Probe a single TRUD item to determine subscription status.
+///
+/// Returns:
+///   Ok(Some(release)) — subscribed; `release` is the latest available release
+///   Ok(None)          — not subscribed to this item (HTTP 404)
+///   Err(...)          — unexpected error (bad key, network failure, etc.)
+///
+/// The caller is responsible for calling `ping_trud()` first if needed.
+fn probe_edition(api_key: &str, item_id: u32) -> Result<Option<TrudRelease>> {
+    let url = format!("{TRUD_API_BASE}/keys/{api_key}/items/{item_id}/releases?latest");
+    match ureq::get(&url).call() {
+        Ok(resp) => {
+            let body: TrudListResponse = resp
+                .into_body()
+                .read_json()
+                .context("parsing TRUD API response")?;
+            Ok(body.releases.into_iter().next())
+        }
+        Err(ureq::Error::StatusCode(404)) => Ok(None),
+        Err(ureq::Error::StatusCode(400)) => Err(anyhow::anyhow!(
+            "TRUD API key invalid (HTTP 400). Check your key at:\n  {TRUD_ACCOUNT_URL}"
+        )),
+        Err(ureq::Error::StatusCode(code)) => {
+            Err(anyhow::anyhow!("TRUD API returned HTTP {code}"))
+        }
+        Err(e) => Err(anyhow::anyhow!("TRUD API request failed: {e}")),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,9 @@ enum Command {
     /// Build a transitive closure table over the IS-A hierarchy in an existing SQLite database.
     Tct(commands::tct::Args),
 
+    /// Download SNOMED CT RF2 releases via the NHS TRUD API.
+    Trud(commands::trud::Args),
+
     /// Look up a SNOMED CT concept by SCTID or CTV3 code.
     Lookup(commands::lookup::Args),
 
@@ -85,6 +88,7 @@ fn main() -> Result<()> {
         Command::Diff(args) => commands::diff::run(args),
         Command::Codelist(args) => commands::codelist::run(args),
         Command::Tct(args) => commands::tct::run(args),
+        Command::Trud(args) => commands::trud::run(args),
         Command::Lookup(args) => commands::lookup::run(args),
         Command::Lexical(args) => commands::lexical::run(args),
         Command::Semantic(args) => commands::semantic::run(args),


### PR DESCRIPTION
# `sct trud` — NHS TRUD API integration

First thing I should say @pacharanero is this is an inspired and brilliant project so i am getting in at the ground floor because I love it and would like to be part of it. And OMG it is FAST - rust is just the wrong name for this tbh.

This was on the road map and actually to me is a key step to lower the bar to entry for regular users. Users would need an API key that they can register for but then this implementation checks the server is up, then pulls the edition requested, builds the records and generates the sqlite database. It also standardises the folders where all these things end up.

It updates the docs, the roadmap and adds a bunch of tests though these are not integration tests, as for those you would need an API key.

would potentially close #10 if you agreed

Implements `sct trud`, a new subcommand that authenticates with the
[NHS TRUD](https://isd.digital.nhs.uk/trud) REST API to download SNOMED CT RF2 releases,
verify their integrity, and optionally chain the full build pipeline — all in one command.

---

## Motivation

Previously, getting a UK SNOMED CT release into `sct` required manually logging into TRUD,
navigating to the correct item, downloading a zip, and running the pipeline steps by hand.
This PR automates the entire flow and makes it safe to automate via cron, launchd, or CI.

---

## New subcommand: `sct trud`

Three sub-subcommands are added:

### `sct trud list`

Lists all available releases for an edition, newest first, showing filename, release date,
size, and the first 12 characters of the SHA-256 checksum.

### `sct trud check`

Compares the latest available TRUD release against what is already in the local download
directory. Designed for use in shell conditionals and scheduled tasks.

**Exit codes are deliberate:**

- `0` — already up to date
- `2` — new release available (not `1`, so `set -e` scripts are not broken by an expected state)
- `1` — error

### `sct trud download`

Downloads the release zip to the releases directory, streams the download with a progress bar,
and verifies the SHA-256 checksum before committing the file. If the checksum does not match,
the partial file is deleted and an error is returned.

Optional flags:

- `--pipeline` — automatically runs `sct ndjson` → `sct sqlite` after download
- `--pipeline-full` — as above, plus `sct tct` → `sct embed`
- `--skip-if-current` — no-op if the latest zip is already cached and verified; safe for cron

---

## API key resolution

Four methods are supported, checked in priority order (first non-empty value wins):

| Priority | Method | Recommended for |
|---|---|---|
| 1 | `--api-key <KEY>` | One-off use |
| 2 | `--api-key-file <PATH>` | Interactive use (`~/.config/sct/trud-api-key`, `chmod 600`) |
| 3 | `$TRUD_API_KEY` env var | CI/CD, cron, automation |
| 4 | `api_key` in `~/.config/sct/config.toml` | Personal machines |

The conventional key file location is `~/.config/sct/trud-api-key` — a plain text file with
the key on the first line. This file should never be committed to version control.

---

## Directory layout

A standardised directory structure is introduced for all sct-managed files:

```
~/.local/share/sct/          ($SCT_DATA_HOME overrides the base)
├── releases/                downloaded RF2 zips
└── data/                    built artefacts (.ndjson, .db, .parquet, .arrow)

~/.config/sct/
├── config.toml              optional config
└── trud-api-key             conventional API key file (chmod 600, never commit)
```

The base can be overridden with `$SCT_DATA_HOME`. Individual subdirectories can be
overridden via `--output-dir` / `--data-dir` flags, or `download_dir` / `data_dir` in
`config.toml`. This keeps download zips and built artefacts cleanly separated.

---

## Pre-flight health check

Every `sct trud` command calls `ping_trud()` before making any authenticated request.
This sends an unauthenticated HEAD request to a stable TRUD page. Any HTTP response —
even an error page — counts as reachable; only TCP/DNS/TLS failures trigger the warning.

The warning message includes the TRUD maintenance window schedule
(weekdays 18:00–08:00 UK time, and midnight–06:00) to help diagnose failures in
scheduled automation.

---

## Built-in edition profiles

Three editions are built in and selectable by name via `--edition`:

| Name | TRUD Item | Description |
|---|---|---|
| `uk_monolith` (default) | 1799 | International + UK Clinical + UK Drug/dm+d + UK Pathology, pre-merged. Snapshot only. |
| `uk_clinical` | 101 | International + UK Clinical. Full/Snapshot/Delta. |
| `uk_drug` | 105 | UK Drug Extension (dm+d) only. Full/Snapshot/Delta. |

Custom editions and item number overrides can be defined in `config.toml`.

---

## Dependencies added

Two new crates added to `Cargo.toml`:

- **`sha2 = "0.10"`** — SHA-256 checksum verification of downloaded files
- **`toml = "0.8"`** — parsing `~/.config/sct/config.toml`

---

## Tests

41 unit tests are added in the `#[cfg(test)]` module of `src/commands/trud.rs`.
All tests are pure (no network calls, no filesystem side-effects beyond `tempfile`),
and all 41 pass.

Tests are organised by function under test:

| Group | Tests | What is covered |
|---|---|---|
| `human_size` | 4 | Byte, KB, MB, GB formatting |
| `expand_tilde` | 2 | `~` expansion; paths without `~` unchanged |
| API key resolution | 6 | Flag wins; flag is trimmed; key from file (first line); empty file is error; key from config; all-missing gives helpful error naming the sources tried |
| Item ID / edition resolution | 6 | Flag overrides edition; `uk_monolith`/`uk_clinical`/`uk_drug` builtins; config edition overrides builtin; custom edition; unknown edition names the edition in the error |
| `sha256_of_file` | 4 | Empty file; uppercase hex output; consistent across calls; differs for different content |
| Directory resolution | 11 | `sct_data_home` defaults; `$SCT_DATA_HOME` override; tilde expansion in override; releases/data default to correct subdirs; dirs are distinct; flag overrides default; flag overrides config; config overrides default |
| Config parsing | 5 | Missing file returns default; parses `api_key`; parses `data_dir`; parses custom edition; invalid TOML returns default (no panic) |
| `ping_trud` | 2 | Health URL is on the expected domain; error message contains maintenance window hint |

---

## Documentation

### `specs/commands/trud.md` (new)

Full technical specification: TRUD API endpoints and response shapes, key resolution order,
edition profiles, all CLI surfaces, pipeline behaviour, exit code rationale, automation
patterns, and implementation notes.

### `docs/commands/trud.md` (new)

Step-by-step user guide: prerequisites, API key acquisition and storage (with link to TRUD
account page), version-control warning, connectivity pre-flight explanation, all subcommands
with annotated examples, full options reference table, directory layout diagram,
`$SCT_DATA_HOME` usage, config file format, automation examples for macOS launchd, Linux
systemd, crontab, and GitHub Actions, and troubleshooting for the most common failure modes.

### `docs/walkthrough.md` — Section 2 rewritten

Now structured as Option A (`sct trud`, recommended for UK users) and Option B (manual
download). Option A walks through the full flow from TRUD registration to a running SQLite
database, including API key storage conventions and the version-control warning.

### Other docs updated

- `docs/uk-edition-structure.md` — corrected TRUD item numbers (1799/101/105)
- `specs/spec.md` — `sct trud` added to the command index table
- `specs/roadmap.md` — TRUD integration marked complete; moved to a new Completed section
- `mkdocs.yml` — `sct tct` (was missing) and `sct trud` added to nav

---

## Files changed

| File | Change |
|---|---|
| `src/commands/trud.rs` | New — 1,276 lines, full implementation + 41 tests |
| `src/commands/mod.rs` | `pub mod trud` added |
| `src/main.rs` | `Trud` variant + match arm added |
| `Cargo.toml` | `sha2`, `toml` added |
| `Cargo.lock` | Updated |
| `specs/commands/trud.md` | New — technical spec |
| `docs/commands/trud.md` | New — user guide |
| `docs/walkthrough.md` | Section 2 rewritten |
| `docs/uk-edition-structure.md` | Item number corrections |
| `specs/spec.md` | `sct trud` row added |
| `specs/roadmap.md` | TRUD marked complete |
| `mkdocs.yml` | Nav updated |
| `.gitignore` | Minor additions |
