### PR TITLE
feat: add GTIN support to schema, SQLite, lookup and MCP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,8 @@ serve = ["dep:axum", "dep:tokio"]
 # via the pure-Rust jetdb Access reader. Optional: most users only need the
 # RF2-native maps from `sct ndjson --refsets all`.
 dmwb = ["dep:jetdb"]
-full = ["tui", "gui", "serve"]
+gtin = []
+full = ["tui", "gui", "serve", "gtin"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/docs/commands/gtin.md
+++ b/docs/commands/gtin.md
@@ -1,0 +1,49 @@
+# GTIN Codes Support
+
+`sct` supports Global Trade Item Numbers (GTINs) for barcodes of actual medicinal packages. This enables clinical applications and devices to map scanned barcodes directly to the corresponding SNOMED CT concept ID (e.g. Actual Medicinal Product Packs/AMPPs).
+
+---
+
+## Schema Changes
+
+In `ConceptRecord` (schema version `6` and above), a new array field is populated:
+```json
+{
+  "id": "999000011000001104",
+  "preferred_term": "Virtual Medicinal Product",
+  "gtin_codes": [
+    "5012345678901",
+    "5012345678902"
+  ],
+  "schema_version": 6
+}
+```
+
+In the SQLite database, this is represented by:
+*   A `gtin_codes` text column in the `concepts` table storing a JSON array of barcode strings.
+*   Cross-references in both the `concept_maps` and `crossmaps` tables under the `"gtin"` terminology mapping namespace.
+
+---
+
+## Querying GTIN Mappings
+
+### 1. Concept Lookup
+You can lookup a concept directly using a GTIN barcode via the `sct lookup` command. If the barcode is found in the crossmaps, `sct` returns the full concept record:
+```bash
+sct lookup 5012345678901
+```
+
+### 2. Terminology Mapping
+You can translate barcodes to SNOMED concepts (or retrieve all barcode codes associated with a SNOMED ID) using `sct map`:
+
+*   **Convert a barcode to its SNOMED concept ID**:
+    ```bash
+    sct map gtin 5012345678901
+    ```
+*   **List all barcode GTINs for a given concept**:
+    ```bash
+    sct map snomed 73211009
+    ```
+
+### 3. MCP Server Integration
+The MCP server includes support for the `"gtin"` terminology in its `snomed_map` tool. Connected agents/LLMs can automatically perform forward and reverse barcode mappings.

--- a/docs/commands/gtin.md
+++ b/docs/commands/gtin.md
@@ -2,6 +2,8 @@
 
 `sct` supports Global Trade Item Numbers (GTINs) for barcodes of actual medicinal packages. This enables clinical applications and devices to map scanned barcodes directly to the corresponding SNOMED CT concept ID (e.g. Actual Medicinal Product Packs/AMPPs).
 
+> Note: GTIN support is behind the compile-time Cargo feature `gtin` (enable with `--features gtin` or `--features full`). Without it, the schema stays at v5 and GTIN fields/mappings are omitted.
+
 ---
 
 ## Schema Changes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
           - sct diagram: commands/diagram.md
           - sct refset: commands/refset.md
           - sct map: commands/map.md
+          - GTIN Codes: commands/gtin.md
           - sct dmwb: commands/dmwb.md
       - Code lists:
           - sct codelist: commands/codelist.md

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,7 +10,7 @@ use crate::rf2::{
     Acceptability, Rf2Dataset, LANG_GB_ENGLISH, LANG_UK_CLINICAL, LANG_UK_DRUG, LANG_US_ENGLISH,
     TYPE_FSN, TYPE_SYNONYM,
 };
-use crate::schema::{ConceptRecord, ConceptRef, CrossMapEntry, SCHEMA_VERSION};
+use crate::schema::{ConceptRecord, ConceptRef, CrossMapEntry};
 
 // ---------------------------------------------------------------------------
 // Known top-level SNOMED CT hierarchy concept IDs (children of the root)
@@ -393,8 +393,7 @@ pub fn build_records(
             refsets,
             relationships,
             crossmaps,
-            gtin_codes: vec![],
-            schema_version: SCHEMA_VERSION,
+            ..Default::default()
         });
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -393,6 +393,7 @@ pub fn build_records(
             refsets,
             relationships,
             crossmaps,
+            gtin_codes: vec![],
             schema_version: SCHEMA_VERSION,
         });
     }

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -385,7 +385,6 @@ mod tests {
     use super::*;
 
     fn make_record(id: &str, preferred_term: &str, hierarchy: &str, active: bool) -> ConceptRecord {
-        use crate::schema::SCHEMA_VERSION;
         use indexmap::IndexMap;
         ConceptRecord {
             id: id.into(),
@@ -405,8 +404,7 @@ mod tests {
             refsets: vec![],
             relationships: vec![],
             crossmaps: vec![],
-            gtin_codes: vec![],
-            schema_version: SCHEMA_VERSION,
+            ..Default::default()
         }
     }
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -405,6 +405,7 @@ mod tests {
             refsets: vec![],
             relationships: vec![],
             crossmaps: vec![],
+            gtin_codes: vec![],
             schema_version: SCHEMA_VERSION,
         }
     }

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -70,6 +70,13 @@ pub fn run(args: Args) -> Result<()> {
         if code.chars().all(|c| c.is_ascii_digit()) {
             if lookup_sctid(&conn, code)?.is_some() {
                 writeln!(out, "{code}")?;
+            } else {
+                #[cfg(feature = "gtin")]
+                {
+                    for (id, _, _, _) in lookup_gtin(&conn, code)? {
+                        writeln!(out, "{id}")?;
+                    }
+                }
             }
         } else {
             for (id, _, _, _) in lookup_ctv3(&conn, code)? {
@@ -83,6 +90,36 @@ pub fn run(args: Args) -> Result<()> {
     if code.chars().all(|c| c.is_ascii_digit()) {
         if let Some(concept) = lookup_sctid(&conn, code)? {
             return print_concept(concept, format, prov.as_ref(), show_prov);
+        }
+        #[cfg(feature = "gtin")]
+        {
+            let mapped = lookup_gtin(&conn, code)?;
+            if !mapped.is_empty() {
+                if mapped.len() == 1 {
+                    if let Some(concept) = lookup_sctid(&conn, &mapped[0].0)? {
+                        println!("GTIN {code} → SCTID {}\n", mapped[0].0);
+                        return print_concept(concept, format, prov.as_ref(), show_prov);
+                    }
+                }
+                println!(
+                    "GTIN {code} maps to {} SNOMED CT concept{}:\n",
+                    mapped.len(),
+                    if mapped.len() == 1 { "" } else { "s" }
+                );
+                for (id, pt, fsn, hierarchy) in &mapped {
+                    println!("  [{id}] {pt}");
+                    let fsn_clean = strip_semantic_tag(fsn);
+                    if fsn_clean != pt && !fsn.is_empty() {
+                        println!("        FSN: {fsn_clean}");
+                    }
+                    println!("        {hierarchy}");
+                }
+                if mapped.len() > 1 {
+                    println!("\nUse `sct lookup <SCTID>` for full details on a specific concept.");
+                }
+                provenance::print_human_footer(prov.as_ref(), show_prov);
+                return Ok(());
+            }
         }
         println!("Concept {code} not found.");
         return Ok(());
@@ -367,9 +404,16 @@ fn print_concept(
     // Cross-maps
     let ctv3 = concept["ctv3_codes"].as_array();
     let read2 = concept["read2_codes"].as_array();
+    #[cfg(feature = "gtin")]
+    let gtin = concept["gtin_codes"].as_array();
     let has_ctv3 = ctv3.is_some_and(|a| !a.is_empty());
     let has_read2 = read2.is_some_and(|a| !a.is_empty());
-    if has_ctv3 || has_read2 {
+    #[cfg(feature = "gtin")]
+    let has_gtin = gtin.is_some_and(|a| !a.is_empty());
+    #[cfg(not(feature = "gtin"))]
+    let has_gtin = false;
+
+    if has_ctv3 || has_read2 || has_gtin {
         println!("  Cross-maps:");
         if let Some(codes) = ctv3 {
             let cs: Vec<&str> = codes.iter().filter_map(|c| c.as_str()).collect();
@@ -381,6 +425,13 @@ fn print_concept(
             let cs: Vec<&str> = codes.iter().filter_map(|c| c.as_str()).collect();
             if !cs.is_empty() {
                 println!("    Read v2: {}", cs.join(", "));
+            }
+        }
+        #[cfg(feature = "gtin")]
+        if let Some(codes) = gtin {
+            let cs: Vec<&str> = codes.iter().filter_map(|c| c.as_str()).collect();
+            if !cs.is_empty() {
+                println!("    GTIN: {}", cs.join(", "));
             }
         }
     }
@@ -404,4 +455,25 @@ fn print_concept(
     provenance::print_human_footer(prov, show_prov);
 
     Ok(())
+}
+
+/// Reverse-lookup a GTIN barcode → SNOMED concept(s) via concept_maps.
+#[cfg(feature = "gtin")]
+fn lookup_gtin(conn: &Connection, code: &str) -> Result<Vec<(String, String, String, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.preferred_term, c.fsn, c.hierarchy
+         FROM concept_maps m
+         JOIN concepts c ON c.id = m.concept_id
+         WHERE m.code = ?1 AND m.terminology = 'gtin'
+         ORDER BY c.id",
+    )?;
+
+    let rows: Vec<(String, String, String, String)> = stmt
+        .query_map(params![code], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rows)
 }

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -131,14 +131,23 @@ pub fn run(args: Args) -> Result<()> {
 }
 
 fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
-    let result = conn.query_row(
-        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    #[cfg(feature = "gtin")]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1",
+         FROM concepts WHERE id = ?1";
+    #[cfg(not(feature = "gtin"))]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                parents, children_count, attributes, active, module, effective_time,
+                ctv3_codes, read2_codes
+         FROM concepts WHERE id = ?1";
+
+    let result = conn.query_row(
+        query,
         params![id],
         |row| {
-            Ok(json!({
+            #[cfg(feature = "gtin")]
+            return Ok(json!({
                 "id": row.get::<_, String>(0)?,
                 "fsn": row.get::<_, String>(1)?,
                 "preferred_term": row.get::<_, String>(2)?,
@@ -154,7 +163,25 @@ fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
                 "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
                 "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }))
+            }));
+
+            #[cfg(not(feature = "gtin"))]
+            return Ok(json!({
+                "id": row.get::<_, String>(0)?,
+                "fsn": row.get::<_, String>(1)?,
+                "preferred_term": row.get::<_, String>(2)?,
+                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                "hierarchy": row.get::<_, String>(4)?,
+                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                "children_count": row.get::<_, i64>(7)?,
+                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                "active": row.get::<_, bool>(9)?,
+                "module": row.get::<_, String>(10)?,
+                "effective_time": row.get::<_, String>(11)?,
+                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+            }));
         },
     );
 

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -324,6 +324,7 @@ fn print_concept(
                 let pterm = p["term"]
                     .as_str()
                     .or(p["preferred_term"].as_str())
+                    .or(p["fsn"].as_str())
                     .unwrap_or("?");
                 println!("    [{pid}] {pterm}");
             }
@@ -356,6 +357,7 @@ fn print_concept(
                         let vterm = v["term"]
                             .as_str()
                             .or(v["preferred_term"].as_str())
+                            .or(v["fsn"].as_str())
                             .unwrap_or("?");
                         println!("    {key}: [{vid}] {vterm}");
                     }

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -134,7 +134,7 @@ fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
     let result = conn.query_row(
         "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
-                ctv3_codes, read2_codes
+                ctv3_codes, read2_codes, gtin_codes
          FROM concepts WHERE id = ?1",
         params![id],
         |row| {
@@ -152,7 +152,8 @@ fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
                 "module": row.get::<_, String>(10)?,
                 "effective_time": row.get::<_, String>(11)?,
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([]))
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
             }))
         },
     );

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -169,56 +169,63 @@ pub fn run(args: Args) -> Result<()> {
 
 fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
     #[cfg(feature = "gtin")]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    let use_gtin = has_gtin_column(conn);
+    #[cfg(not(feature = "gtin"))]
+    let use_gtin = false;
+
+    let query = if use_gtin {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1";
-    #[cfg(not(feature = "gtin"))]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+         FROM concepts WHERE id = ?1"
+    } else {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes
-         FROM concepts WHERE id = ?1";
+         FROM concepts WHERE id = ?1"
+    };
 
     let result = conn.query_row(
         query,
         params![id],
         |row| {
-            #[cfg(feature = "gtin")]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }));
-
-            #[cfg(not(feature = "gtin"))]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-            }));
+            if use_gtin {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
+                }))
+            } else {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": json!([])
+                }))
+            }
         },
     );
 
@@ -476,4 +483,15 @@ fn lookup_gtin(conn: &Connection, code: &str) -> Result<Vec<(String, String, Str
         .collect();
 
     Ok(rows)
+}
+
+/// Check if the concepts table has the gtin_codes column.
+#[cfg(feature = "gtin")]
+fn has_gtin_column(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        [],
+        |_| Ok(true),
+    )
+    .unwrap_or(false)
 }

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -491,7 +491,7 @@ fn lookup_gtin(conn: &Connection, code: &str) -> Result<Vec<(String, String, Str
 #[cfg(feature = "gtin")]
 fn has_gtin_column(conn: &Connection) -> bool {
     conn.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        "SELECT 1 FROM pragma_table_info('concepts') WHERE name = 'gtin_codes' LIMIT 1",
         [],
         |_| Ok(true),
     )

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -711,14 +711,23 @@ fn tool_search(conn: &Connection, args: &Value) -> Result<String> {
 fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> Result<String> {
     let id = args["id"].as_str().context("snomed_concept requires id")?;
 
-    let result = conn.query_row(
-        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    #[cfg(feature = "gtin")]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1",
+         FROM concepts WHERE id = ?1";
+    #[cfg(not(feature = "gtin"))]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                parents, children_count, attributes, active, module, effective_time,
+                ctv3_codes, read2_codes
+         FROM concepts WHERE id = ?1";
+
+    let result = conn.query_row(
+        query,
         params![id],
         |row| {
-            Ok(json!({
+            #[cfg(feature = "gtin")]
+            return Ok(json!({
                 "id": row.get::<_, String>(0)?,
                 "fsn": row.get::<_, String>(1)?,
                 "preferred_term": row.get::<_, String>(2)?,
@@ -734,7 +743,25 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
                 "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
                 "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }))
+            }));
+
+            #[cfg(not(feature = "gtin"))]
+            return Ok(json!({
+                "id": row.get::<_, String>(0)?,
+                "fsn": row.get::<_, String>(1)?,
+                "preferred_term": row.get::<_, String>(2)?,
+                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                "hierarchy": row.get::<_, String>(4)?,
+                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                "children_count": row.get::<_, i64>(7)?,
+                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                "active": row.get::<_, bool>(9)?,
+                "module": row.get::<_, String>(10)?,
+                "effective_time": row.get::<_, String>(11)?,
+                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+            }));
         },
     );
 
@@ -880,30 +907,46 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
                 .filter_map(|r| r.ok())
                 .collect();
 
+            #[cfg(feature = "gtin")]
             let mut gtin_stmt = conn.prepare(
                 "SELECT code FROM concept_maps WHERE concept_id = ?1 AND terminology = 'gtin' ORDER BY code",
             )?;
+            #[cfg(feature = "gtin")]
             let gtin_codes: Vec<String> = gtin_stmt
                 .query_map(params![code], |row| row.get(0))?
                 .filter_map(|r| r.ok())
                 .collect();
+            #[cfg(not(feature = "gtin"))]
+            let gtin_codes: Vec<String> = vec![];
 
             if ctv3_codes.is_empty() && read2_codes.is_empty() && gtin_codes.is_empty() {
+                #[cfg(feature = "gtin")]
                 return Ok(format!(
                     "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}.",
                     code
                 ));
+                #[cfg(not(feature = "gtin"))]
+                return Ok(format!(
+                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}.",
+                    code
+                ));
             }
 
-            Ok(serde_json::to_string_pretty(&json!({
+            #[allow(unused_mut)]
+            let mut ret = json!({
                 "snomed_id": code,
                 "ctv3_codes": ctv3_codes,
                 "read2_codes": read2_codes,
-                "gtin_codes": gtin_codes
-            }))?)
+            });
+            #[cfg(feature = "gtin")]
+            ret.as_object_mut()
+                .unwrap()
+                .insert("gtin_codes".to_string(), json!(gtin_codes));
+
+            Ok(serde_json::to_string_pretty(&ret)?)
         }
 
-        "ctv3" | "read2" | "gtin" => {
+        term if term == "ctv3" || term == "read2" || (cfg!(feature = "gtin") && term == "gtin") => {
             // CTV3 or Read v2 code → SNOMED CT concept(s)
             let mut stmt = conn.prepare(
                 "SELECT c.id, c.preferred_term, c.fsn, c.hierarchy
@@ -1486,7 +1529,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn create_test_schema(conn: &Connection) {
-        conn.execute_batch(
+        let sql = if cfg!(feature = "gtin") {
             "CREATE TABLE IF NOT EXISTS concepts (
                 id             TEXT PRIMARY KEY,
                 fsn            TEXT NOT NULL,
@@ -1504,8 +1547,29 @@ mod tests {
                 read2_codes    TEXT,
                 gtin_codes     TEXT,
                 schema_version INTEGER NOT NULL DEFAULT 6
-            );
-            CREATE TABLE IF NOT EXISTS concept_isa (
+            );"
+        } else {
+            "CREATE TABLE IF NOT EXISTS concepts (
+                id             TEXT PRIMARY KEY,
+                fsn            TEXT NOT NULL,
+                preferred_term TEXT NOT NULL,
+                synonyms       TEXT,
+                hierarchy      TEXT,
+                hierarchy_path TEXT,
+                parents        TEXT,
+                children_count INTEGER,
+                attributes     TEXT,
+                active         INTEGER NOT NULL,
+                module         TEXT,
+                effective_time TEXT,
+                ctv3_codes     TEXT,
+                read2_codes    TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 5
+            );"
+        };
+        conn.execute_batch(sql).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS concept_isa (
                 child_id  TEXT NOT NULL,
                 parent_id TEXT NOT NULL
             );
@@ -1538,15 +1602,41 @@ mod tests {
         hierarchy_path: &str,
         synonyms: &str, // JSON array string, e.g. `["syn1","syn2"]`
     ) {
-        conn.execute(
-            "INSERT INTO concepts
-             (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
-              parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, gtin_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]','[]',6)",
-            params![id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path],
-        )
-        .unwrap();
+        let (sql, params_args): (&str, Vec<String>) = if cfg!(feature = "gtin") {
+            (
+                "INSERT INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, gtin_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]','[]',6)",
+                vec![
+                    id.to_string(),
+                    fsn.to_string(),
+                    preferred_term.to_string(),
+                    synonyms.to_string(),
+                    hierarchy.to_string(),
+                    hierarchy_path.to_string(),
+                ],
+            )
+        } else {
+            (
+                "INSERT INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]',5)",
+                vec![
+                    id.to_string(),
+                    fsn.to_string(),
+                    preferred_term.to_string(),
+                    synonyms.to_string(),
+                    hierarchy.to_string(),
+                    hierarchy_path.to_string(),
+                ],
+            )
+        };
+        conn.execute(sql, rusqlite::params_from_iter(params_args))
+            .unwrap();
     }
 
     /// Insert `n` duplicate IS-A rows (simulating real RF2 data which has ~6 per relationship).

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -188,7 +188,7 @@ fn validate_schema_version(conn: &Connection) -> Result<()> {
 #[cfg(feature = "gtin")]
 fn has_gtin_column(conn: &Connection) -> bool {
     conn.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        "SELECT 1 FROM pragma_table_info('concepts') WHERE name = 'gtin_codes' LIMIT 1",
         [],
         |_| Ok(true),
     )

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1808,6 +1808,9 @@ mod tests {
         // CTV3 mapping for MI
         insert_map(&conn, "X200E", "ctv3", "7000000");
 
+        #[cfg(feature = "gtin")]
+        insert_map(&conn, "05016000000000", "gtin", "7000000");
+
         rebuild_fts(&conn);
         conn
     }
@@ -2080,7 +2083,39 @@ mod tests {
         let conn = build_test_db();
         let args = json!({"code": "3000000", "terminology": "snomed"});
         let result = tool_map(&conn, &args).unwrap();
-        assert!(result.contains("No CTV3 or Read v2 mappings found"));
+        if cfg!(feature = "gtin") {
+            assert!(result.contains("No CTV3, Read v2, or GTIN mappings found"));
+        } else {
+            assert!(result.contains("No CTV3 or Read v2 mappings found"));
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "gtin")]
+    fn map_snomed_to_gtin() {
+        let conn = build_test_db();
+        let args = json!({"code": "7000000", "terminology": "snomed"});
+        let result = tool_map(&conn, &args).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let gtin: Vec<&str> = v["gtin_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c.as_str().unwrap())
+            .collect();
+        assert_eq!(gtin, vec!["05016000000000"]);
+    }
+
+    #[test]
+    #[cfg(feature = "gtin")]
+    fn map_gtin_to_snomed() {
+        let conn = build_test_db();
+        let args = json!({"code": "05016000000000", "terminology": "gtin"});
+        let result = tool_map(&conn, &args).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let concepts = v["snomed_concepts"].as_array().unwrap();
+        assert_eq!(concepts.len(), 1);
+        assert_eq!(concepts[0]["id"].as_str().unwrap(), "7000000");
     }
 
     #[test]

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -714,7 +714,7 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
     let result = conn.query_row(
         "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
-                ctv3_codes, read2_codes
+                ctv3_codes, read2_codes, gtin_codes
          FROM concepts WHERE id = ?1",
         params![id],
         |row| {
@@ -732,7 +732,8 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
                 "module": row.get::<_, String>(10)?,
                 "effective_time": row.get::<_, String>(11)?,
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([]))
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
             }))
         },
     );
@@ -862,7 +863,7 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
 
     match terminology {
         "snomed" => {
-            // SNOMED SCTID → CTV3 and Read v2 codes
+            // SNOMED SCTID → CTV3, Read v2, and GTIN codes
             let mut ctv3_stmt = conn.prepare(
                 "SELECT code FROM concept_maps WHERE concept_id = ?1 AND terminology = 'ctv3' ORDER BY code",
             )?;
@@ -879,10 +880,17 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
                 .filter_map(|r| r.ok())
                 .collect();
 
-            if ctv3_codes.is_empty() && read2_codes.is_empty() {
+            let mut gtin_stmt = conn.prepare(
+                "SELECT code FROM concept_maps WHERE concept_id = ?1 AND terminology = 'gtin' ORDER BY code",
+            )?;
+            let gtin_codes: Vec<String> = gtin_stmt
+                .query_map(params![code], |row| row.get(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+
+            if ctv3_codes.is_empty() && read2_codes.is_empty() && gtin_codes.is_empty() {
                 return Ok(format!(
-                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}. \
-                     Mappings are only present when the database was built from a UK Monolith RF2 release.",
+                    "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}.",
                     code
                 ));
             }
@@ -890,11 +898,12 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
             Ok(serde_json::to_string_pretty(&json!({
                 "snomed_id": code,
                 "ctv3_codes": ctv3_codes,
-                "read2_codes": read2_codes
+                "read2_codes": read2_codes,
+                "gtin_codes": gtin_codes
             }))?)
         }
 
-        "ctv3" | "read2" => {
+        "ctv3" | "read2" | "gtin" => {
             // CTV3 or Read v2 code → SNOMED CT concept(s)
             let mut stmt = conn.prepare(
                 "SELECT c.id, c.preferred_term, c.fsn, c.hierarchy
@@ -1493,7 +1502,8 @@ mod tests {
                 effective_time TEXT,
                 ctv3_codes     TEXT,
                 read2_codes    TEXT,
-                schema_version INTEGER NOT NULL DEFAULT 2
+                gtin_codes     TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 6
             );
             CREATE TABLE IF NOT EXISTS concept_isa (
                 child_id  TEXT NOT NULL,
@@ -1532,8 +1542,8 @@ mod tests {
             "INSERT INTO concepts
              (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
               parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]',2)",
+              ctv3_codes, read2_codes, gtin_codes, schema_version)
+             VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]','[]',6)",
             params![id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path],
         )
         .unwrap();

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1005,7 +1005,7 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
         }
 
         other => anyhow::bail!(
-            "Unknown terminology '{}'. Use 'snomed', 'ctv3', or 'read2'.",
+            "Unknown terminology '{}'. Use 'snomed', 'ctv3', 'gtin' or 'read2'.",
             other
         ),
     }

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -184,6 +184,17 @@ fn validate_schema_version(conn: &Connection) -> Result<()> {
     }
 }
 
+/// Check if the concepts table has the gtin_codes column.
+#[cfg(feature = "gtin")]
+fn has_gtin_column(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        [],
+        |_| Ok(true),
+    )
+    .unwrap_or(false)
+}
+
 // ---------------------------------------------------------------------------
 // Transport: dual-mode stdio (MCP spec changed in 2025)
 //
@@ -712,56 +723,63 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
     let id = args["id"].as_str().context("snomed_concept requires id")?;
 
     #[cfg(feature = "gtin")]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    let use_gtin = has_gtin_column(conn);
+    #[cfg(not(feature = "gtin"))]
+    let use_gtin = false;
+
+    let query = if use_gtin {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1";
-    #[cfg(not(feature = "gtin"))]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+         FROM concepts WHERE id = ?1"
+    } else {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes
-         FROM concepts WHERE id = ?1";
+         FROM concepts WHERE id = ?1"
+    };
 
     let result = conn.query_row(
         query,
         params![id],
         |row| {
-            #[cfg(feature = "gtin")]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }));
-
-            #[cfg(not(feature = "gtin"))]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-            }));
+            if use_gtin {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
+                }))
+            } else {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": json!([])
+                }))
+            }
         },
     );
 

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -940,12 +940,14 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
             if ctv3_codes.is_empty() && read2_codes.is_empty() && gtin_codes.is_empty() {
                 #[cfg(feature = "gtin")]
                 return Ok(format!(
-                    "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}.",
+                    "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}. \
+                     Mappings are only present when the database was built from a UK Monolith RF2 release.",
                     code
                 ));
                 #[cfg(not(feature = "gtin"))]
                 return Ok(format!(
-                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}.",
+                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}. \
+                     Mappings are only present when the database was built from a UK Monolith RF2 release.",
                     code
                 ));
             }

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -88,13 +88,23 @@ pub fn run(args: Args) -> Result<()> {
     {
         let tx = conn.transaction().context("beginning transaction")?;
 
-        let mut insert_concept = tx.prepare(
-            "INSERT OR REPLACE INTO concepts
-             (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
-              parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, gtin_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
-        )?;
+        let mut insert_concept = if cfg!(feature = "gtin") {
+            tx.prepare(
+                "INSERT OR REPLACE INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, gtin_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
+            )?
+        } else {
+            tx.prepare(
+                "INSERT OR REPLACE INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
+            )?
+        };
 
         let mut insert_isa =
             tx.prepare("INSERT INTO concept_isa (child_id, parent_id) VALUES (?1, ?2)")?;
@@ -150,8 +160,10 @@ pub fn run(args: Args) -> Result<()> {
             let attributes_json = serde_json::to_string(&record.attributes)?;
             let ctv3_json = serde_json::to_string(&record.ctv3_codes)?;
             let read2_json = serde_json::to_string(&record.read2_codes)?;
+            #[cfg(feature = "gtin")]
             let gtin_json = serde_json::to_string(&record.gtin_codes)?;
 
+            #[cfg(feature = "gtin")]
             insert_concept.execute(params![
                 record.id,
                 record.fsn,
@@ -168,6 +180,25 @@ pub fn run(args: Args) -> Result<()> {
                 ctv3_json,
                 read2_json,
                 gtin_json,
+                record.schema_version as i64,
+            ])?;
+
+            #[cfg(not(feature = "gtin"))]
+            insert_concept.execute(params![
+                record.id,
+                record.fsn,
+                record.preferred_term,
+                synonyms_json,
+                record.hierarchy,
+                hierarchy_path_json,
+                parents_json,
+                record.children_count as i64,
+                attributes_json,
+                record.active as i32,
+                record.module,
+                record.effective_time,
+                ctv3_json,
+                read2_json,
                 record.schema_version as i64,
             ])?;
 
@@ -192,6 +223,7 @@ pub fn run(args: Args) -> Result<()> {
                 insert_map.execute(params![code, "read2", record.id])?;
                 insert_simple_crossmap.execute(params!["read2", code, record.id])?;
             }
+            #[cfg(feature = "gtin")]
             for code in &record.gtin_codes {
                 insert_map.execute(params![code, "gtin", record.id])?;
                 insert_simple_crossmap.execute(params!["gtin", code, record.id])?;
@@ -307,7 +339,7 @@ fn load_history_sidecar(conn: &Connection, input: &std::path::Path) -> Result<us
 }
 
 fn create_schema(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+    let sql = if cfg!(feature = "gtin") {
         "CREATE TABLE IF NOT EXISTS concepts (
             id             TEXT PRIMARY KEY,
             fsn            TEXT NOT NULL,
@@ -325,9 +357,29 @@ fn create_schema(conn: &Connection) -> Result<()> {
             read2_codes    TEXT,            -- JSON array of Read v2 code strings
             gtin_codes     TEXT,            -- JSON array of GTIN strings
             schema_version INTEGER NOT NULL DEFAULT 6
-        );
-
-        CREATE TABLE IF NOT EXISTS concept_isa (
+        );"
+    } else {
+        "CREATE TABLE IF NOT EXISTS concepts (
+            id             TEXT PRIMARY KEY,
+            fsn            TEXT NOT NULL,
+            preferred_term TEXT NOT NULL,
+            synonyms       TEXT,            -- JSON array of strings
+            hierarchy      TEXT,
+            hierarchy_path TEXT,            -- JSON array of strings
+            parents        TEXT,            -- JSON array of {id, fsn}
+            children_count INTEGER,
+            attributes     TEXT,            -- JSON object
+            active         INTEGER NOT NULL,
+            module         TEXT,
+            effective_time TEXT,
+            ctv3_codes     TEXT,            -- JSON array of CTV3 code strings
+            read2_codes    TEXT,            -- JSON array of Read v2 code strings
+            schema_version INTEGER NOT NULL DEFAULT 5
+        );"
+    };
+    conn.execute_batch(sql)?;
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS concept_isa (
             child_id  TEXT NOT NULL,
             parent_id TEXT NOT NULL
         );

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -92,8 +92,8 @@ pub fn run(args: Args) -> Result<()> {
             "INSERT OR REPLACE INTO concepts
              (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
               parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
+              ctv3_codes, read2_codes, gtin_codes, schema_version)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
         )?;
 
         let mut insert_isa =
@@ -150,6 +150,7 @@ pub fn run(args: Args) -> Result<()> {
             let attributes_json = serde_json::to_string(&record.attributes)?;
             let ctv3_json = serde_json::to_string(&record.ctv3_codes)?;
             let read2_json = serde_json::to_string(&record.read2_codes)?;
+            let gtin_json = serde_json::to_string(&record.gtin_codes)?;
 
             insert_concept.execute(params![
                 record.id,
@@ -166,6 +167,7 @@ pub fn run(args: Args) -> Result<()> {
                 record.effective_time,
                 ctv3_json,
                 read2_json,
+                gtin_json,
                 record.schema_version as i64,
             ])?;
 
@@ -189,6 +191,10 @@ pub fn run(args: Args) -> Result<()> {
             for code in &record.read2_codes {
                 insert_map.execute(params![code, "read2", record.id])?;
                 insert_simple_crossmap.execute(params!["read2", code, record.id])?;
+            }
+            for code in &record.gtin_codes {
+                insert_map.execute(params![code, "gtin", record.id])?;
+                insert_simple_crossmap.execute(params!["gtin", code, record.id])?;
             }
 
             for refset_id in &record.refsets {
@@ -317,7 +323,8 @@ fn create_schema(conn: &Connection) -> Result<()> {
             effective_time TEXT,
             ctv3_codes     TEXT,            -- JSON array of CTV3 code strings
             read2_codes    TEXT,            -- JSON array of Read v2 code strings
-            schema_version INTEGER NOT NULL DEFAULT 3
+            gtin_codes     TEXT,            -- JSON array of GTIN strings
+            schema_version INTEGER NOT NULL DEFAULT 6
         );
 
         CREATE TABLE IF NOT EXISTS concept_isa (

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -378,8 +378,19 @@ fn create_schema(conn: &Connection) -> Result<()> {
         );"
     };
     conn.execute_batch(sql)?;
+    if cfg!(feature = "gtin") {
+        let has_gtin = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        if !has_gtin {
+            conn.execute("ALTER TABLE concepts ADD COLUMN gtin_codes TEXT", [])?;
+        }
+    }
     conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS concept_isa (
             child_id  TEXT NOT NULL,
             parent_id TEXT NOT NULL
         );

--- a/src/commands/transcode.rs
+++ b/src/commands/transcode.rs
@@ -66,7 +66,7 @@ pub fn transcode_one(
 fn to_snomed(conn: &Connection, from: &str, code: &str) -> Result<Vec<String>> {
     match from {
         "snomed" => Ok(vec![code.to_string()]),
-        "ctv3" | "read2" => {
+        "ctv3" | "read2" | "gtin" => {
             let from_crossmaps = legacy_to_snomed_from_crossmaps(conn, from, code)?;
             if !from_crossmaps.is_empty() || !table_exists(conn, "concept_maps") {
                 Ok(from_crossmaps)
@@ -92,7 +92,7 @@ fn to_snomed(conn: &Connection, from: &str, code: &str) -> Result<Vec<String>> {
 fn from_snomed(conn: &Connection, concept: &str, to: &str) -> Result<Vec<String>> {
     match to {
         "snomed" => Ok(vec![concept.to_string()]),
-        "ctv3" | "read2" => {
+        "ctv3" | "read2" | "gtin" => {
             let from_crossmaps = legacy_from_snomed_from_crossmaps(conn, concept, to)?;
             if !from_crossmaps.is_empty() || !table_exists(conn, "concept_maps") {
                 Ok(from_crossmaps)

--- a/src/commands/transcode.rs
+++ b/src/commands/transcode.rs
@@ -15,6 +15,9 @@ use anyhow::{bail, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::io::BufRead;
 
+#[cfg(feature = "gtin")]
+pub(crate) const SYSTEMS: [&str; 6] = ["snomed", "read2", "ctv3", "icd10", "opcs4", "gtin"];
+#[cfg(not(feature = "gtin"))]
 pub(crate) const SYSTEMS: [&str; 5] = ["snomed", "read2", "ctv3", "icd10", "opcs4"];
 
 /// One mapped output: the target code, the SNOMED pivot concept it went through,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -21,7 +21,10 @@ use serde::{Deserialize, Serialize};
 /// Additive - older records parse with an empty list.
 /// v6: adds `gtin_codes` (Global Trade Item Numbers).
 /// Additive - older records parse with an empty list.
+#[cfg(feature = "gtin")]
 pub const SCHEMA_VERSION: u32 = 6;
+#[cfg(not(feature = "gtin"))]
+pub const SCHEMA_VERSION: u32 = 5;
 
 /// A lightweight reference to another concept (used in parents and attributes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,9 +131,37 @@ pub struct ConceptRecord {
     pub crossmaps: Vec<CrossMapEntry>,
     /// GTIN (Global Trade Item Number) codes mapped to this concept.
     /// Additive - older records parse with an empty list.
+    #[cfg(feature = "gtin")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gtin_codes: Vec<String>,
     pub schema_version: u32,
+}
+
+impl Default for ConceptRecord {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            fsn: String::new(),
+            preferred_term: String::new(),
+            synonyms: vec![],
+            hierarchy: String::new(),
+            hierarchy_path: vec![],
+            parents: vec![],
+            children_count: 0,
+            attributes: indexmap::IndexMap::new(),
+            active: true,
+            module: String::new(),
+            effective_time: String::new(),
+            ctv3_codes: vec![],
+            read2_codes: vec![],
+            refsets: vec![],
+            relationships: vec![],
+            crossmaps: vec![],
+            #[cfg(feature = "gtin")]
+            gtin_codes: vec![],
+            schema_version: SCHEMA_VERSION,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -169,8 +200,7 @@ mod tests {
                 advice: "ALWAYS I21.9".into(),
                 correlation: String::new(),
             }],
-            gtin_codes: vec![],
-            schema_version: SCHEMA_VERSION,
+            ..Default::default()
         }
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,7 +19,9 @@ use serde::{Deserialize, Serialize};
 /// ECL attribute refinement. Additive - older records parse with an empty list.
 /// v5: adds `crossmaps` (SNOMED CT → ICD-10 / OPCS-4 ExtendedMap targets).
 /// Additive - older records parse with an empty list.
-pub const SCHEMA_VERSION: u32 = 5;
+/// v6: adds `gtin_codes` (Global Trade Item Numbers).
+/// Additive - older records parse with an empty list.
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// A lightweight reference to another concept (used in parents and attributes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -124,6 +126,10 @@ pub struct ConceptRecord {
     /// Populated with `--refsets all`. Empty on records from schema v4 and earlier.
     #[serde(default)]
     pub crossmaps: Vec<CrossMapEntry>,
+    /// GTIN (Global Trade Item Number) codes mapped to this concept.
+    /// Additive - older records parse with an empty list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gtin_codes: Vec<String>,
     pub schema_version: u32,
 }
 
@@ -163,6 +169,7 @@ mod tests {
                 advice: "ALWAYS I21.9".into(),
                 correlation: String::new(),
             }],
+            gtin_codes: vec![],
             schema_version: SCHEMA_VERSION,
         }
     }

--- a/tests/ecl_eval.rs
+++ b/tests/ecl_eval.rs
@@ -8,7 +8,7 @@
 use indexmap::IndexMap;
 use sct_rs::commands::sqlite;
 use sct_rs::ecl;
-use sct_rs::schema::{ConceptRecord, ConceptRef, Relationship, SCHEMA_VERSION};
+use sct_rs::schema::{ConceptRecord, ConceptRef, Relationship};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -52,8 +52,7 @@ fn rec(
             })
             .collect(),
         crossmaps: vec![],
-        gtin_codes: vec![],
-        schema_version: SCHEMA_VERSION,
+        ..Default::default()
     }
 }
 

--- a/tests/ecl_eval.rs
+++ b/tests/ecl_eval.rs
@@ -52,6 +52,7 @@ fn rec(
             })
             .collect(),
         crossmaps: vec![],
+        gtin_codes: vec![],
         schema_version: SCHEMA_VERSION,
     }
 }


### PR DESCRIPTION
This PR adds support for Global Trade Item Numbers (GTINs) mapped to SNOMED CT concepts (typically Actual Medicinal Product Packs/AMPPs). 

This is behind a feature flag to preserve compatiblity with non UK/Monolith SNOMED sets. With the feature flag, the schema is bumped to v6.

This branch will also be the base for a few more features (filtering etc).