### PR TITLE
feat: add size viewer

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -368,8 +368,27 @@ async function loadConcept(id, push) {
   } catch (e) {
     panel.innerHTML = `<div class="text-center py-16 text-sm text-base-content/40">Error: ${esc(e.message)}</div>`;
   }
-}
+  const sizeEl = panel.querySelector("#size-estimates");
+  if (!sizeEl) return;
 
+  try {
+    const sizeData = await apiFetch(`/api/size/${encodeURIComponent(id)}`);
+    if (activeConceptId !== id) return;
+    if (sizeData.error) throw new Error(sizeData.error);
+    sizeEl.innerHTML = `
+      <p class="font-semibold uppercase tracking-widest text-base-content/40 mb-1">Size estimates</p>
+      <div class="flex flex-wrap gap-2">
+        ${sizeData.sqlite_human ? `<span class="badge badge-outline text-xs">SQLite: ${esc(sizeData.sqlite_human)}</span>` : ""}
+        ${sizeData.ndjson_human ? `<span class="badge badge-outline text-xs">NDJSON: ${esc(sizeData.ndjson_human)}</span>` : ""}
+      </div>`;
+  } catch (e) {
+    if (activeConceptId !== id) return;
+    console.warn("Failed to load size estimates:", e);
+    sizeEl.innerHTML = `
+      <p class="font-semibold uppercase tracking-widest text-base-content/40 mb-1">Size estimates</p>
+      <p class="text-base-content/30">Unavailable</p>`;
+  }
+}
 function renderConcept(c, panel) {
   const synonyms    = Array.isArray(c.synonyms)       ? c.synonyms       : [];
   const path        = Array.isArray(c.hierarchy_path) ? c.hierarchy_path : [];
@@ -391,6 +410,12 @@ function renderConcept(c, panel) {
       ${c.hierarchy ? `<span class="badge badge-warning badge-outline text-xs">${esc(c.hierarchy)}</span>` : ""}
       ${c.children_count ? `<span class="badge badge-ghost text-xs">${c.children_count} children</span>` : ""}
       ${c.descendants_count ? `<span class="badge badge-primary badge-outline text-xs">${c.descendants_count.toLocaleString()} descendants</span>` : ""}
+    </div>`;
+
+  html += `
+    <div id="size-estimates" class="text-xs text-base-content/40 mb-6">
+      <p class="font-semibold uppercase tracking-widest text-base-content/40 mb-1">Size estimates</p>
+      <p class="text-base-content/30">Loading…</p>
     </div>`;
 
   if (synonyms.length) {

--- a/assets/index.html
+++ b/assets/index.html
@@ -254,10 +254,10 @@ async function loadHierarchies() {
     data.hierarchies.forEach(h => {
       const btn = document.createElement("button");
       btn.className = "sidebar-item";
-      btn.innerHTML = `<span class="item-label">${esc(h)}</span><span class="item-meta">›</span>`;
+      btn.innerHTML = `<span class="item-label">${esc(h.name)}</span><span class="item-meta">${esc(h.count.toLocaleString())}</span>`;
       btn.addEventListener("click", () => {
         setActiveHierarchy(btn);
-        loadHierarchyConcepts(h);
+        loadHierarchyConcepts(h.name);
         document.getElementById("search-input").value = "";
       });
       el.appendChild(btn);
@@ -390,6 +390,7 @@ function renderConcept(c, panel) {
       <span class="badge badge-outline font-mono text-xs">${esc(c.id)}</span>
       ${c.hierarchy ? `<span class="badge badge-warning badge-outline text-xs">${esc(c.hierarchy)}</span>` : ""}
       ${c.children_count ? `<span class="badge badge-ghost text-xs">${c.children_count} children</span>` : ""}
+      ${c.descendants_count ? `<span class="badge badge-primary badge-outline text-xs">${c.descendants_count.toLocaleString()} descendants</span>` : ""}
     </div>`;
 
   if (synonyms.length) {

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -7,7 +7,7 @@ Estimate the output size of a concept subtree before you export it. `sct size` c
 ## Usage
 
 ```bash
-sct size [--concept <SCTID>] [--sample <N>] [--tree] [--depth <N>] [--format <FMT>] [--db <PATH>]
+sct size [--concept <SCTID>] [--sample <N>] [--tree] [--depth <N>] [--format <FMT>] [--build-tct] [--db <PATH>]
 ```
 
 ## Options
@@ -19,7 +19,31 @@ sct size [--concept <SCTID>] [--sample <N>] [--tree] [--depth <N>] [--format <FM
 | `--tree` | *(flag)* | Also print a `du`-style descendant-count tree. Text output only. |
 | `--depth <N>` | `2` | Maximum tree depth when `--tree` is enabled. |
 | `--format <FMT>` | `text` | Output format: `text`, `json`, or `yaml`. `--tree` is honoured for `text` only. |
+| `--build-tct` | *(flag)* | Build a transitive closure table (TCT) without prompting, if one is missing. For scripts and non-interactive shells. |
 | `--db <PATH>` | discovered (see [Path resolution](../path-resolution.md)) | SQLite database produced by `sct sqlite`. |
+
+---
+
+## Transitive closure table (TCT)
+
+Without a precomputed transitive closure table (`concept_ancestors`), the subtree count falls back to a recursive Common Table Expression (CTE) over the whole IS-A hierarchy. For large subtrees (especially the SNOMED CT root), this is unusably slow.
+
+When `sct size` detects a missing TCT, it offers to build one interactively:
+
+```text
+`sct size` needs a transitive closure table (TCT) to perform adequately.
+Build a TCT now (increases the database on disk by approx. ~2.1 MB)? [Y/n]
+```
+
+Answering "yes" (or just pressing Enter) builds the TCT in-place and proceeds with the fast estimate. Answering "no" continues with the slow recursive CTE.
+
+The prompt is skipped (and the slow path used) when:
+
+- `--format json` or `--format yaml` is given (machine output must not be polluted)
+- stdin or stderr is not a terminal (CI, scripts, pipes)
+- `--build-tct` is given (builds without prompting)
+
+For non-interactive use, `--build-tct` skips the prompt and builds the TCT if missing. It has no effect if a TCT already exists.
 
 ---
 

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -1,0 +1,34 @@
+# Concept Subtree Size Visualizer (`sct size`)
+
+The `sct size` command displays a hierarchical tree of SNOMED CT concepts and their subtree sizes (number of transitive descendants), acting like a disk-usage analyzer (`du` / `ncdu`) for the terminology taxonomy.
+
+---
+
+## Usage
+
+```bash
+# Print the size distribution from the SNOMED CT root concept (default)
+sct size --depth 2
+
+# Inspect a specific sub-hierarchy (e.g. Clinical finding)
+sct size --concept 404684003 --depth 3
+```
+
+---
+
+## Limitations & Design Characteristics
+
+When analyzing subtree sizes in SNOMED CT, keep the following characteristics and limitations in mind:
+
+### 1. Polyhierarchy and Cumulative Math
+SNOMED CT is a polyhierarchical taxonomy (a Directed Acyclic Graph, not a strict tree). This means a single concept can have multiple parent concepts (multiple inheritance).
+
+*   **Behavior**: When printing the hierarchical size tree, a concept that is inherited via multiple parent paths will appear multiple times in the tree (under each of its parent branches).
+*   **Result**: The sum of the subtree sizes of all children of a concept will usually be **larger** than the total subtree size reported on the parent concept itself. This is because any descendants with multiple parents are counted once in each path but deduplicated in the parent's absolute count.
+
+### 2. Performance Fallback without Transitive Closure Table (TCT)
+The size query utilizes a precomputed transitive closure table (`concept_ancestors`) if it exists in the SQLite database (built via `sct tct`).
+
+*   **TCT Present (Recommended)**: Queries are extremely fast (sub-millisecond) because they leverage indexed lookups.
+*   **TCT Absent (Fallback)**: If the `concept_ancestors` table is missing, `sct` falls back to running a recursive Common Table Expression (CTE) query against `concept_isa` to count descendants on the fly.
+*   **Performance Impact**: Running recursive CTE queries for large hierarchies (such as the root concept or Clinical Finding) is resource-intensive and will take several seconds to complete, especially when building multiple levels of a tree. We recommend running `sct tct` on your SQLite database before exploring sizes.

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -1,4 +1,54 @@
-# Concept Subtree Size Visualizer (`sct size`)
+# sct size `experimental!`
+
+Estimate the output size of a subtree rooted at a concept. The command samples NDJSON row sizes, counts the subtree, and reports both NDJSON and SQLite size estimates for planning exports or downstream processing.
+
+---
+
+## Usage
+
+```bash
+sct size [--concept <SCTID>] [--sample <N>] [--tree] [--depth <N>] [--db <PATH>]
+```
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--concept <SCTID>` | root concept | Starting concept ID. Falls back to the active root in filtered databases. |
+| `--sample <N>` | `200` | Number of rows to sample when estimating average NDJSON row size. |
+| `--tree` | *(flag)* | Also print a descendant-count tree. |
+| `--depth <N>` | `2` | Maximum tree depth when `--tree` is enabled. |
+| `--db <PATH>` | discovered (see [Path resolution](../path-resolution.md)) | SQLite database produced by `sct sqlite`. |
+
+---
+
+## Example
+
+```bash
+# Estimate the size of the whole SNOMED CT tree.
+sct size
+
+# Inspect a specific subtree with a smaller sample and a tree view.
+sct size --concept 404684003 --sample 100 --tree
+```
+
+---
+
+## Output
+
+The command reports:
+
+- subtree concept count and percentage of the full database
+- estimated NDJSON export size
+- estimated proportional SQLite database size
+- optional descendant counts for the subtree when `--tree` is set
+
+---
+
+## See also
+
+- [`sct gui`](gui.md) - browser UI with the same size estimates in the concept detail panel
+- [`sct tui`](tui.md) - keyboard UI with a toggleable size row# Concept Subtree Size Visualizer (`sct size`)
 
 The `sct size` command displays a hierarchical tree of SNOMED CT concepts and their subtree sizes (number of transitive descendants), acting like a disk-usage analyzer (`du` / `ncdu`) for the terminology taxonomy.
 

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -1,28 +1,29 @@
 # sct size `experimental!`
 
-Estimate the output size of a subtree rooted at a concept. The command samples NDJSON row sizes, counts the subtree, and reports both NDJSON and SQLite size estimates for planning exports or downstream processing.
+Estimate the output size of a concept subtree before you export it. `sct size` counts every concept in the subtree, samples NDJSON row sizes to project the `sct ndjson` export size, and estimates the proportional SQLite database size. It can also print a `du`-style descendant-count tree, acting like a disk-usage analyzer (`du` / `ncdu`) for the terminology taxonomy.
 
 ---
 
 ## Usage
 
 ```bash
-sct size [--concept <SCTID>] [--sample <N>] [--tree] [--depth <N>] [--db <PATH>]
+sct size [--concept <SCTID>] [--sample <N>] [--tree] [--depth <N>] [--format <FMT>] [--db <PATH>]
 ```
 
 ## Options
 
 | Flag | Default | Description |
 |---|---|---|
-| `--concept <SCTID>` | root concept | Starting concept ID. Falls back to the active root in filtered databases. |
-| `--sample <N>` | `200` | Number of rows to sample when estimating average NDJSON row size. |
-| `--tree` | *(flag)* | Also print a descendant-count tree. |
+| `--concept <SCTID>` | root concept | Starting concept ID. Falls back to the single active root detected in filtered/subset databases. |
+| `--sample <N>` | `200` | Number of rows to sample when estimating the average NDJSON row size. |
+| `--tree` | *(flag)* | Also print a `du`-style descendant-count tree. Text output only. |
 | `--depth <N>` | `2` | Maximum tree depth when `--tree` is enabled. |
+| `--format <FMT>` | `text` | Output format: `text`, `json`, or `yaml`. `--tree` is honoured for `text` only. |
 | `--db <PATH>` | discovered (see [Path resolution](../path-resolution.md)) | SQLite database produced by `sct sqlite`. |
 
 ---
 
-## Example
+## Examples
 
 ```bash
 # Estimate the size of the whole SNOMED CT tree.
@@ -30,6 +31,9 @@ sct size
 
 # Inspect a specific subtree with a smaller sample and a tree view.
 sct size --concept 404684003 --sample 100 --tree
+
+# Emit machine-readable estimates for scripting.
+sct size --concept 404684003 --format json
 ```
 
 ---
@@ -38,47 +42,38 @@ sct size --concept 404684003 --sample 100 --tree
 
 The command reports:
 
-- subtree concept count and percentage of the full database
-- estimated NDJSON export size
-- estimated proportional SQLite database size
-- optional descendant counts for the subtree when `--tree` is set
+- the subtree concept count and its percentage of the full database
+- the estimated NDJSON export size
+- the estimated proportional SQLite database size
+- optional descendant counts for the subtree when `--tree` is set (text output only)
+
+With `--format json` or `--format yaml`, the same figures are emitted as a structured record (including both raw byte counts and human-readable strings) and the tree view is skipped.
+
+---
+
+## Limitations and design characteristics
+
+Keep the following characteristics in mind when interpreting the estimates.
+
+### 1. NDJSON estimate is a deliberate lower bound
+
+The NDJSON size is derived by sampling rows and approximating each line's byte length from the concept's stored text columns. It intentionally excludes `refsets`, `relationships`, and `crossmaps`, which live in separate tables, so a real `sct ndjson` line is somewhat larger than the per-row average reported here. Treat the NDJSON figure as a floor, not an exact size. Increasing `--sample` improves the average's stability but does not change what it measures.
+
+### 2. Polyhierarchy and cumulative math
+
+SNOMED CT is a polyhierarchical taxonomy (a directed acyclic graph, not a strict tree): a single concept can have multiple parents. When `--tree` prints the hierarchical view, a concept reached via multiple parent paths appears under each of those branches. As a result, the sum of the children's subtree sizes is usually **larger** than the subtree size reported on the parent itself, because descendants with multiple parents are counted once per path but deduplicated in the parent's absolute count.
+
+### 3. Performance depends on the transitive closure table (TCT)
+
+The subtree count uses the precomputed transitive closure table (`concept_ancestors`) when it exists, built via `sct tct`.
+
+- **TCT present (recommended)**: counts are near-instant because they use indexed lookups.
+- **TCT absent (fallback)**: `sct` runs a recursive Common Table Expression (CTE) against `concept_isa` to count descendants on the fly, and prints a warning suggesting you build the TCT.
+- **Impact**: recursive CTE queries for large hierarchies (the root, or Clinical finding) can take several seconds, especially when `--tree` expands multiple levels. Run `sct tct --db <db>` once before exploring sizes.
 
 ---
 
 ## See also
 
 - [`sct gui`](gui.md) - browser UI with the same size estimates in the concept detail panel
-- [`sct tui`](tui.md) - keyboard UI with a toggleable size row# Concept Subtree Size Visualizer (`sct size`)
-
-The `sct size` command displays a hierarchical tree of SNOMED CT concepts and their subtree sizes (number of transitive descendants), acting like a disk-usage analyzer (`du` / `ncdu`) for the terminology taxonomy.
-
----
-
-## Usage
-
-```bash
-# Print the size distribution from the SNOMED CT root concept (default)
-sct size --depth 2
-
-# Inspect a specific sub-hierarchy (e.g. Clinical finding)
-sct size --concept 404684003 --depth 3
-```
-
----
-
-## Limitations & Design Characteristics
-
-When analyzing subtree sizes in SNOMED CT, keep the following characteristics and limitations in mind:
-
-### 1. Polyhierarchy and Cumulative Math
-SNOMED CT is a polyhierarchical taxonomy (a Directed Acyclic Graph, not a strict tree). This means a single concept can have multiple parent concepts (multiple inheritance).
-
-*   **Behavior**: When printing the hierarchical size tree, a concept that is inherited via multiple parent paths will appear multiple times in the tree (under each of its parent branches).
-*   **Result**: The sum of the subtree sizes of all children of a concept will usually be **larger** than the total subtree size reported on the parent concept itself. This is because any descendants with multiple parents are counted once in each path but deduplicated in the parent's absolute count.
-
-### 2. Performance Fallback without Transitive Closure Table (TCT)
-The size query utilizes a precomputed transitive closure table (`concept_ancestors`) if it exists in the SQLite database (built via `sct tct`).
-
-*   **TCT Present (Recommended)**: Queries are extremely fast (sub-millisecond) because they leverage indexed lookups.
-*   **TCT Absent (Fallback)**: If the `concept_ancestors` table is missing, `sct` falls back to running a recursive Common Table Expression (CTE) query against `concept_isa` to count descendants on the fly.
-*   **Performance Impact**: Running recursive CTE queries for large hierarchies (such as the root concept or Clinical Finding) is resource-intensive and will take several seconds to complete, especially when building multiple levels of a tree. We recommend running `sct tct` on your SQLite database before exploring sizes.
+- [`sct tui`](tui.md) - keyboard UI with a toggleable size row

--- a/docs/commands/tui.md
+++ b/docs/commands/tui.md
@@ -83,6 +83,7 @@ sct tui
 | `PgUp` / `PgDn` | Scroll detail panel |
 | `b` | Back - return to previously viewed concept |
 | `h` | Jump focus to Hierarchy panel |
+| `s` | Toggle size estimates in the detail panel |
 | `q` / `Q` | Quit |
 | `Ctrl-C` | Quit |
 
@@ -97,6 +98,8 @@ sct tui
 3. **Inspect a concept** - use `↑↓` in the Results list, press `Enter` to load the full concept detail on the right.
 
 4. **Navigate relationships** - the detail panel lists parents and attributes with their SCTIDs. Type the SCTID into the search box to jump to any related concept, or use `b` to navigate back through your history (up to 20 steps).
+
+5. **Inspect subtree size** - press `s` in the detail panel to show the NDJSON and SQLite size estimates for the selected concept's subtree.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
           - sct diagram: commands/diagram.md
           - sct refset: commands/refset.md
           - sct map: commands/map.md
+          - sct size: commands/size.md
           - sct dmwb: commands/dmwb.md
       - Code lists:
           - sct codelist: commands/codelist.md

--- a/src/commands/gui.rs
+++ b/src/commands/gui.rs
@@ -257,7 +257,8 @@ async fn api_size(State(state): State<AppState>, Path(id): Path<String>) -> Json
 
 fn inner_size(db_path: &PathBuf, id: &str) -> Result<Value> {
     let conn = open_db(db_path)?;
-    let est = crate::commands::size::estimate_sizes(&conn, id, 100)?;
+    let est =
+        crate::commands::size::estimate_sizes(&conn, id, crate::commands::size::DEFAULT_SAMPLE)?;
     Ok(json!({
         "id":               id,
         "subtree_count":    est.subtree_count,

--- a/src/commands/gui.rs
+++ b/src/commands/gui.rs
@@ -213,6 +213,7 @@ fn inner_concept(db_path: &PathBuf, id: &str) -> Result<Value> {
             let parse_json = |s: Option<String>| -> Value {
                 serde_json::from_str(&s.unwrap_or_default()).unwrap_or(Value::Null)
             };
+            let descendants_count = crate::commands::get_subtree_size(&conn, id).unwrap_or(0);
             Ok(json!({
                 "id":             row.get::<_, String>(0)?,
                 "fsn":            row.get::<_, String>(1)?,
@@ -222,6 +223,7 @@ fn inner_concept(db_path: &PathBuf, id: &str) -> Result<Value> {
                 "hierarchy_path": parse_json(row.get::<_, Option<String>>(5)?),
                 "parents":        parse_json(row.get::<_, Option<String>>(6)?),
                 "children_count": row.get::<_, i64>(7)?,
+                "descendants_count": descendants_count,
                 "attributes":     parse_json(row.get::<_, Option<String>>(8)?)
             }))
         },
@@ -295,15 +297,21 @@ async fn api_hierarchy(State(state): State<AppState>) -> Json<Value> {
 fn inner_hierarchy(db_path: &PathBuf) -> Result<Value> {
     let conn = open_db(db_path)?;
     let mut stmt = conn.prepare(
-        "SELECT DISTINCT hierarchy FROM concepts \
+        "SELECT hierarchy, COUNT(*) FROM concepts \
          WHERE hierarchy IS NOT NULL AND hierarchy != '' \
+         GROUP BY hierarchy \
          ORDER BY hierarchy",
     )?;
-    let hierarchies: Vec<String> = stmt
-        .query_map([], |row| row.get(0))?
+    let rows: Vec<Value> = stmt
+        .query_map([], |row| {
+            Ok(json!({
+                "name": row.get::<_, String>(0)?,
+                "count": row.get::<_, i64>(1)?
+            }))
+        })?
         .filter_map(|r| r.ok())
         .collect();
-    Ok(json!({"hierarchies": hierarchies}))
+    Ok(json!({"hierarchies": rows}))
 }
 
 async fn api_graph(State(state): State<AppState>, Path(id): Path<String>) -> Json<Value> {

--- a/src/commands/gui.rs
+++ b/src/commands/gui.rs
@@ -61,6 +61,7 @@ pub fn run(args: Args) -> Result<()> {
     // Validate we can open the database before starting the server
     {
         let conn = open_db(&db_path)?;
+        crate::ecl::warn_if_no_tct(&conn);
         drop(conn);
     }
 

--- a/src/commands/gui.rs
+++ b/src/commands/gui.rs
@@ -13,6 +13,7 @@
 //!   GET /api/children/:id     → immediate IS-A children (JSON)
 //!   GET /api/parents/:id      → direct parents (JSON)
 //!   GET /api/hierarchy        → list of top-level hierarchy names (JSON)
+//!   GET /api/size/:id         → size estimate for a concept (JSON)
 //!
 //! Requires the `gui` Cargo feature: `cargo build --features gui`
 
@@ -102,6 +103,7 @@ async fn serve(
         .route("/api/parents/{id}", get(api_parents))
         .route("/api/hierarchy", get(api_hierarchy))
         .route("/api/graph/{id}", get(api_graph))
+        .route("/api/size/{id}", get(api_size))
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -243,6 +245,31 @@ async fn api_children(State(state): State<AppState>, Path(id): Path<String>) -> 
         Ok(v) => Json(v),
         Err(e) => Json(json!({"error": e.to_string()})),
     }
+}
+
+/// GET /api/size/:id — returns NDJSON and SQLite file size estimates for a concept's subtree.
+async fn api_size(State(state): State<AppState>, Path(id): Path<String>) -> Json<Value> {
+    match inner_size(&state.db_path, &id) {
+        Ok(v) => Json(v),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+fn inner_size(db_path: &PathBuf, id: &str) -> Result<Value> {
+    let conn = open_db(db_path)?;
+    let est = crate::commands::size::estimate_sizes(&conn, id, 100)?;
+    Ok(json!({
+        "id":               id,
+        "subtree_count":    est.subtree_count,
+        "total_count":      est.total_count,
+        "pct":              est.pct(),
+        "avg_ndjson_bytes": est.avg_ndjson_bytes,
+        "ndjson_total":     est.ndjson_total,
+        "ndjson_human":     crate::commands::size::fmt_bytes(est.ndjson_total),
+        "total_db_bytes":   est.total_db_bytes,
+        "sqlite_total":     est.sqlite_total,
+        "sqlite_human":     crate::commands::size::fmt_bytes(est.sqlite_total)
+    }))
 }
 
 fn inner_children(db_path: &PathBuf, id: &str) -> Result<Value> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -28,6 +28,8 @@ pub mod tct;
 pub mod transcode;
 pub mod trud;
 
+pub mod size;
+
 #[cfg(feature = "tui")]
 pub mod tui;
 
@@ -57,4 +59,42 @@ pub(crate) fn open_db_readonly(path: &Path, cache_size_kib: Option<u32>) -> Resu
     }
     conn.execute_batch(&pragmas)?;
     Ok(conn)
+}
+
+/// Get the total size of a concept's subtree (including itself).
+/// Uses the transitive closure table if available, falling back to a recursive query.
+pub(crate) fn get_subtree_size(conn: &Connection, concept_id: &str) -> Result<u64> {
+    let has_tct = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+
+    let count: u64 = if has_tct {
+        let cnt: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM (
+                SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = ?1
+                UNION
+                SELECT ?1
+             )",
+            rusqlite::params![concept_id],
+            |r| r.get(0),
+        )?;
+        cnt as u64
+    } else {
+        let cnt: i64 = conn.query_row(
+            "WITH RECURSIVE descendants(id) AS (
+                SELECT ?1
+                UNION
+                SELECT child_id FROM concept_isa JOIN descendants ON parent_id = id
+             )
+             SELECT COUNT(DISTINCT id) FROM descendants",
+            rusqlite::params![concept_id],
+            |r| r.get(0),
+        )?;
+        cnt as u64
+    };
+    Ok(count)
 }

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `sct size` - View size of SNOMED CT concepts and their subtree distributions.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Starting concept ID (default is the root concept "138875005").
+    #[arg(long, short, default_value = "138875005")]
+    pub concept: String,
+
+    /// Maximum depth to print in the tree representation (default 2).
+    #[arg(long, short, default_value_t = 2)]
+    pub depth: usize,
+
+    /// Path to the SNOMED CT SQLite database.
+    #[arg(long)]
+    pub db: Option<PathBuf>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
+    let conn = crate::commands::open_db_readonly(&db_path, None)?;
+
+    // Lookup starting concept info
+    let (term, active): (String, i32) = conn
+        .query_row(
+            "SELECT preferred_term, active FROM concepts WHERE id = ?1",
+            rusqlite::params![args.concept],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .with_context(|| format!("concept {} not found in database", args.concept))?;
+
+    if active == 0 {
+        eprintln!("Warning: Starting concept {} is inactive.", args.concept);
+    }
+
+    println!("\nConcept Subtree Size Tree");
+    println!("=========================");
+    print_tree(&conn, &args.concept, &term, 0, args.depth, "", true)?;
+
+    Ok(())
+}
+
+fn print_tree(
+    conn: &Connection,
+    concept_id: &str,
+    preferred_term: &str,
+    depth: usize,
+    max_depth: usize,
+    prefix: &str,
+    is_last: bool,
+) -> Result<()> {
+    let size = crate::commands::get_subtree_size(conn, concept_id)?;
+
+    // Format this node line
+    let node_str = format!(
+        "{} [{}] ({} descendants)",
+        preferred_term,
+        concept_id,
+        fmt_count(size)
+    );
+    if depth == 0 {
+        println!("{}", node_str);
+    } else {
+        let connector = if is_last { "└── " } else { "├── " };
+        println!("{}{}{}", prefix, connector, node_str);
+    }
+
+    if depth >= max_depth {
+        return Ok(());
+    }
+
+    // Get children of this concept
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.preferred_term
+         FROM concept_isa i
+         JOIN concepts c ON c.id = i.child_id
+         WHERE i.parent_id = ?1 AND c.active = 1",
+    )?;
+
+    let children = stmt
+        .query_map(rusqlite::params![concept_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    // Gather subtree sizes for sorting
+    let mut children_sizes = Vec::new();
+    for (cid, term) in children {
+        let sz = crate::commands::get_subtree_size(conn, &cid)?;
+        children_sizes.push((cid, term, sz));
+    }
+    children_sizes.sort_by_key(|b| std::cmp::Reverse(b.2)); // Sort descending by size
+
+    let len = children_sizes.len();
+    for (i, (cid, term, _)) in children_sizes.into_iter().enumerate() {
+        let next_prefix = if depth == 0 {
+            ""
+        } else if is_last {
+            &format!("{}    ", prefix)
+        } else {
+            &format!("{}│   ", prefix)
+        };
+        print_tree(
+            conn,
+            &cid,
+            &term,
+            depth + 1,
+            max_depth,
+            next_prefix,
+            i == len - 1,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn fmt_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 pub struct Args {
     /// Starting concept ID (default is the root concept "138875005").
-    #[arg(long, short, default_value = "138875005")]
-    pub concept: String,
+    #[arg(long, short)]
+    pub concept: Option<String>,
 
     /// Maximum depth to print in the tree representation (default 2).
     #[arg(long, short, default_value_t = 2)]
@@ -28,22 +28,47 @@ pub fn run(args: Args) -> Result<()> {
     let conn = crate::commands::open_db_readonly(&db_path, None)?;
     crate::ecl::warn_if_no_tct(&conn);
 
+    let start_concept = match args.concept {
+        Some(id) => id,
+        None => {
+            // Try default SNOMED CT root first
+            let exists: bool = conn
+                .query_row("SELECT 1 FROM concepts WHERE id = '138875005'", [], |_| {
+                    Ok(true)
+                })
+                .unwrap_or(false);
+            if exists {
+                "138875005".to_string()
+            } else {
+                // Fall back to detecting any active concept with no parents
+                let detected: Option<String> = conn
+                    .query_row(
+                        "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .ok();
+                detected.unwrap_or_else(|| "138875005".to_string())
+            }
+        }
+    };
+
     // Lookup starting concept info
     let (term, active): (String, i32) = conn
         .query_row(
             "SELECT preferred_term, active FROM concepts WHERE id = ?1",
-            rusqlite::params![args.concept],
+            rusqlite::params![start_concept],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
-        .with_context(|| format!("concept {} not found in database", args.concept))?;
+        .with_context(|| format!("concept {} not found in database", start_concept))?;
 
     if active == 0 {
-        eprintln!("Warning: Starting concept {} is inactive.", args.concept);
+        eprintln!("Warning: Starting concept {} is inactive.", start_concept);
     }
 
     println!("\nConcept Subtree Size Tree");
     println!("=========================");
-    print_tree(&conn, &args.concept, &term, 0, args.depth, "", true)?;
+    print_tree(&conn, &start_concept, &term, 0, args.depth, "", true)?;
 
     Ok(())
 }

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -1,7 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `sct size` - View size of SNOMED CT concepts and their subtree distributions.
+//! `sct size` - Estimate NDJSON and SQLite file sizes for a concept subtree.
+//!
+//! Acts as a data-planning tool ("how big will `sct filter` output be?"):
+//!
+//! - Counts all concepts in the subtree (using the TCT when available).
+//! - Samples N rows from the subtree, serialises each as JSON, and averages the
+//!   byte length to estimate the NDJSON export size.
+//! - Uses SQLite's `PRAGMA page_size` and `PRAGMA page_count` to estimate the
+//!   proportional SQLite database size.
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -10,13 +18,14 @@ use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// Starting concept ID (default is the root concept "138875005").
+    /// Starting concept ID. Defaults to the SNOMED CT root (138875005), or the
+    /// single active root detected in the database for filtered/subset databases.
     #[arg(long, short)]
     pub concept: Option<String>,
 
-    /// Maximum depth to print in the tree representation (default 2).
-    #[arg(long, short, default_value_t = 2)]
-    pub depth: usize,
+    /// Number of rows to sample when estimating average NDJSON row size (default: 200).
+    #[arg(long, short = 'n', default_value_t = 200)]
+    pub sample: usize,
 
     /// Path to the SNOMED CT SQLite database.
     #[arg(long)]
@@ -25,10 +34,12 @@ pub struct Args {
 
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
-    let conn = crate::commands::open_db_readonly(&db_path, None)?;
 
-    // Warn early: sct size runs one recursive CTE per displayed node, which is
-    // extremely slow on a full SNOMED CT database without a transitive-closure table.
+    // Open read-write so we can read PRAGMAs (query_only blocks PRAGMA page_count on older SQLite)
+    let conn = Connection::open(&db_path)
+        .with_context(|| format!("opening database {}", db_path.display()))?;
+    conn.execute_batch("PRAGMA query_only = ON;")?;
+
     let has_tct = conn
         .query_row(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
@@ -36,42 +47,16 @@ pub fn run(args: Args) -> Result<()> {
             |_| Ok(true),
         )
         .unwrap_or(false);
-    if !has_tct {
-        eprintln!(
-            "warning: this database has no transitive-closure table.\n\
-             `sct size` will run one recursive CTE per displayed node and may take a \
-             very long time on a full SNOMED CT database.\n\
-             Build the table first for a fast result: `sct tct --db <db>`"
-        );
-    }
 
-    let start_concept = match args.concept {
-        Some(id) => id,
-        None => {
-            // Try default SNOMED CT root first
-            let exists: bool = conn
-                .query_row("SELECT 1 FROM concepts WHERE id = '138875005'", [], |_| {
-                    Ok(true)
-                })
-                .unwrap_or(false);
-            if exists {
-                "138875005".to_string()
-            } else {
-                // Fall back to detecting any active concept with no parents
-                let detected: Option<String> = conn
-                    .query_row(
-                        "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
-                        [],
-                        |row| row.get(0),
-                    )
-                    .ok();
-                detected.unwrap_or_else(|| "138875005".to_string())
-            }
-        }
-    };
+    let start_concept = resolve_root(&conn, args.concept)?;
 
-    // Lookup starting concept info
-    let (term, active): (String, i32) = conn
+    // --- concept count ---
+    let subtree_count = crate::commands::get_subtree_size(&conn, &start_concept)?;
+    let total_count: u64 = conn
+        .query_row("SELECT COUNT(*) FROM concepts", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+
+    let (preferred_term, _active): (String, i32) = conn
         .query_row(
             "SELECT preferred_term, active FROM concepts WHERE id = ?1",
             rusqlite::params![start_concept],
@@ -79,89 +64,196 @@ pub fn run(args: Args) -> Result<()> {
         )
         .with_context(|| format!("concept {} not found in database", start_concept))?;
 
-    if active == 0 {
-        eprintln!("Warning: Starting concept {} is inactive.", start_concept);
-    }
+    // --- NDJSON size estimation (sample average row size) ---
+    let avg_ndjson_bytes = sample_avg_row_bytes(&conn, &start_concept, has_tct, args.sample)?;
+    let ndjson_estimate = avg_ndjson_bytes * subtree_count;
 
-    println!("\nConcept Subtree Size Tree");
-    println!("=========================");
-    print_tree(&conn, &start_concept, &term, 0, args.depth, "", true)?;
+    // --- SQLite size estimation (proportional page count) ---
+    let page_size: u64 = conn
+        .query_row("PRAGMA page_size", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(4096) as u64;
+    let page_count: u64 = conn
+        .query_row("PRAGMA page_count", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+    let total_db_bytes = page_size * page_count;
+    let sqlite_estimate = if total_count > 0 {
+        (total_db_bytes as f64 * subtree_count as f64 / total_count as f64) as u64
+    } else {
+        0
+    };
+
+    let pct = if total_count > 0 {
+        subtree_count as f64 / total_count as f64 * 100.0
+    } else {
+        0.0
+    };
+
+    // --- Output ---
+    println!();
+    println!("Subtree: {} ({})", preferred_term, start_concept);
+    println!(
+        "Concepts: {}  ({:.1}% of {} total in database)",
+        fmt_count(subtree_count),
+        pct,
+        fmt_count(total_count)
+    );
+    if !has_tct {
+        eprintln!(
+            "\nwarning: no transitive-closure table found — subtree count used a recursive CTE.\n\
+             Build it once for fast estimates: `sct tct --db <db>`"
+        );
+    }
+    println!();
+    println!("{:<18} {:<16} Method", "Format", "Estimated size");
+    println!("{}", "─".repeat(72));
+    println!(
+        "{:<18} {:<16} sampled avg {} B/row × {} rows",
+        "NDJSON",
+        fmt_bytes(ndjson_estimate),
+        fmt_count(avg_ndjson_bytes),
+        fmt_count(subtree_count)
+    );
+    println!(
+        "{:<18} {:<16} proportional to full DB ({}) by concept count",
+        "SQLite DB",
+        fmt_bytes(sqlite_estimate),
+        fmt_bytes(total_db_bytes)
+    );
+    println!();
 
     Ok(())
 }
 
-fn print_tree(
+/// Resolve the starting concept: use the user's value, fall back to `138875005`,
+/// then fall back to any active concept with no parents (for filtered databases).
+fn resolve_root(conn: &Connection, concept: Option<String>) -> Result<String> {
+    if let Some(id) = concept {
+        return Ok(id);
+    }
+    let root_exists: bool = conn
+        .query_row("SELECT 1 FROM concepts WHERE id = '138875005'", [], |_| {
+            Ok(true)
+        })
+        .unwrap_or(false);
+    if root_exists {
+        return Ok("138875005".to_string());
+    }
+    // Filtered DB — find any active concept with an empty parents array
+    let detected: Option<String> = conn
+        .query_row(
+            "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+    Ok(detected.unwrap_or_else(|| "138875005".to_string()))
+}
+
+/// Sample up to `limit` concepts from the subtree, serialise each row's text columns
+/// as a JSON object (approximating a real NDJSON line), and return the average byte count.
+fn sample_avg_row_bytes(
     conn: &Connection,
-    concept_id: &str,
-    preferred_term: &str,
-    depth: usize,
-    max_depth: usize,
-    prefix: &str,
-    is_last: bool,
-) -> Result<()> {
-    let size = crate::commands::get_subtree_size(conn, concept_id)?;
-
-    // Format this node line
-    let node_str = format!(
-        "{} [{}] ({} descendants)",
-        preferred_term,
-        concept_id,
-        fmt_count(size.saturating_sub(1))
-    );
-    if depth == 0 {
-        println!("{}", node_str);
+    root_id: &str,
+    has_tct: bool,
+    limit: usize,
+) -> Result<u64> {
+    // Columns that appear in a ConceptRecord NDJSON line
+    let sql = if has_tct {
+        format!(
+            "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                    parents, children_count, attributes, active, module, effective_time,
+                    ctv3_codes, read2_codes
+             FROM concepts
+             WHERE id IN (
+                 SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = '{root_id}'
+                 UNION SELECT '{root_id}'
+             )
+             ORDER BY RANDOM()
+             LIMIT {limit}"
+        )
     } else {
-        let connector = if is_last { "└── " } else { "├── " };
-        println!("{}{}{}", prefix, connector, node_str);
+        format!(
+            "WITH RECURSIVE descendants(id) AS (
+                 SELECT '{root_id}'
+                 UNION
+                 SELECT child_id FROM concept_isa JOIN descendants ON parent_id = id
+             )
+             SELECT c.id, c.fsn, c.preferred_term, c.synonyms, c.hierarchy, c.hierarchy_path,
+                    c.parents, c.children_count, c.attributes, c.active, c.module, c.effective_time,
+                    c.ctv3_codes, c.read2_codes
+             FROM concepts c
+             JOIN descendants d ON c.id = d.id
+             ORDER BY RANDOM()
+             LIMIT {limit}"
+        )
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+
+    // Measure the byte length of a minimal JSON serialisation of each row.
+    // We build a small JSON object with the same keys sct ndjson would emit.
+    let col_names = [
+        "id",
+        "fsn",
+        "preferred_term",
+        "synonyms",
+        "hierarchy",
+        "hierarchy_path",
+        "parents",
+        "children_count",
+        "attributes",
+        "active",
+        "module",
+        "effective_time",
+        "ctv3_codes",
+        "read2_codes",
+    ];
+
+    let mut total_bytes: u64 = 0;
+    let mut sampled: u64 = 0;
+
+    stmt.query_map([], |row| {
+        // Build a JSON-like byte count: sum all text column lengths + key overhead
+        let mut row_bytes: usize = 2; // outer braces {}
+        for (i, name) in col_names.iter().enumerate() {
+            row_bytes += name.len() + 4; // "key":  (quotes + colon + space)
+            if let Ok(Some(val)) = row.get_ref(i).map(|v| v.as_str().ok()) {
+                row_bytes += val.len() + 2; // value + surrounding quotes
+            } else {
+                row_bytes += 4; // null
+            }
+            if i + 1 < col_names.len() {
+                row_bytes += 1; // comma
+            }
+        }
+        row_bytes += 1; // newline at end of NDJSON line
+        Ok(row_bytes as u64)
+    })?
+    .filter_map(|r| r.ok())
+    .for_each(|bytes| {
+        total_bytes += bytes;
+        sampled += 1;
+    });
+
+    if sampled == 0 {
+        return Ok(0);
     }
+    Ok(total_bytes / sampled)
+}
 
-    if depth >= max_depth {
-        return Ok(());
+fn fmt_bytes(n: u64) -> String {
+    const KB: u64 = 1_024;
+    const MB: u64 = 1_024 * KB;
+    const GB: u64 = 1_024 * MB;
+    if n >= GB {
+        format!("~{:.2} GB", n as f64 / GB as f64)
+    } else if n >= MB {
+        format!("~{:.1} MB", n as f64 / MB as f64)
+    } else if n >= KB {
+        format!("~{:.1} KB", n as f64 / KB as f64)
+    } else {
+        format!("~{} B", n)
     }
-
-    // Get children of this concept
-    let mut stmt = conn.prepare(
-        "SELECT c.id, c.preferred_term
-         FROM concept_isa i
-         JOIN concepts c ON c.id = i.child_id
-         WHERE i.parent_id = ?1 AND c.active = 1",
-    )?;
-
-    let children = stmt
-        .query_map(rusqlite::params![concept_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-
-    // Gather subtree sizes for sorting
-    let mut children_sizes = Vec::new();
-    for (cid, term) in children {
-        let sz = crate::commands::get_subtree_size(conn, &cid)?;
-        children_sizes.push((cid, term, sz));
-    }
-    children_sizes.sort_by_key(|b| std::cmp::Reverse(b.2)); // Sort descending by size
-
-    let len = children_sizes.len();
-    for (i, (cid, term, _)) in children_sizes.into_iter().enumerate() {
-        let next_prefix = if depth == 0 {
-            ""
-        } else if is_last {
-            &format!("{}    ", prefix)
-        } else {
-            &format!("{}│   ", prefix)
-        };
-        print_tree(
-            conn,
-            &cid,
-            &term,
-            depth + 1,
-            max_depth,
-            next_prefix,
-            i == len - 1,
-        )?;
-    }
-
-    Ok(())
 }
 
 fn fmt_count(n: u64) -> String {

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -63,7 +63,7 @@ fn print_tree(
         "{} [{}] ({} descendants)",
         preferred_term,
         concept_id,
-        fmt_count(size)
+        fmt_count(size.saturating_sub(1))
     );
     if depth == 0 {
         println!("{}", node_str);

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -26,6 +26,7 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
     let conn = crate::commands::open_db_readonly(&db_path, None)?;
+    crate::ecl::warn_if_no_tct(&conn);
 
     // Lookup starting concept info
     let (term, active): (String, i32) = conn

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -15,6 +15,11 @@
 //!   proportional SQLite database size.
 //! - Optionally prints a `du`-style tree of descendant counts with `--tree`.
 //!
+//! Because the subtree count is unusably slow without a transitive closure
+//! table (it falls back to a whole-hierarchy recursive CTE), `sct size` offers
+//! to build one interactively when it is missing; `--build-tct` skips the
+//! prompt for scripts and non-interactive shells.
+//!
 //! The core estimation logic is exposed as [`estimate_sizes`] so the GUI and TUI
 //! can reuse it without duplicating code.
 
@@ -22,7 +27,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rusqlite::Connection;
 use serde_json::json;
-use std::path::PathBuf;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
 
 use crate::output::OutputFormat;
 
@@ -113,11 +119,11 @@ pub fn estimate_sizes(conn: &Connection, root_id: &str, sample: usize) -> Result
 pub struct Args {
     /// Starting concept ID. Defaults to the SNOMED CT root (138875005), or the
     /// single active root detected in the database for filtered/subset databases.
-    #[arg(long, short)]
+    #[arg(long, short, value_name = "SCTID")]
     pub concept: Option<String>,
 
     /// Number of rows to sample when estimating average NDJSON row size.
-    #[arg(long, short = 'n', default_value_t = DEFAULT_SAMPLE)]
+    #[arg(long, short = 'n', default_value_t = DEFAULT_SAMPLE, value_name = "N")]
     pub sample: usize,
 
     /// Also print a `du`-style descendant count tree (text output only).
@@ -125,12 +131,18 @@ pub struct Args {
     pub tree: bool,
 
     /// Maximum depth for the tree view. Only used with --tree.
-    #[arg(long, short = 'd', default_value_t = 2)]
+    #[arg(long, short = 'd', default_value_t = 2, value_name = "N")]
     pub depth: usize,
 
     /// Output format. `--tree` is honoured for `text` only.
     #[arg(long, short = 'f', value_enum, default_value_t = OutputFormat::Text)]
     pub format: OutputFormat,
+
+    /// Build a transitive closure table (TCT) without asking, if one is missing.
+    /// Equivalent to answering "yes" to the interactive prompt; use this in
+    /// scripts or non-interactive shells where no prompt can be shown.
+    #[arg(long)]
+    pub build_tct: bool,
 
     /// SQLite database produced by `sct sqlite`. See `docs/path-resolution.md`
     /// for the discovery order when this flag is omitted.
@@ -140,9 +152,9 @@ pub struct Args {
 
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
-    let conn = crate::commands::open_db_readonly(&db_path, None)?;
+    let mut conn = crate::commands::open_db_readonly(&db_path, None)?;
 
-    let has_tct = conn
+    let mut has_tct = conn
         .query_row(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
             [],
@@ -159,6 +171,21 @@ pub fn run(args: Args) -> Result<()> {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .with_context(|| format!("concept {} not found in database", start_concept))?;
+
+    // Without a TCT the estimate below falls back to a whole-hierarchy recursive
+    // CTE, which is punishingly slow rooted at (or near) the SNOMED CT root.
+    // Offer to build the TCT first - once, interactively - so the command is
+    // actually usable. Machine output (`--format json`/`yaml`) never prompts.
+    if !has_tct {
+        let allow_prompt = !args.format.is_structured();
+        if (args.build_tct || allow_prompt)
+            && maybe_build_tct(&db_path, &conn, args.build_tct, allow_prompt)?
+        {
+            drop(conn);
+            conn = crate::commands::open_db_readonly(&db_path, None)?;
+            has_tct = true;
+        }
+    }
 
     let est = estimate_sizes(&conn, &start_concept, args.sample)?;
 
@@ -350,6 +377,133 @@ fn sample_avg_row_bytes(
         return Ok(0);
     }
     Ok(total_bytes / sampled)
+}
+
+/// Offer to build a transitive closure table when the database has none.
+///
+/// Returns `Ok(true)` if a TCT was built, so the caller should reopen the
+/// database and re-run the estimate against it. Building writes to the
+/// database, so it only happens with explicit consent: either `--build-tct`
+/// (`force`), or a "yes" to the interactive prompt. On a non-interactive shell
+/// without `force` it does nothing and returns `Ok(false)`, leaving the caller
+/// on the slow recursive-CTE path.
+fn maybe_build_tct(
+    db_path: &Path,
+    conn: &Connection,
+    force: bool,
+    allow_prompt: bool,
+) -> Result<bool> {
+    use std::io::{IsTerminal, Write};
+
+    if !force {
+        // Only prompt on an interactive terminal (and never for machine output).
+        if !allow_prompt || !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+            return Ok(false);
+        }
+        let est = estimate_tct_bytes(conn).unwrap_or(0);
+        eprintln!("`sct size` needs a transitive closure table (TCT) to perform adequately.");
+        eprint!(
+            "Build a TCT now (increases the database on disk by approx. {})? [Y/n] ",
+            fmt_bytes(est)
+        );
+        std::io::stderr().flush().ok();
+
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("reading confirmation from stdin")?;
+        let answer = answer.trim().to_ascii_lowercase();
+        if !(answer.is_empty() || answer == "y" || answer == "yes") {
+            eprintln!(
+                "Continuing without a TCT - this may be slow. \
+                 Build one later with `sct tct --db <db>`."
+            );
+            return Ok(false);
+        }
+    }
+
+    // A TCT is a write; the read-only connection can't build it. Open a
+    // dedicated writable handle with the same build-time pragmas `sct tct` uses.
+    eprintln!("Building transitive closure table...");
+    let mut wconn = Connection::open(db_path)
+        .with_context(|| format!("opening {} for writing", db_path.display()))?;
+    wconn
+        .execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA cache_size = -65536;
+             PRAGMA temp_store = MEMORY;",
+        )
+        .context("setting TCT build pragmas")?;
+    crate::commands::tct::build(&mut wconn, false)?;
+    Ok(true)
+}
+
+/// Rough estimate of how many bytes a transitive closure table would add, used
+/// only to size the "build a TCT?" prompt. Loads the IS-A edges once and samples
+/// concepts, doing an in-memory upward BFS to approximate the average ancestor
+/// count per concept, then scales by the concept count and an empirical
+/// bytes-per-row figure. Deliberately approximate.
+fn estimate_tct_bytes(conn: &Connection) -> Result<u64> {
+    // Average on-disk cost of one (ancestor, descendant, depth) row across the
+    // table b-tree plus the three indexes `concept_ancestors` carries. Empirical.
+    const BYTES_PER_ROW: u64 = 64;
+    const SAMPLE: usize = 500;
+
+    let total_concepts: u64 = conn
+        .query_row("SELECT COUNT(*) FROM concepts", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+    if total_concepts == 0 {
+        return Ok(0);
+    }
+
+    // child -> parents, held as integers (SCTIDs are numeric) for cheap hashing.
+    let mut parents_of: HashMap<u64, Vec<u64>> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT CAST(child_id AS INTEGER), CAST(parent_id AS INTEGER) FROM concept_isa",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok((r.get::<_, i64>(0)? as u64, r.get::<_, i64>(1)? as u64))
+        })?;
+        for row in rows {
+            let (child, parent) = row?;
+            parents_of.entry(child).or_default().push(parent);
+        }
+    }
+
+    // SAMPLE is a compile-time constant, so interpolating it is injection-safe.
+    let sample_ids: Vec<u64> = conn
+        .prepare(&format!(
+            "SELECT CAST(id AS INTEGER) FROM concepts ORDER BY RANDOM() LIMIT {SAMPLE}"
+        ))?
+        .query_map([], |r| r.get::<_, i64>(0).map(|v| v as u64))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if sample_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total_ancestors: u64 = 0;
+    for &start in &sample_ids {
+        let mut visited: HashSet<u64> = HashSet::new();
+        visited.insert(start);
+        let mut queue: VecDeque<u64> = VecDeque::new();
+        queue.push_back(start);
+        while let Some(node) = queue.pop_front() {
+            if let Some(parents) = parents_of.get(&node) {
+                for &parent in parents {
+                    if visited.insert(parent) {
+                        queue.push_back(parent);
+                    }
+                }
+            }
+        }
+        total_ancestors += visited.len() as u64 - 1; // exclude self
+    }
+
+    let avg_ancestors = total_ancestors as f64 / sample_ids.len() as f64;
+    let est_rows = (avg_ancestors * total_concepts as f64) as u64;
+    Ok(est_rows * BYTES_PER_ROW)
 }
 
 pub(crate) fn fmt_bytes(n: u64) -> String {

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -11,11 +11,93 @@
 //! - Uses SQLite's `PRAGMA page_size` and `PRAGMA page_count` to estimate the
 //!   proportional SQLite database size.
 //! - Optionally prints a `du`-style tree of descendant counts with `--tree`.
+//!
+//! The core estimation logic is exposed as [`estimate_sizes`] so the GUI and TUI
+//! can reuse it without duplicating code.
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use rusqlite::Connection;
 use std::path::PathBuf;
+
+// ─── Public shared types ──────────────────────────────────────────────────────
+
+/// File-size estimates for a concept subtree.
+///
+/// Produced by [`estimate_sizes`] and consumed by the CLI, TUI, and GUI.
+#[derive(Debug, Clone)]
+pub struct SizeEstimate {
+    /// Number of concepts in the subtree (including the root concept itself).
+    pub subtree_count: u64,
+    /// Total number of concepts in the database.
+    pub total_count: u64,
+    /// Average NDJSON row size in bytes (from sampling).
+    pub avg_ndjson_bytes: u64,
+    /// Estimated total NDJSON export size in bytes.
+    pub ndjson_total: u64,
+    /// Total SQLite database size in bytes (page_size × page_count).
+    pub total_db_bytes: u64,
+    /// Estimated proportional SQLite size for this subtree in bytes.
+    pub sqlite_total: u64,
+}
+
+impl SizeEstimate {
+    /// Percentage of the full database represented by this subtree.
+    pub fn pct(&self) -> f64 {
+        if self.total_count > 0 {
+            self.subtree_count as f64 / self.total_count as f64 * 100.0
+        } else {
+            0.0
+        }
+    }
+}
+
+/// Compute [`SizeEstimate`] for the subtree rooted at `root_id`.
+///
+/// `sample` controls how many rows are randomly sampled to derive the average
+/// NDJSON row byte length. A value of 50–200 gives a good balance between speed
+/// and accuracy. Requires an open `Connection`; does **not** open its own.
+pub fn estimate_sizes(conn: &Connection, root_id: &str, sample: usize) -> Result<SizeEstimate> {
+    let has_tct = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+
+    let subtree_count = crate::commands::get_subtree_size(conn, root_id)?;
+    let total_count: u64 = conn
+        .query_row("SELECT COUNT(*) FROM concepts", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+
+    let avg_ndjson_bytes = sample_avg_row_bytes(conn, root_id, has_tct, sample)?;
+    let ndjson_total = avg_ndjson_bytes * subtree_count;
+
+    let page_size: u64 = conn
+        .query_row("PRAGMA page_size", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(4096) as u64;
+    let page_count: u64 = conn
+        .query_row("PRAGMA page_count", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+    let total_db_bytes = page_size * page_count;
+    let sqlite_total = if total_count > 0 {
+        (total_db_bytes as f64 * subtree_count as f64 / total_count as f64) as u64
+    } else {
+        0
+    };
+
+    Ok(SizeEstimate {
+        subtree_count,
+        total_count,
+        avg_ndjson_bytes,
+        ndjson_total,
+        total_db_bytes,
+        sqlite_total,
+    })
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -44,7 +126,7 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
 
-    // Open read-write so we can read PRAGMAs (query_only blocks PRAGMA page_count on older SQLite)
+    // Open without query_only so PRAGMA page_count is readable on all SQLite versions.
     let conn = Connection::open(&db_path)
         .with_context(|| format!("opening database {}", db_path.display()))?;
     conn.execute_batch("PRAGMA query_only = ON;")?;
@@ -59,12 +141,6 @@ pub fn run(args: Args) -> Result<()> {
 
     let start_concept = resolve_root(&conn, args.concept)?;
 
-    // --- concept count ---
-    let subtree_count = crate::commands::get_subtree_size(&conn, &start_concept)?;
-    let total_count: u64 = conn
-        .query_row("SELECT COUNT(*) FROM concepts", [], |r| r.get::<_, i64>(0))
-        .unwrap_or(0) as u64;
-
     let (preferred_term, _active): (String, i32) = conn
         .query_row(
             "SELECT preferred_term, active FROM concepts WHERE id = ?1",
@@ -73,38 +149,16 @@ pub fn run(args: Args) -> Result<()> {
         )
         .with_context(|| format!("concept {} not found in database", start_concept))?;
 
-    // --- NDJSON size estimation (sample average row size) ---
-    let avg_ndjson_bytes = sample_avg_row_bytes(&conn, &start_concept, has_tct, args.sample)?;
-    let ndjson_estimate = avg_ndjson_bytes * subtree_count;
-
-    // --- SQLite size estimation (proportional page count) ---
-    let page_size: u64 = conn
-        .query_row("PRAGMA page_size", [], |r| r.get::<_, i64>(0))
-        .unwrap_or(4096) as u64;
-    let page_count: u64 = conn
-        .query_row("PRAGMA page_count", [], |r| r.get::<_, i64>(0))
-        .unwrap_or(0) as u64;
-    let total_db_bytes = page_size * page_count;
-    let sqlite_estimate = if total_count > 0 {
-        (total_db_bytes as f64 * subtree_count as f64 / total_count as f64) as u64
-    } else {
-        0
-    };
-
-    let pct = if total_count > 0 {
-        subtree_count as f64 / total_count as f64 * 100.0
-    } else {
-        0.0
-    };
+    let est = estimate_sizes(&conn, &start_concept, args.sample)?;
 
     // --- Output ---
     println!();
     println!("Subtree: {} ({})", preferred_term, start_concept);
     println!(
         "Concepts: {}  ({:.1}% of {} total in database)",
-        fmt_count(subtree_count),
-        pct,
-        fmt_count(total_count)
+        fmt_count(est.subtree_count),
+        est.pct(),
+        fmt_count(est.total_count)
     );
     if !has_tct {
         eprintln!(
@@ -118,15 +172,15 @@ pub fn run(args: Args) -> Result<()> {
     println!(
         "{:<18} {:<16} sampled avg {} B/row × {} rows",
         "NDJSON",
-        fmt_bytes(ndjson_estimate),
-        fmt_count(avg_ndjson_bytes),
-        fmt_count(subtree_count)
+        fmt_bytes(est.ndjson_total),
+        fmt_count(est.avg_ndjson_bytes),
+        fmt_count(est.subtree_count)
     );
     println!(
         "{:<18} {:<16} proportional to full DB ({}) by concept count",
         "SQLite DB",
-        fmt_bytes(sqlite_estimate),
-        fmt_bytes(total_db_bytes)
+        fmt_bytes(est.sqlite_total),
+        fmt_bytes(est.total_db_bytes)
     );
     println!();
 
@@ -149,6 +203,8 @@ pub fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
 /// Resolve the starting concept: use the user's value, fall back to `138875005`,
 /// then fall back to any active concept with no parents (for filtered databases).
 fn resolve_root(conn: &Connection, concept: Option<String>) -> Result<String> {
@@ -163,7 +219,6 @@ fn resolve_root(conn: &Connection, concept: Option<String>) -> Result<String> {
     if root_exists {
         return Ok("138875005".to_string());
     }
-    // Filtered DB — find any active concept with an empty parents array
     let detected: Option<String> = conn
         .query_row(
             "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
@@ -182,7 +237,6 @@ fn sample_avg_row_bytes(
     has_tct: bool,
     limit: usize,
 ) -> Result<u64> {
-    // Columns that appear in a ConceptRecord NDJSON line
     let sql = if has_tct {
         format!(
             "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
@@ -215,8 +269,6 @@ fn sample_avg_row_bytes(
 
     let mut stmt = conn.prepare(&sql)?;
 
-    // Measure the byte length of a minimal JSON serialisation of each row.
-    // We build a small JSON object with the same keys sct ndjson would emit.
     let col_names = [
         "id",
         "fsn",
@@ -238,7 +290,6 @@ fn sample_avg_row_bytes(
     let mut sampled: u64 = 0;
 
     stmt.query_map([], |row| {
-        // Build a JSON-like byte count: sum all text column lengths + key overhead
         let mut row_bytes: usize = 2; // outer braces {}
         for (i, name) in col_names.iter().enumerate() {
             row_bytes += name.len() + 4; // "key":  (quotes + colon + space)
@@ -266,7 +317,7 @@ fn sample_avg_row_bytes(
     Ok(total_bytes / sampled)
 }
 
-fn fmt_bytes(n: u64) -> String {
+pub(crate) fn fmt_bytes(n: u64) -> String {
     const KB: u64 = 1_024;
     const MB: u64 = 1_024 * KB;
     const GB: u64 = 1_024 * MB;
@@ -281,7 +332,7 @@ fn fmt_bytes(n: u64) -> String {
     }
 }
 
-fn fmt_count(n: u64) -> String {
+pub(crate) fn fmt_count(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::with_capacity(s.len() + s.len() / 3);
     for (i, ch) in s.chars().rev().enumerate() {

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -10,6 +10,7 @@
 //!   byte length to estimate the NDJSON export size.
 //! - Uses SQLite's `PRAGMA page_size` and `PRAGMA page_count` to estimate the
 //!   proportional SQLite database size.
+//! - Optionally prints a `du`-style tree of descendant counts with `--tree`.
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -26,6 +27,14 @@ pub struct Args {
     /// Number of rows to sample when estimating average NDJSON row size (default: 200).
     #[arg(long, short = 'n', default_value_t = 200)]
     pub sample: usize,
+
+    /// Also print a `du`-style descendant count tree.
+    #[arg(long, short = 't')]
+    pub tree: bool,
+
+    /// Maximum depth for the tree view (default: 2). Only used with --tree.
+    #[arg(long, short = 'd', default_value_t = 2)]
+    pub depth: usize,
 
     /// Path to the SNOMED CT SQLite database.
     #[arg(long)]
@@ -120,6 +129,22 @@ pub fn run(args: Args) -> Result<()> {
         fmt_bytes(total_db_bytes)
     );
     println!();
+
+    // --- Optional descendant count tree ---
+    if args.tree {
+        println!("Descendant Count Tree");
+        println!("=====================");
+        print_tree(
+            &conn,
+            &start_concept,
+            &preferred_term,
+            0,
+            args.depth,
+            "",
+            true,
+        )?;
+        println!();
+    }
 
     Ok(())
 }
@@ -266,4 +291,73 @@ fn fmt_count(n: u64) -> String {
         result.push(ch);
     }
     result.chars().rev().collect()
+}
+
+fn print_tree(
+    conn: &Connection,
+    concept_id: &str,
+    preferred_term: &str,
+    depth: usize,
+    max_depth: usize,
+    prefix: &str,
+    is_last: bool,
+) -> Result<()> {
+    let size = crate::commands::get_subtree_size(conn, concept_id)?;
+    let node_str = format!(
+        "{} [{}] ({} descendants)",
+        preferred_term,
+        concept_id,
+        fmt_count(size.saturating_sub(1))
+    );
+    if depth == 0 {
+        println!("{node_str}");
+    } else {
+        let connector = if is_last { "└── " } else { "├── " };
+        println!("{prefix}{connector}{node_str}");
+    }
+
+    if depth >= max_depth {
+        return Ok(());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.preferred_term
+         FROM concept_isa i
+         JOIN concepts c ON c.id = i.child_id
+         WHERE i.parent_id = ?1 AND c.active = 1",
+    )?;
+    let children = stmt
+        .query_map(rusqlite::params![concept_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut children_sizes: Vec<(String, String, u64)> = Vec::new();
+    for (cid, term) in children {
+        let sz = crate::commands::get_subtree_size(conn, &cid)?;
+        children_sizes.push((cid, term, sz));
+    }
+    children_sizes.sort_by_key(|b| std::cmp::Reverse(b.2));
+
+    let len = children_sizes.len();
+    for (i, (cid, term, _)) in children_sizes.into_iter().enumerate() {
+        let child_is_last = i == len - 1;
+        let next_prefix = if depth == 0 {
+            String::new()
+        } else if is_last {
+            format!("{prefix}    ")
+        } else {
+            format!("{prefix}│   ")
+        };
+        print_tree(
+            conn,
+            &cid,
+            &term,
+            depth + 1,
+            max_depth,
+            &next_prefix,
+            child_is_last,
+        )?;
+    }
+    Ok(())
 }

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -6,8 +6,11 @@
 //! Acts as a data-planning tool ("how big will `sct filter` output be?"):
 //!
 //! - Counts all concepts in the subtree (using the TCT when available).
-//! - Samples N rows from the subtree, serialises each as JSON, and averages the
-//!   byte length to estimate the NDJSON export size.
+//! - Samples N rows and approximates each row's NDJSON byte length from its
+//!   stored text columns, then averages, to estimate the export size. This is a
+//!   deliberate lower bound: it excludes `refsets`, `relationships`, and
+//!   `crossmaps` (which live in other tables), so a real `sct ndjson` line is
+//!   somewhat larger.
 //! - Uses SQLite's `PRAGMA page_size` and `PRAGMA page_count` to estimate the
 //!   proportional SQLite database size.
 //! - Optionally prints a `du`-style tree of descendant counts with `--tree`.
@@ -18,7 +21,14 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use rusqlite::Connection;
+use serde_json::json;
 use std::path::PathBuf;
+
+use crate::output::OutputFormat;
+
+/// Default number of rows sampled to estimate the average NDJSON row size.
+/// Shared by the CLI default and the TUI/GUI callers so all three agree.
+pub(crate) const DEFAULT_SAMPLE: usize = 200;
 
 // ─── Public shared types ──────────────────────────────────────────────────────
 
@@ -106,30 +116,31 @@ pub struct Args {
     #[arg(long, short)]
     pub concept: Option<String>,
 
-    /// Number of rows to sample when estimating average NDJSON row size (default: 200).
-    #[arg(long, short = 'n', default_value_t = 200)]
+    /// Number of rows to sample when estimating average NDJSON row size.
+    #[arg(long, short = 'n', default_value_t = DEFAULT_SAMPLE)]
     pub sample: usize,
 
-    /// Also print a `du`-style descendant count tree.
+    /// Also print a `du`-style descendant count tree (text output only).
     #[arg(long, short = 't')]
     pub tree: bool,
 
-    /// Maximum depth for the tree view (default: 2). Only used with --tree.
+    /// Maximum depth for the tree view. Only used with --tree.
     #[arg(long, short = 'd', default_value_t = 2)]
     pub depth: usize,
 
-    /// Path to the SNOMED CT SQLite database.
-    #[arg(long)]
+    /// Output format. `--tree` is honoured for `text` only.
+    #[arg(long, short = 'f', value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+
+    /// SQLite database produced by `sct sqlite`. See `docs/path-resolution.md`
+    /// for the discovery order when this flag is omitted.
+    #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
     pub db: Option<PathBuf>,
 }
 
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
-
-    // Open without query_only so PRAGMA page_count is readable on all SQLite versions.
-    let conn = Connection::open(&db_path)
-        .with_context(|| format!("opening database {}", db_path.display()))?;
-    conn.execute_batch("PRAGMA query_only = ON;")?;
+    let conn = crate::commands::open_db_readonly(&db_path, None)?;
 
     let has_tct = conn
         .query_row(
@@ -150,6 +161,29 @@ pub fn run(args: Args) -> Result<()> {
         .with_context(|| format!("concept {} not found in database", start_concept))?;
 
     let est = estimate_sizes(&conn, &start_concept, args.sample)?;
+
+    // Structured output (`--format json`/`yaml`): emit the estimate and stop.
+    // `--tree` is a text-only visualisation, so it is not rendered here.
+    if args.format.is_structured() {
+        let value = json!({
+            "id": start_concept,
+            "preferred_term": preferred_term,
+            "has_tct": has_tct,
+            "subtree_count": est.subtree_count,
+            "total_count": est.total_count,
+            "pct": est.pct(),
+            "avg_ndjson_bytes": est.avg_ndjson_bytes,
+            "ndjson_total_bytes": est.ndjson_total,
+            "ndjson_human": fmt_bytes(est.ndjson_total),
+            "total_db_bytes": est.total_db_bytes,
+            "sqlite_total_bytes": est.sqlite_total,
+            "sqlite_human": fmt_bytes(est.sqlite_total),
+        });
+        if let Some(s) = args.format.render(&value)? {
+            println!("{s}");
+        }
+        return Ok(());
+    }
 
     // --- Output ---
     println!();
@@ -229,45 +263,46 @@ fn resolve_root(conn: &Connection, concept: Option<String>) -> Result<String> {
     Ok(detected.unwrap_or_else(|| "138875005".to_string()))
 }
 
-/// Sample up to `limit` concepts from the subtree, serialise each row's text columns
-/// as a JSON object (approximating a real NDJSON line), and return the average byte count.
+/// Sample up to `limit` concepts from the subtree, approximate each row's NDJSON
+/// byte length from its stored text columns, and return the average. This is a
+/// lower bound: it omits `refsets` / `relationships` / `crossmaps` (separate
+/// tables), so a real `sct ndjson` line is somewhat larger.
 fn sample_avg_row_bytes(
     conn: &Connection,
     root_id: &str,
     has_tct: bool,
     limit: usize,
 ) -> Result<u64> {
+    // `root_id` is user-controlled (`--concept`, and the GUI's `/api/size/:id`
+    // path), so it is bound as a parameter, never interpolated. `?1` is reused
+    // for both references in the TCT branch.
     let sql = if has_tct {
-        format!(
-            "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
-                    parents, children_count, attributes, active, module, effective_time,
-                    ctv3_codes, read2_codes
-             FROM concepts
-             WHERE id IN (
-                 SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = '{root_id}'
-                 UNION SELECT '{root_id}'
-             )
-             ORDER BY RANDOM()
-             LIMIT {limit}"
-        )
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                parents, children_count, attributes, active, module, effective_time,
+                ctv3_codes, read2_codes
+         FROM concepts
+         WHERE id IN (
+             SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = ?1
+             UNION SELECT ?1
+         )
+         ORDER BY RANDOM()
+         LIMIT ?2"
     } else {
-        format!(
-            "WITH RECURSIVE descendants(id) AS (
-                 SELECT '{root_id}'
-                 UNION
-                 SELECT child_id FROM concept_isa JOIN descendants ON parent_id = id
-             )
-             SELECT c.id, c.fsn, c.preferred_term, c.synonyms, c.hierarchy, c.hierarchy_path,
-                    c.parents, c.children_count, c.attributes, c.active, c.module, c.effective_time,
-                    c.ctv3_codes, c.read2_codes
-             FROM concepts c
-             JOIN descendants d ON c.id = d.id
-             ORDER BY RANDOM()
-             LIMIT {limit}"
-        )
+        "WITH RECURSIVE descendants(id) AS (
+             SELECT ?1
+             UNION
+             SELECT child_id FROM concept_isa JOIN descendants ON parent_id = id
+         )
+         SELECT c.id, c.fsn, c.preferred_term, c.synonyms, c.hierarchy, c.hierarchy_path,
+                c.parents, c.children_count, c.attributes, c.active, c.module, c.effective_time,
+                c.ctv3_codes, c.read2_codes
+         FROM concepts c
+         JOIN descendants d ON c.id = d.id
+         ORDER BY RANDOM()
+         LIMIT ?2"
     };
 
-    let mut stmt = conn.prepare(&sql)?;
+    let mut stmt = conn.prepare(sql)?;
 
     let col_names = [
         "id",
@@ -289,7 +324,7 @@ fn sample_avg_row_bytes(
     let mut total_bytes: u64 = 0;
     let mut sampled: u64 = 0;
 
-    stmt.query_map([], |row| {
+    stmt.query_map(rusqlite::params![root_id, limit as i64], |row| {
         let mut row_bytes: usize = 2; // outer braces {}
         for (i, name) in col_names.iter().enumerate() {
             row_bytes += name.len() + 4; // "key":  (quotes + colon + space)

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -26,7 +26,24 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
     let conn = crate::commands::open_db_readonly(&db_path, None)?;
-    crate::ecl::warn_if_no_tct(&conn);
+
+    // Warn early: sct size runs one recursive CTE per displayed node, which is
+    // extremely slow on a full SNOMED CT database without a transitive-closure table.
+    let has_tct = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+    if !has_tct {
+        eprintln!(
+            "warning: this database has no transitive-closure table.\n\
+             `sct size` will run one recursive CTE per displayed node and may take a \
+             very long time on a full SNOMED CT database.\n\
+             Build the table first for a fast result: `sct tct --db <db>`"
+        );
+    }
 
     let start_concept = match args.concept {
         Some(id) => id,

--- a/src/commands/tct.rs
+++ b/src/commands/tct.rs
@@ -188,26 +188,35 @@ pub fn build(conn: &mut Connection, include_self: bool) -> Result<()> {
     }
 
     bar.finish_and_clear();
-    let pb = crate::progress::spinner("Creating indexes...");
+    let pb = crate::progress::count_bar(3);
+    pb.set_message("Creating transitive closure indexes");
 
-    conn.execute_batch(
-        "CREATE INDEX IF NOT EXISTS idx_ca_ancestor
-             ON concept_ancestors(ancestor_id);
-         CREATE INDEX IF NOT EXISTS idx_ca_descendant
-             ON concept_ancestors(descendant_id);
-         CREATE UNIQUE INDEX IF NOT EXISTS idx_ca_pair
-             ON concept_ancestors(ancestor_id, descendant_id);",
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ca_ancestor ON concept_ancestors(ancestor_id)",
+        [],
     )
-    .context("creating concept_ancestors indexes")?;
+    .context("creating ancestor index")?;
+    pb.inc(1);
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ca_descendant ON concept_ancestors(descendant_id)",
+        [],
+    )
+    .context("creating descendant index")?;
+    pb.inc(1);
+
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_ca_pair ON concept_ancestors(ancestor_id, descendant_id)", [])
+        .context("creating pair index")?;
+    pb.inc(1);
 
     let row_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM concept_ancestors", [], |r| r.get(0))
         .unwrap_or(0);
 
-    pb.finish_with_message(format!(
+    eprintln!(
         "Done. {} ancestor-descendant pairs in concept_ancestors.",
         row_count
-    ));
+    );
 
     Ok(())
 }

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -27,7 +27,7 @@ use rusqlite::{params, Connection, OpenFlags};
 use serde_json::Value;
 use std::{io, path::PathBuf, time::Duration};
 
-use crate::commands::size::{estimate_sizes, fmt_bytes, SizeEstimate};
+use crate::commands::size::{estimate_sizes, fmt_bytes, fmt_count, SizeEstimate, DEFAULT_SAMPLE};
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -195,7 +195,7 @@ impl App {
         }
         if let Ok(Some(c)) = fetch_concept(&self.conn, &id) {
             let size_estimate = if self.show_size {
-                estimate_sizes(&self.conn, &id, 100).ok()
+                estimate_sizes(&self.conn, &id, DEFAULT_SAMPLE).ok()
             } else {
                 None
             };
@@ -908,16 +908,4 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         .scroll((app.detail_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
-}
-
-fn fmt_count(n: u64) -> String {
-    let s = n.to_string();
-    let mut result = String::with_capacity(s.len() + s.len() / 3);
-    for (i, ch) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(ch);
-    }
-    result.chars().rev().collect()
 }

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -199,10 +199,7 @@ impl App {
             } else {
                 None
             };
-            self.current_concept = Some(Concept {
-                size_estimate,
-                ..c
-            });
+            self.current_concept = Some(Concept { size_estimate, ..c });
             self.detail_scroll = 0;
         }
     }
@@ -418,6 +415,7 @@ fn fetch_concept(conn: &Connection, id: &str) -> Result<Option<Concept>> {
                 children_count,
                 attributes,
                 subtree_size,
+                size_estimate: None,
             }))
         }
     }

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -85,6 +85,7 @@ struct Concept {
     parents: Vec<(String, String)>, // (id, fsn)
     children_count: i64,
     attributes: Vec<(String, Vec<(String, String)>)>, // (attr_name, [(id, fsn)])
+    subtree_size: u64,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -97,7 +98,7 @@ enum Focus {
 struct App {
     conn: Connection,
     // Hierarchy panel
-    hierarchies: Vec<String>,
+    hierarchies: Vec<(String, u64)>,
     hierarchy_state: ListState,
     // Search panel
     search_query: String,
@@ -206,14 +207,17 @@ impl App {
 // DB queries
 // ---------------------------------------------------------------------------
 
-fn load_hierarchies(conn: &Connection) -> Result<Vec<String>> {
+fn load_hierarchies(conn: &Connection) -> Result<Vec<(String, u64)>> {
     let mut stmt = conn.prepare(
-        "SELECT DISTINCT hierarchy FROM concepts \
+        "SELECT hierarchy, COUNT(*) FROM concepts \
          WHERE hierarchy IS NOT NULL AND hierarchy != '' \
+         GROUP BY hierarchy \
          ORDER BY hierarchy",
     )?;
     let hierarchies = stmt
-        .query_map([], |row| row.get(0))?
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+        })?
         .filter_map(|r| r.ok())
         .collect();
     Ok(hierarchies)
@@ -360,6 +364,8 @@ fn fetch_concept(conn: &Connection, id: &str) -> Result<Option<Concept>> {
                     vec![]
                 };
 
+            let subtree_size = crate::commands::get_subtree_size(conn, &id).unwrap_or(0);
+
             Ok(Some(Concept {
                 id,
                 fsn,
@@ -370,6 +376,7 @@ fn fetch_concept(conn: &Connection, id: &str) -> Result<Option<Concept>> {
                 parents,
                 children_count,
                 attributes,
+                subtree_size,
             }))
         }
     }
@@ -477,7 +484,7 @@ fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
         KeyCode::Enter => match app.focus {
             Focus::Hierarchy => {
                 if let Some(i) = app.hierarchy_state.selected() {
-                    if let Some(h) = app.hierarchies.get(i).cloned() {
+                    if let Some((h, _)) = app.hierarchies.get(i).cloned() {
                         app.load_hierarchy_concepts(h);
                         app.focus = Focus::Search;
                     }
@@ -587,7 +594,7 @@ fn render_hierarchy(frame: &mut Frame, app: &mut App, area: Rect) {
     let items: Vec<ListItem> = app
         .hierarchies
         .iter()
-        .map(|h| ListItem::new(format!("  {}", h)))
+        .map(|(h, size)| ListItem::new(format!("  {} ({})", h, fmt_count(*size))))
         .collect();
 
     let list = List::new(items)
@@ -733,6 +740,10 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
             Span::styled("Children:  ", Style::default().fg(DIM)),
             Span::raw(concept.children_count.to_string()),
         ]),
+        Line::from(vec![
+            Span::styled("Subtree:   ", Style::default().fg(DIM)),
+            Span::raw(format!("{} descendants", fmt_count(concept.subtree_size))),
+        ]),
         Line::from(""),
     ];
 
@@ -830,4 +841,16 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         .scroll((app.detail_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
+}
+
+fn fmt_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
 }

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -27,6 +27,8 @@ use rusqlite::{params, Connection, OpenFlags};
 use serde_json::Value;
 use std::{io, path::PathBuf, time::Duration};
 
+use crate::commands::size::{estimate_sizes, fmt_bytes, SizeEstimate};
+
 #[derive(Parser, Debug)]
 pub struct Args {
     /// Path to the SNOMED CT SQLite database produced by `sct sqlite`.
@@ -87,6 +89,7 @@ struct Concept {
     children_count: i64,
     attributes: Vec<(String, Vec<(String, String)>)>, // (attr_name, [(id, fsn)])
     subtree_size: u64,
+    size_estimate: Option<SizeEstimate>,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -110,6 +113,7 @@ struct App {
     // Detail panel
     current_concept: Option<Concept>,
     detail_scroll: u16,
+    show_size: bool,
     // Navigation
     history: Vec<String>,
     focus: Focus,
@@ -130,6 +134,7 @@ impl App {
             last_queried: String::new(),
             current_concept: None,
             detail_scroll: 0,
+            show_size: false,
             history: Vec::new(),
             focus: Focus::Hierarchy,
             should_quit: false,
@@ -189,7 +194,15 @@ impl App {
             }
         }
         if let Ok(Some(c)) = fetch_concept(&self.conn, &id) {
-            self.current_concept = Some(c);
+            let size_estimate = if self.show_size {
+                estimate_sizes(&self.conn, &id, 100).ok()
+            } else {
+                None
+            };
+            self.current_concept = Some(Concept {
+                size_estimate,
+                ..c
+            });
             self.detail_scroll = 0;
         }
     }
@@ -531,6 +544,12 @@ fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
 
         KeyCode::Char('b') => app.go_back(),
         KeyCode::Char('h') => app.focus = Focus::Hierarchy,
+        KeyCode::Char('s') => {
+            app.show_size = !app.show_size;
+            if let Some(id) = app.current_concept.as_ref().map(|c| c.id.clone()) {
+                app.load_concept(id);
+            }
+        }
 
         _ => {}
     }
@@ -583,7 +602,7 @@ fn render(frame: &mut Frame, app: &mut App) {
 
     // Title bar
     let title = Paragraph::new(
-        "  sct - SNOMED CT Explorer        [/] search  [Tab] switch panel  [q] quit",
+        "  sct - SNOMED CT Explorer        [/] search  [Tab] switch panel  [s] size  [q] quit",
     )
     .style(Style::default().fg(Color::White).bg(NHS_BLUE));
     frame.render_widget(title, outer[0]);
@@ -606,7 +625,7 @@ fn render(frame: &mut Frame, app: &mut App) {
 
     // Status bar
     let status = Paragraph::new(
-        " [/] search  [↑↓] navigate  [Enter] select  [Tab] panels  [b] back  [q] quit",
+        " [/] search  [↑↓] navigate  [Enter] select  [Tab] panels  [b] back  [s] size  [q] quit",
     )
     .style(Style::default().fg(DIM).bg(Color::Rgb(20, 20, 30)));
     frame.render_widget(status, outer[2]);
@@ -739,6 +758,17 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let width = inner.width as usize;
     let rule = "─".repeat(width.min(60));
+    let size_line = if app.show_size {
+        concept.size_estimate.as_ref().map(|size| {
+            format!(
+                "NDJSON {}  ·  SQLite {}",
+                fmt_bytes(size.ndjson_total),
+                fmt_bytes(size.sqlite_total)
+            )
+        })
+    } else {
+        None
+    };
 
     let mut lines: Vec<Line> = vec![
         Line::from(Span::styled(
@@ -775,6 +805,14 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                 fmt_count(concept.subtree_size.saturating_sub(1))
             )),
         ]),
+        if let Some(size) = size_line {
+            Line::from(vec![
+                Span::styled("Size:      ", Style::default().fg(DIM)),
+                Span::raw(size),
+            ])
+        } else {
+            Line::from("")
+        },
         Line::from(""),
     ];
 

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -43,6 +43,7 @@ pub fn run(args: Args) -> Result<()> {
     )
     .with_context(|| format!("opening database {}", db_path.display()))?;
     conn.execute_batch("PRAGMA cache_size = -32768;")?;
+    crate::ecl::warn_if_no_tct(&conn);
 
     let mut app = App::new(conn)?;
 

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -215,13 +215,24 @@ fn load_hierarchies(conn: &Connection) -> Result<Vec<(String, u64)>> {
          GROUP BY hierarchy \
          ORDER BY hierarchy",
     )?;
-    let hierarchies = stmt
+    let hierarchies: Vec<(String, u64)> = stmt
         .query_map([], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
         })?
         .filter_map(|r| r.ok())
         .collect();
-    Ok(hierarchies)
+
+    if hierarchies.is_empty() {
+        // Filtered/subset DB has no hierarchy labels — show a single catch-all entry
+        let total: u64 = conn
+            .query_row("SELECT COUNT(*) FROM concepts", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap_or(0) as u64;
+        Ok(vec![("(All concepts)".to_string(), total)])
+    } else {
+        Ok(hierarchies)
+    }
 }
 
 fn sanitise_fts(q: &str) -> String {
@@ -270,6 +281,22 @@ fn fetch_hierarchy_concepts(
     hierarchy: &str,
     limit: usize,
 ) -> Result<Vec<ConceptSummary>> {
+    // "(All concepts)" is a synthetic sentinel emitted when no hierarchy labels exist
+    if hierarchy == "(All concepts)" {
+        let mut stmt = conn
+            .prepare("SELECT id, preferred_term FROM concepts ORDER BY preferred_term LIMIT ?1")?;
+        let rows = stmt
+            .query_map(params![limit as i64], |row| {
+                Ok(ConceptSummary {
+                    id: row.get(0)?,
+                    preferred_term: row.get(1)?,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        return Ok(rows);
+    }
+
     let mut stmt = conn.prepare(
         "SELECT id, preferred_term FROM concepts \
          WHERE hierarchy = ?1 ORDER BY preferred_term LIMIT ?2",

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -742,7 +742,10 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("Subtree:   ", Style::default().fg(DIM)),
-            Span::raw(format!("{} descendants", fmt_count(concept.subtree_size))),
+            Span::raw(format!(
+                "{} descendants",
+                fmt_count(concept.subtree_size.saturating_sub(1))
+            )),
         ]),
         Line::from(""),
     ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,9 @@ enum Command {
     /// Print shell completion scripts (bash, zsh, fish, powershell, elvish).
     Completions(commands::completions::Args),
 
+    /// View size of SNOMED CT concepts and their subtree distributions.
+    Size(commands::size::Args),
+
     /// Launch an interactive terminal UI for exploring SNOMED CT (requires --features tui).
     #[cfg(feature = "tui")]
     Tui(commands::tui::Args),
@@ -146,6 +149,7 @@ fn main() -> Result<()> {
         Command::Lexical(args) => commands::lexical::run(args),
         Command::Semantic(args) => commands::semantic::run(args),
         Command::Completions(args) => commands::completions::run(args, Cli::command()),
+        Command::Size(args) => commands::size::run(args),
         #[cfg(feature = "tui")]
         Command::Tui(args) => commands::tui::run(args),
         #[cfg(feature = "gui")]

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -11,6 +11,7 @@
 
 use rusqlite::Connection;
 use sct_rs::commands::ndjson::{self, RefsetMode};
+use sct_rs::commands::size;
 use sct_rs::commands::sqlite;
 use sct_rs::ecl;
 use sct_rs::schema::ConceptRecord;
@@ -376,4 +377,17 @@ fn sqlite_fts5_maps_relationships_and_tct() {
         .map(|r| r.unwrap())
         .collect();
     assert_eq!(members, ["44054006", "46635009"]);
+}
+
+#[test]
+fn size_estimate_for_root() {
+    let (_d, _ndjson, db) = build("en-GB");
+    let conn = Connection::open(&db).unwrap();
+
+    let est = size::estimate_sizes(&conn, "138875005", 50).unwrap();
+    assert_eq!(est.subtree_count, est.total_count);
+    assert_eq!(est.pct(), 100.0);
+    assert!(est.avg_ndjson_bytes > 0);
+    assert_eq!(est.sqlite_total, est.total_db_bytes);
+    assert!(est.ndjson_total > 0);
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -391,3 +391,47 @@ fn size_estimate_for_root() {
     assert_eq!(est.sqlite_total, est.total_db_bytes);
     assert!(est.ndjson_total > 0);
 }
+
+#[test]
+fn size_builds_tct_when_missing() {
+    use sct_rs::commands::size::{self, Args};
+    use sct_rs::output::OutputFormat;
+
+    let (_d, _ndjson, db) = build("en-GB");
+
+    // Drop the TCT to simulate a database without one.
+    {
+        let conn = Connection::open(&db).unwrap();
+        conn.execute("DROP TABLE concept_ancestors", []).unwrap();
+    }
+
+    // Run `sct size --build-tct`, which should rebuild the TCT and proceed.
+    let args = Args {
+        concept: None, // defaults to root (138875005)
+        sample: 50,
+        tree: false,
+        depth: 2,
+        format: OutputFormat::Text,
+        build_tct: true, // the flag under test
+        db: Some(db.clone()),
+    };
+    size::run(args).unwrap();
+
+    // Verify the TCT was rebuilt.
+    {
+        let conn = Connection::open(&db).unwrap();
+        let has_tct: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        assert!(has_tct, "concept_ancestors table should have been rebuilt");
+
+        let row_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM concept_ancestors", [], |r| r.get(0))
+            .unwrap();
+        assert!(row_count > 0, "concept_ancestors should contain rows");
+    }
+}


### PR DESCRIPTION
This PR implements concept subtree size analysis (transitive descendant counts) across the CLI, TUI, and GUI for sqlite databases. This enables users to quickly browse the size distribution of different concept branches, acting like a disk usage analyzer (du/ncdu) for the SNOMED CT taxonomy. It uses a Transitive Closure Table to determine the size of the concept and all it's ancestors. If it does not have ancestors, it will uses Common Table Expression against the concept_isa table.

This could be useful for applications where storage size is important, for example mobile applications.

This PR adds a CLI size tree viewer, as well as a tui and web interface viewers.