### PR TITLE
[codex] add completions installer

### DIFF
--- a/docs/commands/completions.md
+++ b/docs/commands/completions.md
@@ -1,6 +1,6 @@
 # sct completions
 
-Print a shell completion script to stdout. Supports bash, zsh, fish, PowerShell, and elvish.
+Install or print shell completion scripts. Supports bash, zsh, fish, PowerShell, and elvish.
 
 ---
 
@@ -8,6 +8,8 @@ Print a shell completion script to stdout. Supports bash, zsh, fish, PowerShell,
 
 ```
 sct completions <SHELL>
+sct completions --dir <PATH> <SHELL>
+sct completions install [--shell <SHELL>] [--dir <PATH>]
 ```
 
 ## Arguments
@@ -20,17 +22,25 @@ sct completions <SHELL>
 
 ## Installation
 
+For the current user, prefer the installer:
+
+```bash
+sct completions install
+```
+
+It detects your shell, writes the correctly named completion file, and prints any one-time shell setup still needed. Re-run it after upgrading `sct` if your package manager or installer did not refresh completions for you.
+
 ### bash
 
 ```bash
 mkdir -p ~/.local/share/bash-completion/completions
-sct completions bash > ~/.local/share/bash-completion/completions/sct
+sct completions --dir ~/.local/share/bash-completion/completions bash
 ```
 
 Or system-wide:
 
 ```bash
-sct completions bash > /etc/bash_completion.d/sct
+sct completions --dir /etc/bash_completion.d bash
 ```
 
 Reload with `source ~/.bashrc` or open a new shell.
@@ -39,7 +49,7 @@ Reload with `source ~/.bashrc` or open a new shell.
 
 ```zsh
 mkdir -p ~/.zfunc
-sct completions zsh > ~/.zfunc/_sct
+sct completions --dir ~/.zfunc zsh
 ```
 
 Ensure `~/.zfunc` is on `$fpath` - add this to `~/.zshrc` **before** `compinit`:
@@ -54,7 +64,7 @@ Then open a new shell or run `exec zsh`.
 ### fish
 
 ```fish
-sct completions fish > ~/.config/fish/completions/sct.fish
+sct completions --dir ~/.config/fish/completions fish
 ```
 
 Takes effect immediately in new fish sessions.
@@ -62,7 +72,7 @@ Takes effect immediately in new fish sessions.
 ### PowerShell
 
 ```powershell
-sct completions powershell >> $PROFILE
+sct completions --dir ~/.config/powershell/completions powershell
 ```
 
 Reload with `. $PROFILE` or open a new PowerShell session.
@@ -70,7 +80,7 @@ Reload with `. $PROFILE` or open a new PowerShell session.
 ### elvish
 
 ```elvish
-sct completions elvish >> ~/.elvish/lib/completions.elv
+sct completions --dir ~/.elvish/lib elvish
 ```
 
 ---
@@ -78,7 +88,7 @@ sct completions elvish >> ~/.elvish/lib/completions.elv
 ## Example
 
 ```bash
-$ sct completions zsh > ~/.zfunc/_sct
+$ sct completions install --shell zsh
 $ exec zsh
 $ sct <TAB>
 codelist     completions  diff         embed        gui          info

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,41 +1,143 @@
 // SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `sct completions` - Print shell completion scripts to stdout.
+//! `sct completions` - Print or install shell completion scripts.
 //!
 //! Supports bash, zsh, fish, powershell, and elvish.
 //!
-//! Installation:
+//! Human install:
 //!
-//!   # bash (add to ~/.bashrc or drop in /etc/bash_completion.d/)
-//!   sct completions bash > ~/.local/share/bash-completion/completions/sct
-//!
-//!   # zsh (add to a directory on $fpath, then `compinit`)
-//!   mkdir -p ~/.zfunc
-//!   sct completions zsh > ~/.zfunc/_sct
-//!   # ensure ~/.zfunc is on fpath - add to ~/.zshrc before compinit:
-//!   #   fpath=(~/.zfunc $fpath)
-//!
-//!   # fish
-//!   sct completions fish > ~/.config/fish/completions/sct.fish
-//!
-//!   # PowerShell
-//!   sct completions powershell >> $PROFILE
-//!
-//!   # elvish
-//!   sct completions elvish >> ~/.elvish/lib/completions.elv
+//!   sct completions install
 
-use anyhow::Result;
-use clap::{Command, Parser};
+use anyhow::{anyhow, Context, Result};
+use clap::{Command, Parser, Subcommand};
 use clap_complete::{generate, Shell};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
 pub struct Args {
+    #[command(subcommand)]
+    pub command: Option<CompletionCommand>,
+
     /// Shell to generate completions for.
-    pub shell: Shell,
+    pub shell: Option<Shell>,
+
+    /// Output directory. Prints to stdout when omitted.
+    #[arg(long, short = 'd')]
+    pub dir: Option<PathBuf>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CompletionCommand {
+    /// Install completions for the current user.
+    Install {
+        /// Shell to install completions for. Detected from $SHELL when omitted.
+        #[arg(long)]
+        shell: Option<Shell>,
+
+        /// Completion directory to write to.
+        #[arg(long, short = 'd')]
+        dir: Option<PathBuf>,
+    },
 }
 
 pub fn run(args: Args, mut cmd: Command) -> Result<()> {
-    generate(args.shell, &mut cmd, "sct", &mut std::io::stdout());
+    match args.command {
+        Some(CompletionCommand::Install { shell, dir }) => {
+            let shell = shell.or_else(detect_shell).ok_or_else(|| {
+                anyhow!("could not detect shell; pass --shell bash|zsh|fish|powershell|elvish")
+            })?;
+            let dir = dir
+                .map(Ok)
+                .unwrap_or_else(|| default_completion_dir(shell))?;
+            write_completion(shell, &mut cmd, &dir)?;
+            print_install_note(shell, &dir);
+        }
+        None => {
+            let shell = args
+                .shell
+                .ok_or_else(|| anyhow!("missing shell; try `sct completions install`"))?;
+            if let Some(dir) = args.dir {
+                write_completion(shell, &mut cmd, &dir)?;
+            } else {
+                generate(shell, &mut cmd, "sct", &mut std::io::stdout());
+            }
+        }
+    }
     Ok(())
+}
+
+fn write_completion(shell: Shell, cmd: &mut Command, dir: &Path) -> Result<PathBuf> {
+    fs::create_dir_all(dir)
+        .with_context(|| format!("creating completion directory {}", dir.display()))?;
+    let path = dir.join(completion_filename(shell));
+    let mut file = fs::File::create(&path)
+        .with_context(|| format!("creating completion file {}", path.display()))?;
+    generate(shell, cmd, "sct", &mut file);
+    println!("Completion script written to: {}", path.display());
+    Ok(path)
+}
+
+fn completion_filename(shell: Shell) -> &'static str {
+    match shell {
+        Shell::Bash => "sct",
+        Shell::Zsh => "_sct",
+        Shell::Fish => "sct.fish",
+        Shell::PowerShell => "sct.ps1",
+        Shell::Elvish => "sct.elv",
+        _ => "sct.completion",
+    }
+}
+
+fn detect_shell() -> Option<Shell> {
+    let shell = env::var("SHELL").ok()?;
+    let name = Path::new(&shell).file_name()?.to_string_lossy();
+    match name.as_ref() {
+        "bash" => Some(Shell::Bash),
+        "zsh" => Some(Shell::Zsh),
+        "fish" => Some(Shell::Fish),
+        "elvish" => Some(Shell::Elvish),
+        _ => None,
+    }
+}
+
+fn default_completion_dir(shell: Shell) -> Result<PathBuf> {
+    let home = home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    Ok(match shell {
+        Shell::Bash => env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".local/share"))
+            .join("bash-completion/completions"),
+        Shell::Zsh => home.join(".zfunc"),
+        Shell::Fish => env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"))
+            .join("fish/completions"),
+        Shell::PowerShell => home.join(".config/powershell/completions"),
+        Shell::Elvish => home.join(".elvish/lib"),
+        _ => home.join(".local/share/sct/completions"),
+    })
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn print_install_note(shell: Shell, dir: &Path) {
+    match shell {
+        Shell::Zsh => {
+            println!("Add this before `compinit` in ~/.zshrc if it is not already there:");
+            println!("  fpath=({} $fpath)", dir.display());
+            println!("Then restart zsh or run `autoload -Uz compinit && compinit`.");
+        }
+        Shell::PowerShell => {
+            println!("Add this to your PowerShell profile if it is not already there:");
+            println!("  . {}/sct.ps1", dir.display());
+        }
+        _ => println!("Restart your shell to load the updated completions."),
+    }
 }

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::process::Command;
+
+#[test]
+fn completions_generate_and_install() {
+    let bin = env!("CARGO_BIN_EXE_sct");
+    let out_dir = std::env::temp_dir().join(format!("sct-completions-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&out_dir);
+
+    let output = Command::new(bin)
+        .args(["completions", "bash"])
+        .output()
+        .expect("run sct completions bash");
+    assert!(output.status.success());
+    let bash = String::from_utf8(output.stdout).expect("bash completions are utf8");
+    assert!(bash.contains("complete"));
+    assert!(bash.contains("completions"));
+
+    let output = Command::new(bin)
+        .args([
+            "completions",
+            "install",
+            "--shell",
+            "zsh",
+            "--dir",
+            out_dir.to_str().expect("temp path"),
+        ])
+        .output()
+        .expect("run sct completions install");
+    assert!(output.status.success());
+    assert!(out_dir.join("_sct").exists());
+}


### PR DESCRIPTION
## Summary
- add `sct completions install` for the current-user install path
- keep `sct completions <shell>` and add `--dir` for package/custom installs
- document installer-first usage and add an integration test

## Validation
- `cargo fmt --all --check`
- `cargo check`
- `cargo run --quiet -- completions bash >/tmp/sct.bash`
- `cargo run --quiet -- completions install --shell zsh --dir /tmp/sct-completions-test`
- `cargo test completions_generate_and_install`