### PR TITLE
feat: implement SNOMED CT NDJSON filtering, parent collapsing, and GTIN remapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,8 @@ serve = ["dep:axum", "dep:tokio"]
 # via the pure-Rust jetdb Access reader. Optional: most users only need the
 # RF2-native maps from `sct ndjson --refsets all`.
 dmwb = ["dep:jetdb"]
-full = ["tui", "gui", "serve"]
+gtin = []
+full = ["tui", "gui", "serve", "gtin"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/assets/index.html
+++ b/assets/index.html
@@ -368,8 +368,27 @@ async function loadConcept(id, push) {
   } catch (e) {
     panel.innerHTML = `<div class="text-center py-16 text-sm text-base-content/40">Error: ${esc(e.message)}</div>`;
   }
-}
+  const sizeEl = panel.querySelector("#size-estimates");
+  if (!sizeEl) return;
 
+  try {
+    const sizeData = await apiFetch(`/api/size/${encodeURIComponent(id)}`);
+    if (activeConceptId !== id) return;
+    if (sizeData.error) throw new Error(sizeData.error);
+    sizeEl.innerHTML = `
+      <p class="font-semibold uppercase tracking-widest text-base-content/40 mb-1">Size estimates</p>
+      <div class="flex flex-wrap gap-2">
+        ${sizeData.sqlite_human ? `<span class="badge badge-outline text-xs">SQLite: ${esc(sizeData.sqlite_human)}</span>` : ""}
+        ${sizeData.ndjson_human ? `<span class="badge badge-outline text-xs">NDJSON: ${esc(sizeData.ndjson_human)}</span>` : ""}
+      </div>`;
+  } catch (e) {
+    if (activeConceptId !== id) return;
+    console.warn("Failed to load size estimates:", e);
+    sizeEl.innerHTML = `
+      <p class="font-semibold uppercase tracking-widest text-base-content/40 mb-1">Size estimates</p>
+      <p class="text-base-content/30">Unavailable</p>`;
+  }
+}
 function renderConcept(c, panel) {
   const synonyms    = Array.isArray(c.synonyms)       ? c.synonyms       : [];
   const path        = Array.isArray(c.hierarchy_path) ? c.hierarchy_path : [];
@@ -391,6 +410,12 @@ function renderConcept(c, panel) {
       ${c.hierarchy ? `<span class="badge badge-warning badge-outline text-xs">${esc(c.hierarchy)}</span>` : ""}
       ${c.children_count ? `<span class="badge badge-ghost text-xs">${c.children_count} children</span>` : ""}
       ${c.descendants_count ? `<span class="badge badge-primary badge-outline text-xs">${c.descendants_count.toLocaleString()} descendants</span>` : ""}
+    </div>`;
+
+  html += `
+    <div id="size-estimates" class="text-xs text-base-content/40 mb-6">
+      <p class="font-semibold uppercase tracking-widest text-base-content/40 mb-1">Size estimates</p>
+      <p class="text-base-content/30">Loading…</p>
     </div>`;
 
   if (synonyms.length) {

--- a/assets/index.html
+++ b/assets/index.html
@@ -254,10 +254,10 @@ async function loadHierarchies() {
     data.hierarchies.forEach(h => {
       const btn = document.createElement("button");
       btn.className = "sidebar-item";
-      btn.innerHTML = `<span class="item-label">${esc(h)}</span><span class="item-meta">›</span>`;
+      btn.innerHTML = `<span class="item-label">${esc(h.name)}</span><span class="item-meta">${esc(h.count.toLocaleString())}</span>`;
       btn.addEventListener("click", () => {
         setActiveHierarchy(btn);
-        loadHierarchyConcepts(h);
+        loadHierarchyConcepts(h.name);
         document.getElementById("search-input").value = "";
       });
       el.appendChild(btn);
@@ -390,6 +390,7 @@ function renderConcept(c, panel) {
       <span class="badge badge-outline font-mono text-xs">${esc(c.id)}</span>
       ${c.hierarchy ? `<span class="badge badge-warning badge-outline text-xs">${esc(c.hierarchy)}</span>` : ""}
       ${c.children_count ? `<span class="badge badge-ghost text-xs">${c.children_count} children</span>` : ""}
+      ${c.descendants_count ? `<span class="badge badge-primary badge-outline text-xs">${c.descendants_count.toLocaleString()} descendants</span>` : ""}
     </div>`;
 
   if (synonyms.length) {

--- a/docs/commands/filter.md
+++ b/docs/commands/filter.md
@@ -1,0 +1,88 @@
+# sct filter
+
+Filter a SNOMED CT NDJSON file to keep a subset of concepts and automatically remap associated barcodes (GTINs) from filtered-out concepts to their nearest kept ancestor in the taxonomy.
+
+This is a powerful tool to generate highly optimized, minimal databases (e.g. for specific drug lists or localized departments) without losing the ability to map scanned pack barcodes to their corresponding drug classes.
+
+---
+
+## Usage
+
+```
+sct filter --input <INPUT> --output <OUTPUT> [OPTIONS]
+```
+
+### Options
+
+| Flag | Type | Description |
+|---|---|---|
+| `-i, --input` | `Path` | **Required.** Path to the original full SNOMED CT NDJSON file. |
+| `-o, --output` | `Path` | **Required.** Path to write the filtered NDJSON file. |
+| `--keep-ids` | `Path` | Path to a text file containing concept IDs to keep, one per line (optional). |
+| `--keep-ecl` | `String` | ECL query (e.g. `<< 999000011000001104` to select VMP/VTM concepts) to keep (optional). |
+| `--db` | `Path` | Path to a SQLite database. Required if using `--keep-ecl` (optional). |
+| `--gtin-map` | `Path` | Path to a CSV/TSV file mapping GTIN barcodes to SNOMED pack concept IDs (optional). |
+
+---
+
+## How It Works
+
+### Concept Filtering
+Only concepts specified in the `--keep-ids` file and/or matching the `--keep-ecl` query are retained in the output NDJSON. All other concept records are discarded. 
+
+### GTIN Remapping
+If a `--gtin-map` file (mapping GTIN barcodes to concept IDs, e.g. Actual Medicinal Product Packs / AMPPs) is supplied:
+1. `sct filter` parses the original NDJSON to understand parent-child relationships across the complete SNOMED hierarchy.
+2. For each GTIN mapping:
+   - If the mapped concept is retained in the kept set, the barcode remains associated with it.
+   - If the mapped concept is filtered out, the tool traverses up the hierarchy (parents/ancestors) to find the closest kept concept (e.g. the Virtual Medicinal Product / VMP).
+   - The GTIN is then appended to that kept concept's `gtin_codes` list.
+3. The resulting database lets you query the barcodes directly, resolving them to the appropriate higher-level kept concept!
+
+---
+
+## Examples
+
+### 1. Filtering with a List of Concept IDs
+Keep only concepts listed in `keep_list.txt`:
+```bash
+sct filter --input snomed.ndjson --output filtered.ndjson --keep-ids keep_list.txt
+```
+
+### 2. Filtering with ECL
+Keep only concepts matching an ECL expression (e.g., all descendants of Virtual Medicinal Product):
+```bash
+sct filter --input snomed.ndjson --output filtered.ndjson --keep-ecl "< 999000011000001104" --db snomed.db
+```
+
+### 3. Filtering and Remapping GTINs
+Remap GTIN barcodes from a CSV mapping file (`gtin_map.csv`) to kept ancestor concepts:
+```bash
+sct filter --input snomed.ndjson --output filtered.ndjson --keep-ids keep_list.txt --gtin-map gtin_map.csv
+```
+
+### 4. Loading the Filtered Database
+Since `sct filter` outputs standard NDJSON, you can feed it directly to the existing `sqlite` command to generate your filtered database:
+```bash
+sct sqlite --input filtered.ndjson --output filtered.db
+```
+
+---
+
+## CLI Output Example
+
+When running `sct filter`, the CLI outputs a space-savings summary indicating exactly how many concepts were pruned and how much disk space was saved:
+
+```
+Reading input NDJSON...
+Loading and remapping GTINs...
+Mapped 42,912 of 45,103 GTINs to kept concepts.
+Filtering and writing output NDJSON...
+
+Database Filtering Summary
+==========================
+Concepts kept:     41,209 / 837,930 (4.9%)
+Initial file size:  1.2 GB
+Filtered file size: 68.2 MB
+Space saved:        1.1 GB (94.3%)
+```

--- a/docs/commands/gtin.md
+++ b/docs/commands/gtin.md
@@ -1,0 +1,49 @@
+# GTIN Codes Support
+
+`sct` supports Global Trade Item Numbers (GTINs) for barcodes of actual medicinal packages. This enables clinical applications and devices to map scanned barcodes directly to the corresponding SNOMED CT concept ID (e.g. Actual Medicinal Product Packs/AMPPs).
+
+---
+
+## Schema Changes
+
+In `ConceptRecord` (schema version `6` and above), a new array field is populated:
+```json
+{
+  "id": "999000011000001104",
+  "preferred_term": "Virtual Medicinal Product",
+  "gtin_codes": [
+    "5012345678901",
+    "5012345678902"
+  ],
+  "schema_version": 6
+}
+```
+
+In the SQLite database, this is represented by:
+*   A `gtin_codes` text column in the `concepts` table storing a JSON array of barcode strings.
+*   Cross-references in both the `concept_maps` and `crossmaps` tables under the `"gtin"` terminology mapping namespace.
+
+---
+
+## Querying GTIN Mappings
+
+### 1. Concept Lookup
+You can lookup a concept directly using a GTIN barcode via the `sct lookup` command. If the barcode is found in the crossmaps, `sct` returns the full concept record:
+```bash
+sct lookup 5012345678901
+```
+
+### 2. Terminology Mapping
+You can translate barcodes to SNOMED concepts (or retrieve all barcode codes associated with a SNOMED ID) using `sct map`:
+
+*   **Convert a barcode to its SNOMED concept ID**:
+    ```bash
+    sct map gtin 5012345678901
+    ```
+*   **List all barcode GTINs for a given concept**:
+    ```bash
+    sct map snomed 73211009
+    ```
+
+### 3. MCP Server Integration
+The MCP server includes support for the `"gtin"` terminology in its `snomed_map` tool. Connected agents/LLMs can automatically perform forward and reverse barcode mappings.

--- a/docs/commands/gtin.md
+++ b/docs/commands/gtin.md
@@ -2,6 +2,8 @@
 
 `sct` supports Global Trade Item Numbers (GTINs) for barcodes of actual medicinal packages. This enables clinical applications and devices to map scanned barcodes directly to the corresponding SNOMED CT concept ID (e.g. Actual Medicinal Product Packs/AMPPs).
 
+> Note: GTIN support is behind the compile-time Cargo feature `gtin` (enable with `--features gtin` or `--features full`). Without it, the schema stays at v5 and GTIN fields/mappings are omitted.
+
 ---
 
 ## Schema Changes

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -1,0 +1,34 @@
+# Concept Subtree Size Visualizer (`sct size`)
+
+The `sct size` command displays a hierarchical tree of SNOMED CT concepts and their subtree sizes (number of transitive descendants), acting like a disk-usage analyzer (`du` / `ncdu`) for the terminology taxonomy.
+
+---
+
+## Usage
+
+```bash
+# Print the size distribution from the SNOMED CT root concept (default)
+sct size --depth 2
+
+# Inspect a specific sub-hierarchy (e.g. Clinical finding)
+sct size --concept 404684003 --depth 3
+```
+
+---
+
+## Limitations & Design Characteristics
+
+When analyzing subtree sizes in SNOMED CT, keep the following characteristics and limitations in mind:
+
+### 1. Polyhierarchy and Cumulative Math
+SNOMED CT is a polyhierarchical taxonomy (a Directed Acyclic Graph, not a strict tree). This means a single concept can have multiple parent concepts (multiple inheritance).
+
+*   **Behavior**: When printing the hierarchical size tree, a concept that is inherited via multiple parent paths will appear multiple times in the tree (under each of its parent branches).
+*   **Result**: The sum of the subtree sizes of all children of a concept will usually be **larger** than the total subtree size reported on the parent concept itself. This is because any descendants with multiple parents are counted once in each path but deduplicated in the parent's absolute count.
+
+### 2. Performance Fallback without Transitive Closure Table (TCT)
+The size query utilizes a precomputed transitive closure table (`concept_ancestors`) if it exists in the SQLite database (built via `sct tct`).
+
+*   **TCT Present (Recommended)**: Queries are extremely fast (sub-millisecond) because they leverage indexed lookups.
+*   **TCT Absent (Fallback)**: If the `concept_ancestors` table is missing, `sct` falls back to running a recursive Common Table Expression (CTE) query against `concept_isa` to count descendants on the fly.
+*   **Performance Impact**: Running recursive CTE queries for large hierarchies (such as the root concept or Clinical Finding) is resource-intensive and will take several seconds to complete, especially when building multiple levels of a tree. We recommend running `sct tct` on your SQLite database before exploring sizes.

--- a/docs/commands/size.md
+++ b/docs/commands/size.md
@@ -1,4 +1,54 @@
-# Concept Subtree Size Visualizer (`sct size`)
+# sct size `experimental!`
+
+Estimate the output size of a subtree rooted at a concept. The command samples NDJSON row sizes, counts the subtree, and reports both NDJSON and SQLite size estimates for planning exports or downstream processing.
+
+---
+
+## Usage
+
+```bash
+sct size [--concept <SCTID>] [--sample <N>] [--tree] [--depth <N>] [--db <PATH>]
+```
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--concept <SCTID>` | root concept | Starting concept ID. Falls back to the active root in filtered databases. |
+| `--sample <N>` | `200` | Number of rows to sample when estimating average NDJSON row size. |
+| `--tree` | *(flag)* | Also print a descendant-count tree. |
+| `--depth <N>` | `2` | Maximum tree depth when `--tree` is enabled. |
+| `--db <PATH>` | discovered (see [Path resolution](../path-resolution.md)) | SQLite database produced by `sct sqlite`. |
+
+---
+
+## Example
+
+```bash
+# Estimate the size of the whole SNOMED CT tree.
+sct size
+
+# Inspect a specific subtree with a smaller sample and a tree view.
+sct size --concept 404684003 --sample 100 --tree
+```
+
+---
+
+## Output
+
+The command reports:
+
+- subtree concept count and percentage of the full database
+- estimated NDJSON export size
+- estimated proportional SQLite database size
+- optional descendant counts for the subtree when `--tree` is set
+
+---
+
+## See also
+
+- [`sct gui`](gui.md) - browser UI with the same size estimates in the concept detail panel
+- [`sct tui`](tui.md) - keyboard UI with a toggleable size row# Concept Subtree Size Visualizer (`sct size`)
 
 The `sct size` command displays a hierarchical tree of SNOMED CT concepts and their subtree sizes (number of transitive descendants), acting like a disk-usage analyzer (`du` / `ncdu`) for the terminology taxonomy.
 

--- a/docs/commands/tui.md
+++ b/docs/commands/tui.md
@@ -83,6 +83,7 @@ sct tui
 | `PgUp` / `PgDn` | Scroll detail panel |
 | `b` | Back - return to previously viewed concept |
 | `h` | Jump focus to Hierarchy panel |
+| `s` | Toggle size estimates in the detail panel |
 | `q` / `Q` | Quit |
 | `Ctrl-C` | Quit |
 
@@ -97,6 +98,8 @@ sct tui
 3. **Inspect a concept** - use `↑↓` in the Results list, press `Enter` to load the full concept detail on the right.
 
 4. **Navigate relationships** - the detail panel lists parents and attributes with their SCTIDs. Type the SCTID into the search box to jump to any related concept, or use `b` to navigate back through your history (up to 20 steps).
+
+5. **Inspect subtree size** - press `s` in the detail panel to show the NDJSON and SQLite size estimates for the selected concept's subtree.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
           - sct diagram: commands/diagram.md
           - sct refset: commands/refset.md
           - sct map: commands/map.md
+          - GTIN Codes: commands/gtin.md
           - sct dmwb: commands/dmwb.md
       - Code lists:
           - sct codelist: commands/codelist.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
           - sct diagram: commands/diagram.md
           - sct refset: commands/refset.md
           - sct map: commands/map.md
+          - sct size: commands/size.md
           - sct dmwb: commands/dmwb.md
       - Code lists:
           - sct codelist: commands/codelist.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
           - sct trud: commands/trud.md
           - sct read2: commands/read2.md
           - sct ndjson: commands/ndjson.md
+          - sct filter: commands/filter.md
           - sct sqlite: commands/sqlite.md
           - sct parquet: commands/parquet.md
           - sct markdown: commands/markdown.md

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,7 +10,7 @@ use crate::rf2::{
     Acceptability, Rf2Dataset, LANG_GB_ENGLISH, LANG_UK_CLINICAL, LANG_UK_DRUG, LANG_US_ENGLISH,
     TYPE_FSN, TYPE_SYNONYM,
 };
-use crate::schema::{ConceptRecord, ConceptRef, CrossMapEntry, SCHEMA_VERSION};
+use crate::schema::{ConceptRecord, ConceptRef, CrossMapEntry};
 
 // ---------------------------------------------------------------------------
 // Known top-level SNOMED CT hierarchy concept IDs (children of the root)
@@ -393,8 +393,7 @@ pub fn build_records(
             refsets,
             relationships,
             crossmaps,
-            gtin_codes: vec![],
-            schema_version: SCHEMA_VERSION,
+            ..Default::default()
         });
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -393,6 +393,7 @@ pub fn build_records(
             refsets,
             relationships,
             crossmaps,
+            gtin_codes: vec![],
             schema_version: SCHEMA_VERSION,
         });
     }

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -385,7 +385,6 @@ mod tests {
     use super::*;
 
     fn make_record(id: &str, preferred_term: &str, hierarchy: &str, active: bool) -> ConceptRecord {
-        use crate::schema::SCHEMA_VERSION;
         use indexmap::IndexMap;
         ConceptRecord {
             id: id.into(),
@@ -405,8 +404,7 @@ mod tests {
             refsets: vec![],
             relationships: vec![],
             crossmaps: vec![],
-            gtin_codes: vec![],
-            schema_version: SCHEMA_VERSION,
+            ..Default::default()
         }
     }
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -405,6 +405,7 @@ mod tests {
             refsets: vec![],
             relationships: vec![],
             crossmaps: vec![],
+            gtin_codes: vec![],
             schema_version: SCHEMA_VERSION,
         }
     }

--- a/src/commands/filter.rs
+++ b/src/commands/filter.rs
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `sct filter` - filter a SNOMED CT NDJSON file, collapse hierarchy, and remap GTINs.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::{BufRead, BufWriter, Write};
+use std::path::PathBuf;
+
+use crate::schema::{ConceptRecord, ConceptRef};
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Path to the input SNOMED CT NDJSON file.
+    #[arg(long, short)]
+    pub input: PathBuf,
+
+    /// Path to write the filtered NDJSON file.
+    #[arg(long, short)]
+    pub output: PathBuf,
+
+    /// Keep only concepts matching this ECL expression (requires a SQLite database via --db).
+    #[arg(long)]
+    pub keep_ecl: Option<String>,
+
+    /// Path to a text file containing concept IDs to keep (one per line).
+    #[arg(long)]
+    pub keep_ids: Option<PathBuf>,
+
+    /// Path to a SQLite database. Required if evaluating --keep-ecl.
+    #[arg(long)]
+    pub db: Option<PathBuf>,
+
+    /// Path to a CSV/TSV file mapping GTINs to concepts (format: gtin,concept_id) (optional).
+    #[arg(long)]
+    pub gtin_map: Option<PathBuf>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    // 1. Determine the set of concept IDs to keep
+    let mut kept_ids = HashSet::new();
+
+    if let Some(ecl_expr) = &args.keep_ecl {
+        let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
+        let conn = crate::commands::open_db_readonly(&db_path, None)?;
+        crate::ecl::warn_if_no_tct(&conn);
+        let ids = crate::ecl::expand(&conn, ecl_expr)?;
+        kept_ids.extend(ids);
+    }
+
+    if let Some(ids_file) = &args.keep_ids {
+        let file = std::fs::File::open(ids_file)
+            .with_context(|| format!("opening keep-ids file {}", ids_file.display()))?;
+        let reader = std::io::BufReader::new(file);
+        for line in reader.lines() {
+            let line = line?;
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                kept_ids.insert(trimmed.to_string());
+            }
+        }
+    }
+
+    anyhow::ensure!(
+        !kept_ids.is_empty(),
+        "No concepts specified to keep. Provide --keep-ecl and/or --keep-ids."
+    );
+
+    // 2. Load the original NDJSON to build the hierarchy and get concepts
+    eprintln!("Reading input NDJSON...");
+    let file = std::fs::File::open(&args.input)
+        .with_context(|| format!("opening input file {}", args.input.display()))?;
+    let input_len = file.metadata()?.len();
+    let reader = std::io::BufReader::new(file);
+
+    let mut concepts = HashMap::new();
+    let mut parents_map = HashMap::new();
+    let mut provenance_line = None;
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if line.contains("sct_provenance") {
+            provenance_line = Some(line.clone());
+            continue;
+        }
+        let record: ConceptRecord =
+            serde_json::from_str(&line).context("deserializing ConceptRecord from NDJSON")?;
+
+        let p_ids: Vec<String> = record.parents.iter().map(|p| p.id.clone()).collect();
+        parents_map.insert(record.id.clone(), p_ids);
+        concepts.insert(record.id.clone(), record);
+    }
+
+    // 3. Perform automatic GTIN remapping of GTINs already in the NDJSON,
+    // and optionally layer custom mappings from the --gtin-map file.
+    let mut gtin_remaps: HashMap<String, Vec<String>> = HashMap::new();
+
+    // Trace existing GTINs from filtered-out concepts
+    for (id, record) in &concepts {
+        if !record.gtin_codes.is_empty() && !kept_ids.contains(id) {
+            if let Some(target_id) = find_kept_ancestor(id, &parents_map, &kept_ids) {
+                gtin_remaps
+                    .entry(target_id)
+                    .or_default()
+                    .extend(record.gtin_codes.clone());
+            }
+        }
+    }
+
+    if let Some(gtin_map_path) = &args.gtin_map {
+        eprintln!("Loading and remapping custom GTINs...");
+        let file = std::fs::File::open(gtin_map_path)
+            .with_context(|| format!("opening GTIN map file {}", gtin_map_path.display()))?;
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .flexible(true)
+            .from_reader(std::io::BufReader::new(file));
+
+        let mut total_gtins = 0;
+        let mut mapped_gtins = 0;
+
+        for result in rdr.records() {
+            let record = result?;
+            if record.len() < 2 {
+                continue;
+            }
+            let gtin = record.get(0).unwrap_or("").trim().to_string();
+            let concept_id = record.get(1).unwrap_or("").trim().to_string();
+            if gtin.is_empty() || concept_id.is_empty() {
+                continue;
+            }
+
+            total_gtins += 1;
+
+            if let Some(target_id) = find_kept_ancestor(&concept_id, &parents_map, &kept_ids) {
+                gtin_remaps.entry(target_id).or_default().push(gtin);
+                mapped_gtins += 1;
+            }
+        }
+        eprintln!(
+            "Mapped {} of {} custom GTINs to kept concepts.",
+            mapped_gtins, total_gtins
+        );
+    }
+
+    // 4. Collapse the parent links of kept concepts and build new children count map
+    eprintln!("Collapsing hierarchy and updating links...");
+    let mut kept_parents_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut children_counts: HashMap<String, usize> = HashMap::new();
+
+    for id in &kept_ids {
+        if let Some(record) = concepts.get(id) {
+            let mut new_parents = Vec::new();
+            for p in &record.parents {
+                if let Some(ancestor_id) = find_kept_ancestor(&p.id, &parents_map, &kept_ids) {
+                    new_parents.push(ancestor_id.clone());
+                    // Increment the children count for the kept parent
+                    *children_counts.entry(ancestor_id).or_default() += 1;
+                }
+            }
+            new_parents.sort();
+            new_parents.dedup();
+            kept_parents_map.insert(id.clone(), new_parents);
+        }
+    }
+
+    // 5. Filter concepts, assign remapped parents/GTINs/children counts, and write output
+    eprintln!("Filtering and writing output NDJSON...");
+    let out_file = std::fs::File::create(&args.output)
+        .with_context(|| format!("creating output file {}", args.output.display()))?;
+    let mut writer = BufWriter::new(out_file);
+
+    if let Some(prov) = provenance_line {
+        writer.write_all(prov.as_bytes())?;
+        writer.write_all(b"\n")?;
+    }
+
+    let mut kept_count = 0;
+    let initial_count = concepts.len();
+
+    let mut concept_ids: Vec<String> = concepts.keys().cloned().collect();
+    concept_ids.sort_by(|a, b| {
+        let a_num = a.parse::<u64>().ok();
+        let b_num = b.parse::<u64>().ok();
+        match (a_num, b_num) {
+            (Some(an), Some(bn)) => an.cmp(&bn),
+            _ => a.cmp(b),
+        }
+    });
+
+    for id in &concept_ids {
+        if kept_ids.contains(id) {
+            let mut record = concepts.remove(id).unwrap();
+
+            // Assign remapped parent ConceptRefs
+            if let Some(parent_ids) = kept_parents_map.remove(id) {
+                record.parents = parent_ids
+                    .into_iter()
+                    .map(|pid| ConceptRef {
+                        fsn: concepts
+                            .get(&pid)
+                            .or(record.id.eq(&pid).then_some(&record))
+                            .map(|c| c.fsn.clone())
+                            .unwrap_or_default(),
+                        id: pid,
+                    })
+                    .collect();
+            }
+
+            // Assign recalculated children count
+            record.children_count = children_counts.remove(id).unwrap_or(0);
+
+            // Assign remapped GTINs
+            if let Some(mut gtins) = gtin_remaps.remove(id) {
+                record.gtin_codes.append(&mut gtins);
+                record.gtin_codes.sort();
+                record.gtin_codes.dedup();
+            }
+
+            let serialized = serde_json::to_string(&record)?;
+            writer.write_all(serialized.as_bytes())?;
+            writer.write_all(b"\n")?;
+            kept_count += 1;
+        }
+    }
+    writer.flush()?;
+
+    let output_len = std::fs::metadata(&args.output)?.len();
+
+    // 6. Print space savings summary
+    println!("\nDatabase Filtering Summary");
+    println!("==========================");
+    println!(
+        "Concepts kept:     {} / {} ({:.1}%)",
+        fmt_count(kept_count as u64),
+        fmt_count(initial_count as u64),
+        (kept_count as f64 / initial_count as f64) * 100.0
+    );
+    println!("Initial file size:  {}", human_size(input_len));
+    println!("Filtered file size: {}", human_size(output_len));
+    let saved_bytes = input_len.saturating_sub(output_len);
+    println!(
+        "Space saved:        {} ({:.1}%)",
+        human_size(saved_bytes),
+        (saved_bytes as f64 / input_len as f64) * 100.0
+    );
+
+    Ok(())
+}
+
+fn find_kept_ancestor(
+    concept_id: &str,
+    parents_map: &HashMap<String, Vec<String>>,
+    kept_ids: &HashSet<String>,
+) -> Option<String> {
+    if kept_ids.contains(concept_id) {
+        return Some(concept_id.to_string());
+    }
+
+    let mut queue = VecDeque::new();
+    let mut visited = HashSet::new();
+
+    queue.push_back(concept_id.to_string());
+    visited.insert(concept_id.to_string());
+
+    while let Some(current) = queue.pop_front() {
+        if kept_ids.contains(&current) {
+            return Some(current);
+        }
+        if let Some(parents) = parents_map.get(&current) {
+            for parent in parents {
+                if visited.insert(parent.clone()) {
+                    queue.push_back(parent.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn human_size(bytes: u64) -> String {
+    const GB: u64 = 1 << 30;
+    const MB: u64 = 1 << 20;
+    const KB: u64 = 1 << 10;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+fn fmt_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}

--- a/src/commands/filter.rs
+++ b/src/commands/filter.rs
@@ -158,13 +158,14 @@ pub fn run(args: Args) -> Result<()> {
             let mut new_parents = Vec::new();
             for p in &record.parents {
                 if let Some(ancestor_id) = find_kept_ancestor(&p.id, &parents_map, &kept_ids) {
-                    new_parents.push(ancestor_id.clone());
-                    // Increment the children count for the kept parent
-                    *children_counts.entry(ancestor_id).or_default() += 1;
+                    new_parents.push(ancestor_id);
                 }
             }
             new_parents.sort();
             new_parents.dedup();
+            for parent_id in &new_parents {
+                *children_counts.entry(parent_id.clone()).or_default() += 1;
+            }
             kept_parents_map.insert(id.clone(), new_parents);
         }
     }

--- a/src/commands/filter.rs
+++ b/src/commands/filter.rs
@@ -196,7 +196,7 @@ pub fn run(args: Args) -> Result<()> {
 
     for id in &concept_ids {
         if kept_ids.contains(id) {
-            let mut record = concepts.remove(id).unwrap();
+            let mut record = concepts.get(id).unwrap().clone();
 
             // Assign remapped parent ConceptRefs
             if let Some(parent_ids) = kept_parents_map.remove(id) {

--- a/src/commands/gui.rs
+++ b/src/commands/gui.rs
@@ -213,6 +213,7 @@ fn inner_concept(db_path: &PathBuf, id: &str) -> Result<Value> {
             let parse_json = |s: Option<String>| -> Value {
                 serde_json::from_str(&s.unwrap_or_default()).unwrap_or(Value::Null)
             };
+            let descendants_count = crate::commands::get_subtree_size(&conn, id).unwrap_or(0);
             Ok(json!({
                 "id":             row.get::<_, String>(0)?,
                 "fsn":            row.get::<_, String>(1)?,
@@ -222,6 +223,7 @@ fn inner_concept(db_path: &PathBuf, id: &str) -> Result<Value> {
                 "hierarchy_path": parse_json(row.get::<_, Option<String>>(5)?),
                 "parents":        parse_json(row.get::<_, Option<String>>(6)?),
                 "children_count": row.get::<_, i64>(7)?,
+                "descendants_count": descendants_count,
                 "attributes":     parse_json(row.get::<_, Option<String>>(8)?)
             }))
         },
@@ -295,15 +297,21 @@ async fn api_hierarchy(State(state): State<AppState>) -> Json<Value> {
 fn inner_hierarchy(db_path: &PathBuf) -> Result<Value> {
     let conn = open_db(db_path)?;
     let mut stmt = conn.prepare(
-        "SELECT DISTINCT hierarchy FROM concepts \
+        "SELECT hierarchy, COUNT(*) FROM concepts \
          WHERE hierarchy IS NOT NULL AND hierarchy != '' \
+         GROUP BY hierarchy \
          ORDER BY hierarchy",
     )?;
-    let hierarchies: Vec<String> = stmt
-        .query_map([], |row| row.get(0))?
+    let rows: Vec<Value> = stmt
+        .query_map([], |row| {
+            Ok(json!({
+                "name": row.get::<_, String>(0)?,
+                "count": row.get::<_, i64>(1)?
+            }))
+        })?
         .filter_map(|r| r.ok())
         .collect();
-    Ok(json!({"hierarchies": hierarchies}))
+    Ok(json!({"hierarchies": rows}))
 }
 
 async fn api_graph(State(state): State<AppState>, Path(id): Path<String>) -> Json<Value> {

--- a/src/commands/gui.rs
+++ b/src/commands/gui.rs
@@ -61,6 +61,7 @@ pub fn run(args: Args) -> Result<()> {
     // Validate we can open the database before starting the server
     {
         let conn = open_db(&db_path)?;
+        crate::ecl::warn_if_no_tct(&conn);
         drop(conn);
     }
 

--- a/src/commands/gui.rs
+++ b/src/commands/gui.rs
@@ -13,6 +13,7 @@
 //!   GET /api/children/:id     → immediate IS-A children (JSON)
 //!   GET /api/parents/:id      → direct parents (JSON)
 //!   GET /api/hierarchy        → list of top-level hierarchy names (JSON)
+//!   GET /api/size/:id         → size estimate for a concept (JSON)
 //!
 //! Requires the `gui` Cargo feature: `cargo build --features gui`
 
@@ -102,6 +103,7 @@ async fn serve(
         .route("/api/parents/{id}", get(api_parents))
         .route("/api/hierarchy", get(api_hierarchy))
         .route("/api/graph/{id}", get(api_graph))
+        .route("/api/size/{id}", get(api_size))
         .with_state(state);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -243,6 +245,31 @@ async fn api_children(State(state): State<AppState>, Path(id): Path<String>) -> 
         Ok(v) => Json(v),
         Err(e) => Json(json!({"error": e.to_string()})),
     }
+}
+
+/// GET /api/size/:id — returns NDJSON and SQLite file size estimates for a concept's subtree.
+async fn api_size(State(state): State<AppState>, Path(id): Path<String>) -> Json<Value> {
+    match inner_size(&state.db_path, &id) {
+        Ok(v) => Json(v),
+        Err(e) => Json(json!({"error": e.to_string()})),
+    }
+}
+
+fn inner_size(db_path: &PathBuf, id: &str) -> Result<Value> {
+    let conn = open_db(db_path)?;
+    let est = crate::commands::size::estimate_sizes(&conn, id, 100)?;
+    Ok(json!({
+        "id":               id,
+        "subtree_count":    est.subtree_count,
+        "total_count":      est.total_count,
+        "pct":              est.pct(),
+        "avg_ndjson_bytes": est.avg_ndjson_bytes,
+        "ndjson_total":     est.ndjson_total,
+        "ndjson_human":     crate::commands::size::fmt_bytes(est.ndjson_total),
+        "total_db_bytes":   est.total_db_bytes,
+        "sqlite_total":     est.sqlite_total,
+        "sqlite_human":     crate::commands::size::fmt_bytes(est.sqlite_total)
+    }))
 }
 
 fn inner_children(db_path: &PathBuf, id: &str) -> Result<Value> {

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -70,6 +70,13 @@ pub fn run(args: Args) -> Result<()> {
         if code.chars().all(|c| c.is_ascii_digit()) {
             if lookup_sctid(&conn, code)?.is_some() {
                 writeln!(out, "{code}")?;
+            } else {
+                #[cfg(feature = "gtin")]
+                {
+                    for (id, _, _, _) in lookup_gtin(&conn, code)? {
+                        writeln!(out, "{id}")?;
+                    }
+                }
             }
         } else {
             for (id, _, _, _) in lookup_ctv3(&conn, code)? {
@@ -83,6 +90,36 @@ pub fn run(args: Args) -> Result<()> {
     if code.chars().all(|c| c.is_ascii_digit()) {
         if let Some(concept) = lookup_sctid(&conn, code)? {
             return print_concept(concept, format, prov.as_ref(), show_prov);
+        }
+        #[cfg(feature = "gtin")]
+        {
+            let mapped = lookup_gtin(&conn, code)?;
+            if !mapped.is_empty() {
+                if mapped.len() == 1 {
+                    if let Some(concept) = lookup_sctid(&conn, &mapped[0].0)? {
+                        println!("GTIN {code} → SCTID {}\n", mapped[0].0);
+                        return print_concept(concept, format, prov.as_ref(), show_prov);
+                    }
+                }
+                println!(
+                    "GTIN {code} maps to {} SNOMED CT concept{}:\n",
+                    mapped.len(),
+                    if mapped.len() == 1 { "" } else { "s" }
+                );
+                for (id, pt, fsn, hierarchy) in &mapped {
+                    println!("  [{id}] {pt}");
+                    let fsn_clean = strip_semantic_tag(fsn);
+                    if fsn_clean != pt && !fsn.is_empty() {
+                        println!("        FSN: {fsn_clean}");
+                    }
+                    println!("        {hierarchy}");
+                }
+                if mapped.len() > 1 {
+                    println!("\nUse `sct lookup <SCTID>` for full details on a specific concept.");
+                }
+                provenance::print_human_footer(prov.as_ref(), show_prov);
+                return Ok(());
+            }
         }
         println!("Concept {code} not found.");
         return Ok(());
@@ -367,9 +404,16 @@ fn print_concept(
     // Cross-maps
     let ctv3 = concept["ctv3_codes"].as_array();
     let read2 = concept["read2_codes"].as_array();
+    #[cfg(feature = "gtin")]
+    let gtin = concept["gtin_codes"].as_array();
     let has_ctv3 = ctv3.is_some_and(|a| !a.is_empty());
     let has_read2 = read2.is_some_and(|a| !a.is_empty());
-    if has_ctv3 || has_read2 {
+    #[cfg(feature = "gtin")]
+    let has_gtin = gtin.is_some_and(|a| !a.is_empty());
+    #[cfg(not(feature = "gtin"))]
+    let has_gtin = false;
+
+    if has_ctv3 || has_read2 || has_gtin {
         println!("  Cross-maps:");
         if let Some(codes) = ctv3 {
             let cs: Vec<&str> = codes.iter().filter_map(|c| c.as_str()).collect();
@@ -381,6 +425,13 @@ fn print_concept(
             let cs: Vec<&str> = codes.iter().filter_map(|c| c.as_str()).collect();
             if !cs.is_empty() {
                 println!("    Read v2: {}", cs.join(", "));
+            }
+        }
+        #[cfg(feature = "gtin")]
+        if let Some(codes) = gtin {
+            let cs: Vec<&str> = codes.iter().filter_map(|c| c.as_str()).collect();
+            if !cs.is_empty() {
+                println!("    GTIN: {}", cs.join(", "));
             }
         }
     }
@@ -404,4 +455,25 @@ fn print_concept(
     provenance::print_human_footer(prov, show_prov);
 
     Ok(())
+}
+
+/// Reverse-lookup a GTIN barcode → SNOMED concept(s) via concept_maps.
+#[cfg(feature = "gtin")]
+fn lookup_gtin(conn: &Connection, code: &str) -> Result<Vec<(String, String, String, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.preferred_term, c.fsn, c.hierarchy
+         FROM concept_maps m
+         JOIN concepts c ON c.id = m.concept_id
+         WHERE m.code = ?1 AND m.terminology = 'gtin'
+         ORDER BY c.id",
+    )?;
+
+    let rows: Vec<(String, String, String, String)> = stmt
+        .query_map(params![code], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    Ok(rows)
 }

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -131,14 +131,23 @@ pub fn run(args: Args) -> Result<()> {
 }
 
 fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
-    let result = conn.query_row(
-        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    #[cfg(feature = "gtin")]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1",
+         FROM concepts WHERE id = ?1";
+    #[cfg(not(feature = "gtin"))]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                parents, children_count, attributes, active, module, effective_time,
+                ctv3_codes, read2_codes
+         FROM concepts WHERE id = ?1";
+
+    let result = conn.query_row(
+        query,
         params![id],
         |row| {
-            Ok(json!({
+            #[cfg(feature = "gtin")]
+            return Ok(json!({
                 "id": row.get::<_, String>(0)?,
                 "fsn": row.get::<_, String>(1)?,
                 "preferred_term": row.get::<_, String>(2)?,
@@ -154,7 +163,25 @@ fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
                 "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
                 "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }))
+            }));
+
+            #[cfg(not(feature = "gtin"))]
+            return Ok(json!({
+                "id": row.get::<_, String>(0)?,
+                "fsn": row.get::<_, String>(1)?,
+                "preferred_term": row.get::<_, String>(2)?,
+                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                "hierarchy": row.get::<_, String>(4)?,
+                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                "children_count": row.get::<_, i64>(7)?,
+                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                "active": row.get::<_, bool>(9)?,
+                "module": row.get::<_, String>(10)?,
+                "effective_time": row.get::<_, String>(11)?,
+                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+            }));
         },
     );
 

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -324,6 +324,7 @@ fn print_concept(
                 let pterm = p["term"]
                     .as_str()
                     .or(p["preferred_term"].as_str())
+                    .or(p["fsn"].as_str())
                     .unwrap_or("?");
                 println!("    [{pid}] {pterm}");
             }
@@ -356,6 +357,7 @@ fn print_concept(
                         let vterm = v["term"]
                             .as_str()
                             .or(v["preferred_term"].as_str())
+                            .or(v["fsn"].as_str())
                             .unwrap_or("?");
                         println!("    {key}: [{vid}] {vterm}");
                     }

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -134,7 +134,7 @@ fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
     let result = conn.query_row(
         "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
-                ctv3_codes, read2_codes
+                ctv3_codes, read2_codes, gtin_codes
          FROM concepts WHERE id = ?1",
         params![id],
         |row| {
@@ -152,7 +152,8 @@ fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
                 "module": row.get::<_, String>(10)?,
                 "effective_time": row.get::<_, String>(11)?,
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([]))
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
             }))
         },
     );

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -169,56 +169,63 @@ pub fn run(args: Args) -> Result<()> {
 
 fn lookup_sctid(conn: &Connection, id: &str) -> Result<Option<Value>> {
     #[cfg(feature = "gtin")]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    let use_gtin = has_gtin_column(conn);
+    #[cfg(not(feature = "gtin"))]
+    let use_gtin = false;
+
+    let query = if use_gtin {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1";
-    #[cfg(not(feature = "gtin"))]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+         FROM concepts WHERE id = ?1"
+    } else {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes
-         FROM concepts WHERE id = ?1";
+         FROM concepts WHERE id = ?1"
+    };
 
     let result = conn.query_row(
         query,
         params![id],
         |row| {
-            #[cfg(feature = "gtin")]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }));
-
-            #[cfg(not(feature = "gtin"))]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-            }));
+            if use_gtin {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
+                }))
+            } else {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": json!([])
+                }))
+            }
         },
     );
 
@@ -476,4 +483,15 @@ fn lookup_gtin(conn: &Connection, code: &str) -> Result<Vec<(String, String, Str
         .collect();
 
     Ok(rows)
+}
+
+/// Check if the concepts table has the gtin_codes column.
+#[cfg(feature = "gtin")]
+fn has_gtin_column(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        [],
+        |_| Ok(true),
+    )
+    .unwrap_or(false)
 }

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -491,7 +491,7 @@ fn lookup_gtin(conn: &Connection, code: &str) -> Result<Vec<(String, String, Str
 #[cfg(feature = "gtin")]
 fn has_gtin_column(conn: &Connection) -> bool {
     conn.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        "SELECT 1 FROM pragma_table_info('concepts') WHERE name = 'gtin_codes' LIMIT 1",
         [],
         |_| Ok(true),
     )

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -711,14 +711,23 @@ fn tool_search(conn: &Connection, args: &Value) -> Result<String> {
 fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> Result<String> {
     let id = args["id"].as_str().context("snomed_concept requires id")?;
 
-    let result = conn.query_row(
-        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    #[cfg(feature = "gtin")]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1",
+         FROM concepts WHERE id = ?1";
+    #[cfg(not(feature = "gtin"))]
+    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                parents, children_count, attributes, active, module, effective_time,
+                ctv3_codes, read2_codes
+         FROM concepts WHERE id = ?1";
+
+    let result = conn.query_row(
+        query,
         params![id],
         |row| {
-            Ok(json!({
+            #[cfg(feature = "gtin")]
+            return Ok(json!({
                 "id": row.get::<_, String>(0)?,
                 "fsn": row.get::<_, String>(1)?,
                 "preferred_term": row.get::<_, String>(2)?,
@@ -734,7 +743,25 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
                 "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
                 "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }))
+            }));
+
+            #[cfg(not(feature = "gtin"))]
+            return Ok(json!({
+                "id": row.get::<_, String>(0)?,
+                "fsn": row.get::<_, String>(1)?,
+                "preferred_term": row.get::<_, String>(2)?,
+                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                "hierarchy": row.get::<_, String>(4)?,
+                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                "children_count": row.get::<_, i64>(7)?,
+                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                "active": row.get::<_, bool>(9)?,
+                "module": row.get::<_, String>(10)?,
+                "effective_time": row.get::<_, String>(11)?,
+                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+            }));
         },
     );
 
@@ -880,30 +907,46 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
                 .filter_map(|r| r.ok())
                 .collect();
 
+            #[cfg(feature = "gtin")]
             let mut gtin_stmt = conn.prepare(
                 "SELECT code FROM concept_maps WHERE concept_id = ?1 AND terminology = 'gtin' ORDER BY code",
             )?;
+            #[cfg(feature = "gtin")]
             let gtin_codes: Vec<String> = gtin_stmt
                 .query_map(params![code], |row| row.get(0))?
                 .filter_map(|r| r.ok())
                 .collect();
+            #[cfg(not(feature = "gtin"))]
+            let gtin_codes: Vec<String> = vec![];
 
             if ctv3_codes.is_empty() && read2_codes.is_empty() && gtin_codes.is_empty() {
+                #[cfg(feature = "gtin")]
                 return Ok(format!(
                     "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}.",
                     code
                 ));
+                #[cfg(not(feature = "gtin"))]
+                return Ok(format!(
+                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}.",
+                    code
+                ));
             }
 
-            Ok(serde_json::to_string_pretty(&json!({
+            #[allow(unused_mut)]
+            let mut ret = json!({
                 "snomed_id": code,
                 "ctv3_codes": ctv3_codes,
                 "read2_codes": read2_codes,
-                "gtin_codes": gtin_codes
-            }))?)
+            });
+            #[cfg(feature = "gtin")]
+            ret.as_object_mut()
+                .unwrap()
+                .insert("gtin_codes".to_string(), json!(gtin_codes));
+
+            Ok(serde_json::to_string_pretty(&ret)?)
         }
 
-        "ctv3" | "read2" | "gtin" => {
+        term if term == "ctv3" || term == "read2" || (cfg!(feature = "gtin") && term == "gtin") => {
             // CTV3 or Read v2 code → SNOMED CT concept(s)
             let mut stmt = conn.prepare(
                 "SELECT c.id, c.preferred_term, c.fsn, c.hierarchy
@@ -1486,7 +1529,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn create_test_schema(conn: &Connection) {
-        conn.execute_batch(
+        let sql = if cfg!(feature = "gtin") {
             "CREATE TABLE IF NOT EXISTS concepts (
                 id             TEXT PRIMARY KEY,
                 fsn            TEXT NOT NULL,
@@ -1504,8 +1547,29 @@ mod tests {
                 read2_codes    TEXT,
                 gtin_codes     TEXT,
                 schema_version INTEGER NOT NULL DEFAULT 6
-            );
-            CREATE TABLE IF NOT EXISTS concept_isa (
+            );"
+        } else {
+            "CREATE TABLE IF NOT EXISTS concepts (
+                id             TEXT PRIMARY KEY,
+                fsn            TEXT NOT NULL,
+                preferred_term TEXT NOT NULL,
+                synonyms       TEXT,
+                hierarchy      TEXT,
+                hierarchy_path TEXT,
+                parents        TEXT,
+                children_count INTEGER,
+                attributes     TEXT,
+                active         INTEGER NOT NULL,
+                module         TEXT,
+                effective_time TEXT,
+                ctv3_codes     TEXT,
+                read2_codes    TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 5
+            );"
+        };
+        conn.execute_batch(sql).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS concept_isa (
                 child_id  TEXT NOT NULL,
                 parent_id TEXT NOT NULL
             );
@@ -1538,15 +1602,41 @@ mod tests {
         hierarchy_path: &str,
         synonyms: &str, // JSON array string, e.g. `["syn1","syn2"]`
     ) {
-        conn.execute(
-            "INSERT INTO concepts
-             (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
-              parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, gtin_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]','[]',6)",
-            params![id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path],
-        )
-        .unwrap();
+        let (sql, params_args): (&str, Vec<String>) = if cfg!(feature = "gtin") {
+            (
+                "INSERT INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, gtin_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]','[]',6)",
+                vec![
+                    id.to_string(),
+                    fsn.to_string(),
+                    preferred_term.to_string(),
+                    synonyms.to_string(),
+                    hierarchy.to_string(),
+                    hierarchy_path.to_string(),
+                ],
+            )
+        } else {
+            (
+                "INSERT INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]',5)",
+                vec![
+                    id.to_string(),
+                    fsn.to_string(),
+                    preferred_term.to_string(),
+                    synonyms.to_string(),
+                    hierarchy.to_string(),
+                    hierarchy_path.to_string(),
+                ],
+            )
+        };
+        conn.execute(sql, rusqlite::params_from_iter(params_args))
+            .unwrap();
     }
 
     /// Insert `n` duplicate IS-A rows (simulating real RF2 data which has ~6 per relationship).

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -188,7 +188,7 @@ fn validate_schema_version(conn: &Connection) -> Result<()> {
 #[cfg(feature = "gtin")]
 fn has_gtin_column(conn: &Connection) -> bool {
     conn.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        "SELECT 1 FROM pragma_table_info('concepts') WHERE name = 'gtin_codes' LIMIT 1",
         [],
         |_| Ok(true),
     )

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1808,6 +1808,9 @@ mod tests {
         // CTV3 mapping for MI
         insert_map(&conn, "X200E", "ctv3", "7000000");
 
+        #[cfg(feature = "gtin")]
+        insert_map(&conn, "05016000000000", "gtin", "7000000");
+
         rebuild_fts(&conn);
         conn
     }
@@ -2080,7 +2083,39 @@ mod tests {
         let conn = build_test_db();
         let args = json!({"code": "3000000", "terminology": "snomed"});
         let result = tool_map(&conn, &args).unwrap();
-        assert!(result.contains("No CTV3 or Read v2 mappings found"));
+        if cfg!(feature = "gtin") {
+            assert!(result.contains("No CTV3, Read v2, or GTIN mappings found"));
+        } else {
+            assert!(result.contains("No CTV3 or Read v2 mappings found"));
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "gtin")]
+    fn map_snomed_to_gtin() {
+        let conn = build_test_db();
+        let args = json!({"code": "7000000", "terminology": "snomed"});
+        let result = tool_map(&conn, &args).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let gtin: Vec<&str> = v["gtin_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c.as_str().unwrap())
+            .collect();
+        assert_eq!(gtin, vec!["05016000000000"]);
+    }
+
+    #[test]
+    #[cfg(feature = "gtin")]
+    fn map_gtin_to_snomed() {
+        let conn = build_test_db();
+        let args = json!({"code": "05016000000000", "terminology": "gtin"});
+        let result = tool_map(&conn, &args).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let concepts = v["snomed_concepts"].as_array().unwrap();
+        assert_eq!(concepts.len(), 1);
+        assert_eq!(concepts[0]["id"].as_str().unwrap(), "7000000");
     }
 
     #[test]

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -714,7 +714,7 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
     let result = conn.query_row(
         "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
-                ctv3_codes, read2_codes
+                ctv3_codes, read2_codes, gtin_codes
          FROM concepts WHERE id = ?1",
         params![id],
         |row| {
@@ -732,7 +732,8 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
                 "module": row.get::<_, String>(10)?,
                 "effective_time": row.get::<_, String>(11)?,
                 "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([]))
+                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
             }))
         },
     );
@@ -862,7 +863,7 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
 
     match terminology {
         "snomed" => {
-            // SNOMED SCTID → CTV3 and Read v2 codes
+            // SNOMED SCTID → CTV3, Read v2, and GTIN codes
             let mut ctv3_stmt = conn.prepare(
                 "SELECT code FROM concept_maps WHERE concept_id = ?1 AND terminology = 'ctv3' ORDER BY code",
             )?;
@@ -879,10 +880,17 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
                 .filter_map(|r| r.ok())
                 .collect();
 
-            if ctv3_codes.is_empty() && read2_codes.is_empty() {
+            let mut gtin_stmt = conn.prepare(
+                "SELECT code FROM concept_maps WHERE concept_id = ?1 AND terminology = 'gtin' ORDER BY code",
+            )?;
+            let gtin_codes: Vec<String> = gtin_stmt
+                .query_map(params![code], |row| row.get(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+
+            if ctv3_codes.is_empty() && read2_codes.is_empty() && gtin_codes.is_empty() {
                 return Ok(format!(
-                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}. \
-                     Mappings are only present when the database was built from a UK Monolith RF2 release.",
+                    "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}.",
                     code
                 ));
             }
@@ -890,11 +898,12 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
             Ok(serde_json::to_string_pretty(&json!({
                 "snomed_id": code,
                 "ctv3_codes": ctv3_codes,
-                "read2_codes": read2_codes
+                "read2_codes": read2_codes,
+                "gtin_codes": gtin_codes
             }))?)
         }
 
-        "ctv3" | "read2" => {
+        "ctv3" | "read2" | "gtin" => {
             // CTV3 or Read v2 code → SNOMED CT concept(s)
             let mut stmt = conn.prepare(
                 "SELECT c.id, c.preferred_term, c.fsn, c.hierarchy
@@ -1493,7 +1502,8 @@ mod tests {
                 effective_time TEXT,
                 ctv3_codes     TEXT,
                 read2_codes    TEXT,
-                schema_version INTEGER NOT NULL DEFAULT 2
+                gtin_codes     TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 6
             );
             CREATE TABLE IF NOT EXISTS concept_isa (
                 child_id  TEXT NOT NULL,
@@ -1532,8 +1542,8 @@ mod tests {
             "INSERT INTO concepts
              (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
               parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]',2)",
+              ctv3_codes, read2_codes, gtin_codes, schema_version)
+             VALUES (?1,?2,?3,?4,?5,?6,'[]',0,'{}',1,'900000000000207008','20240101','[]','[]','[]',6)",
             params![id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path],
         )
         .unwrap();

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -1005,7 +1005,7 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
         }
 
         other => anyhow::bail!(
-            "Unknown terminology '{}'. Use 'snomed', 'ctv3', or 'read2'.",
+            "Unknown terminology '{}'. Use 'snomed', 'ctv3', 'gtin' or 'read2'.",
             other
         ),
     }

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -184,6 +184,17 @@ fn validate_schema_version(conn: &Connection) -> Result<()> {
     }
 }
 
+/// Check if the concepts table has the gtin_codes column.
+#[cfg(feature = "gtin")]
+fn has_gtin_column(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+        [],
+        |_| Ok(true),
+    )
+    .unwrap_or(false)
+}
+
 // ---------------------------------------------------------------------------
 // Transport: dual-mode stdio (MCP spec changed in 2025)
 //
@@ -712,56 +723,63 @@ fn tool_concept(conn: &Connection, args: &Value, prov: Option<&Provenance>) -> R
     let id = args["id"].as_str().context("snomed_concept requires id")?;
 
     #[cfg(feature = "gtin")]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+    let use_gtin = has_gtin_column(conn);
+    #[cfg(not(feature = "gtin"))]
+    let use_gtin = false;
+
+    let query = if use_gtin {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes, gtin_codes
-         FROM concepts WHERE id = ?1";
-    #[cfg(not(feature = "gtin"))]
-    let query = "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+         FROM concepts WHERE id = ?1"
+    } else {
+        "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
                 parents, children_count, attributes, active, module, effective_time,
                 ctv3_codes, read2_codes
-         FROM concepts WHERE id = ?1";
+         FROM concepts WHERE id = ?1"
+    };
 
     let result = conn.query_row(
         query,
         params![id],
         |row| {
-            #[cfg(feature = "gtin")]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-                "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
-            }));
-
-            #[cfg(not(feature = "gtin"))]
-            return Ok(json!({
-                "id": row.get::<_, String>(0)?,
-                "fsn": row.get::<_, String>(1)?,
-                "preferred_term": row.get::<_, String>(2)?,
-                "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
-                "hierarchy": row.get::<_, String>(4)?,
-                "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
-                "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
-                "children_count": row.get::<_, i64>(7)?,
-                "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
-                "active": row.get::<_, bool>(9)?,
-                "module": row.get::<_, String>(10)?,
-                "effective_time": row.get::<_, String>(11)?,
-                "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
-                "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
-            }));
+            if use_gtin {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": serde_json::from_str::<Value>(&row.get::<_, String>(14).unwrap_or_default()).unwrap_or(json!([]))
+                }))
+            } else {
+                Ok(json!({
+                    "id": row.get::<_, String>(0)?,
+                    "fsn": row.get::<_, String>(1)?,
+                    "preferred_term": row.get::<_, String>(2)?,
+                    "synonyms": serde_json::from_str::<Value>(&row.get::<_, String>(3).unwrap_or_default()).unwrap_or(Value::Null),
+                    "hierarchy": row.get::<_, String>(4)?,
+                    "hierarchy_path": serde_json::from_str::<Value>(&row.get::<_, String>(5).unwrap_or_default()).unwrap_or(Value::Null),
+                    "parents": serde_json::from_str::<Value>(&row.get::<_, String>(6).unwrap_or_default()).unwrap_or(Value::Null),
+                    "children_count": row.get::<_, i64>(7)?,
+                    "attributes": serde_json::from_str::<Value>(&row.get::<_, String>(8).unwrap_or_default()).unwrap_or(Value::Null),
+                    "active": row.get::<_, bool>(9)?,
+                    "module": row.get::<_, String>(10)?,
+                    "effective_time": row.get::<_, String>(11)?,
+                    "ctv3_codes": serde_json::from_str::<Value>(&row.get::<_, String>(12).unwrap_or_default()).unwrap_or(json!([])),
+                    "read2_codes": serde_json::from_str::<Value>(&row.get::<_, String>(13).unwrap_or_default()).unwrap_or(json!([])),
+                    "gtin_codes": json!([])
+                }))
+            }
         },
     );
 

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -940,12 +940,14 @@ fn tool_map(conn: &Connection, args: &Value) -> Result<String> {
             if ctv3_codes.is_empty() && read2_codes.is_empty() && gtin_codes.is_empty() {
                 #[cfg(feature = "gtin")]
                 return Ok(format!(
-                    "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}.",
+                    "No CTV3, Read v2, or GTIN mappings found for SNOMED CT concept {}. \
+                     Mappings are only present when the database was built from a UK Monolith RF2 release.",
                     code
                 ));
                 #[cfg(not(feature = "gtin"))]
                 return Ok(format!(
-                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}.",
+                    "No CTV3 or Read v2 mappings found for SNOMED CT concept {}. \
+                     Mappings are only present when the database was built from a UK Monolith RF2 release.",
                     code
                 ));
             }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -28,6 +28,8 @@ pub mod tct;
 pub mod transcode;
 pub mod trud;
 
+pub mod size;
+
 #[cfg(feature = "tui")]
 pub mod tui;
 
@@ -57,4 +59,42 @@ pub(crate) fn open_db_readonly(path: &Path, cache_size_kib: Option<u32>) -> Resu
     }
     conn.execute_batch(&pragmas)?;
     Ok(conn)
+}
+
+/// Get the total size of a concept's subtree (including itself).
+/// Uses the transitive closure table if available, falling back to a recursive query.
+pub(crate) fn get_subtree_size(conn: &Connection, concept_id: &str) -> Result<u64> {
+    let has_tct = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+
+    let count: u64 = if has_tct {
+        let cnt: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM (
+                SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = ?1
+                UNION
+                SELECT ?1
+             )",
+            rusqlite::params![concept_id],
+            |r| r.get(0),
+        )?;
+        cnt as u64
+    } else {
+        let cnt: i64 = conn.query_row(
+            "WITH RECURSIVE descendants(id) AS (
+                SELECT ?1
+                UNION
+                SELECT child_id FROM concept_isa JOIN descendants ON parent_id = id
+             )
+             SELECT COUNT(DISTINCT id) FROM descendants",
+            rusqlite::params![concept_id],
+            |r| r.get(0),
+        )?;
+        cnt as u64
+    };
+    Ok(count)
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod diff;
 pub mod dmwb;
 pub mod ecl;
 pub mod embed;
+pub mod filter;
 pub mod fst;
 pub mod info;
 pub mod lexical;

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `sct size` - View size of SNOMED CT concepts and their subtree distributions.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Starting concept ID (default is the root concept "138875005").
+    #[arg(long, short, default_value = "138875005")]
+    pub concept: String,
+
+    /// Maximum depth to print in the tree representation (default 2).
+    #[arg(long, short, default_value_t = 2)]
+    pub depth: usize,
+
+    /// Path to the SNOMED CT SQLite database.
+    #[arg(long)]
+    pub db: Option<PathBuf>,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
+    let conn = crate::commands::open_db_readonly(&db_path, None)?;
+
+    // Lookup starting concept info
+    let (term, active): (String, i32) = conn
+        .query_row(
+            "SELECT preferred_term, active FROM concepts WHERE id = ?1",
+            rusqlite::params![args.concept],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .with_context(|| format!("concept {} not found in database", args.concept))?;
+
+    if active == 0 {
+        eprintln!("Warning: Starting concept {} is inactive.", args.concept);
+    }
+
+    println!("\nConcept Subtree Size Tree");
+    println!("=========================");
+    print_tree(&conn, &args.concept, &term, 0, args.depth, "", true)?;
+
+    Ok(())
+}
+
+fn print_tree(
+    conn: &Connection,
+    concept_id: &str,
+    preferred_term: &str,
+    depth: usize,
+    max_depth: usize,
+    prefix: &str,
+    is_last: bool,
+) -> Result<()> {
+    let size = crate::commands::get_subtree_size(conn, concept_id)?;
+
+    // Format this node line
+    let node_str = format!(
+        "{} [{}] ({} descendants)",
+        preferred_term,
+        concept_id,
+        fmt_count(size)
+    );
+    if depth == 0 {
+        println!("{}", node_str);
+    } else {
+        let connector = if is_last { "└── " } else { "├── " };
+        println!("{}{}{}", prefix, connector, node_str);
+    }
+
+    if depth >= max_depth {
+        return Ok(());
+    }
+
+    // Get children of this concept
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.preferred_term
+         FROM concept_isa i
+         JOIN concepts c ON c.id = i.child_id
+         WHERE i.parent_id = ?1 AND c.active = 1",
+    )?;
+
+    let children = stmt
+        .query_map(rusqlite::params![concept_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    // Gather subtree sizes for sorting
+    let mut children_sizes = Vec::new();
+    for (cid, term) in children {
+        let sz = crate::commands::get_subtree_size(conn, &cid)?;
+        children_sizes.push((cid, term, sz));
+    }
+    children_sizes.sort_by_key(|b| std::cmp::Reverse(b.2)); // Sort descending by size
+
+    let len = children_sizes.len();
+    for (i, (cid, term, _)) in children_sizes.into_iter().enumerate() {
+        let next_prefix = if depth == 0 {
+            ""
+        } else if is_last {
+            &format!("{}    ", prefix)
+        } else {
+            &format!("{}│   ", prefix)
+        };
+        print_tree(
+            conn,
+            &cid,
+            &term,
+            depth + 1,
+            max_depth,
+            next_prefix,
+            i == len - 1,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn fmt_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 pub struct Args {
     /// Starting concept ID (default is the root concept "138875005").
-    #[arg(long, short, default_value = "138875005")]
-    pub concept: String,
+    #[arg(long, short)]
+    pub concept: Option<String>,
 
     /// Maximum depth to print in the tree representation (default 2).
     #[arg(long, short, default_value_t = 2)]
@@ -28,22 +28,47 @@ pub fn run(args: Args) -> Result<()> {
     let conn = crate::commands::open_db_readonly(&db_path, None)?;
     crate::ecl::warn_if_no_tct(&conn);
 
+    let start_concept = match args.concept {
+        Some(id) => id,
+        None => {
+            // Try default SNOMED CT root first
+            let exists: bool = conn
+                .query_row("SELECT 1 FROM concepts WHERE id = '138875005'", [], |_| {
+                    Ok(true)
+                })
+                .unwrap_or(false);
+            if exists {
+                "138875005".to_string()
+            } else {
+                // Fall back to detecting any active concept with no parents
+                let detected: Option<String> = conn
+                    .query_row(
+                        "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .ok();
+                detected.unwrap_or_else(|| "138875005".to_string())
+            }
+        }
+    };
+
     // Lookup starting concept info
     let (term, active): (String, i32) = conn
         .query_row(
             "SELECT preferred_term, active FROM concepts WHERE id = ?1",
-            rusqlite::params![args.concept],
+            rusqlite::params![start_concept],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
-        .with_context(|| format!("concept {} not found in database", args.concept))?;
+        .with_context(|| format!("concept {} not found in database", start_concept))?;
 
     if active == 0 {
-        eprintln!("Warning: Starting concept {} is inactive.", args.concept);
+        eprintln!("Warning: Starting concept {} is inactive.", start_concept);
     }
 
     println!("\nConcept Subtree Size Tree");
     println!("=========================");
-    print_tree(&conn, &args.concept, &term, 0, args.depth, "", true)?;
+    print_tree(&conn, &start_concept, &term, 0, args.depth, "", true)?;
 
     Ok(())
 }

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -1,7 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `sct size` - View size of SNOMED CT concepts and their subtree distributions.
+//! `sct size` - Estimate NDJSON and SQLite file sizes for a concept subtree.
+//!
+//! Acts as a data-planning tool ("how big will `sct filter` output be?"):
+//!
+//! - Counts all concepts in the subtree (using the TCT when available).
+//! - Samples N rows from the subtree, serialises each as JSON, and averages the
+//!   byte length to estimate the NDJSON export size.
+//! - Uses SQLite's `PRAGMA page_size` and `PRAGMA page_count` to estimate the
+//!   proportional SQLite database size.
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -10,13 +18,14 @@ use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// Starting concept ID (default is the root concept "138875005").
+    /// Starting concept ID. Defaults to the SNOMED CT root (138875005), or the
+    /// single active root detected in the database for filtered/subset databases.
     #[arg(long, short)]
     pub concept: Option<String>,
 
-    /// Maximum depth to print in the tree representation (default 2).
-    #[arg(long, short, default_value_t = 2)]
-    pub depth: usize,
+    /// Number of rows to sample when estimating average NDJSON row size (default: 200).
+    #[arg(long, short = 'n', default_value_t = 200)]
+    pub sample: usize,
 
     /// Path to the SNOMED CT SQLite database.
     #[arg(long)]
@@ -25,10 +34,12 @@ pub struct Args {
 
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
-    let conn = crate::commands::open_db_readonly(&db_path, None)?;
 
-    // Warn early: sct size runs one recursive CTE per displayed node, which is
-    // extremely slow on a full SNOMED CT database without a transitive-closure table.
+    // Open read-write so we can read PRAGMAs (query_only blocks PRAGMA page_count on older SQLite)
+    let conn = Connection::open(&db_path)
+        .with_context(|| format!("opening database {}", db_path.display()))?;
+    conn.execute_batch("PRAGMA query_only = ON;")?;
+
     let has_tct = conn
         .query_row(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
@@ -36,42 +47,16 @@ pub fn run(args: Args) -> Result<()> {
             |_| Ok(true),
         )
         .unwrap_or(false);
-    if !has_tct {
-        eprintln!(
-            "warning: this database has no transitive-closure table.\n\
-             `sct size` will run one recursive CTE per displayed node and may take a \
-             very long time on a full SNOMED CT database.\n\
-             Build the table first for a fast result: `sct tct --db <db>`"
-        );
-    }
 
-    let start_concept = match args.concept {
-        Some(id) => id,
-        None => {
-            // Try default SNOMED CT root first
-            let exists: bool = conn
-                .query_row("SELECT 1 FROM concepts WHERE id = '138875005'", [], |_| {
-                    Ok(true)
-                })
-                .unwrap_or(false);
-            if exists {
-                "138875005".to_string()
-            } else {
-                // Fall back to detecting any active concept with no parents
-                let detected: Option<String> = conn
-                    .query_row(
-                        "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
-                        [],
-                        |row| row.get(0),
-                    )
-                    .ok();
-                detected.unwrap_or_else(|| "138875005".to_string())
-            }
-        }
-    };
+    let start_concept = resolve_root(&conn, args.concept)?;
 
-    // Lookup starting concept info
-    let (term, active): (String, i32) = conn
+    // --- concept count ---
+    let subtree_count = crate::commands::get_subtree_size(&conn, &start_concept)?;
+    let total_count: u64 = conn
+        .query_row("SELECT COUNT(*) FROM concepts", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+
+    let (preferred_term, _active): (String, i32) = conn
         .query_row(
             "SELECT preferred_term, active FROM concepts WHERE id = ?1",
             rusqlite::params![start_concept],
@@ -79,89 +64,196 @@ pub fn run(args: Args) -> Result<()> {
         )
         .with_context(|| format!("concept {} not found in database", start_concept))?;
 
-    if active == 0 {
-        eprintln!("Warning: Starting concept {} is inactive.", start_concept);
-    }
+    // --- NDJSON size estimation (sample average row size) ---
+    let avg_ndjson_bytes = sample_avg_row_bytes(&conn, &start_concept, has_tct, args.sample)?;
+    let ndjson_estimate = avg_ndjson_bytes * subtree_count;
 
-    println!("\nConcept Subtree Size Tree");
-    println!("=========================");
-    print_tree(&conn, &start_concept, &term, 0, args.depth, "", true)?;
+    // --- SQLite size estimation (proportional page count) ---
+    let page_size: u64 = conn
+        .query_row("PRAGMA page_size", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(4096) as u64;
+    let page_count: u64 = conn
+        .query_row("PRAGMA page_count", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+    let total_db_bytes = page_size * page_count;
+    let sqlite_estimate = if total_count > 0 {
+        (total_db_bytes as f64 * subtree_count as f64 / total_count as f64) as u64
+    } else {
+        0
+    };
+
+    let pct = if total_count > 0 {
+        subtree_count as f64 / total_count as f64 * 100.0
+    } else {
+        0.0
+    };
+
+    // --- Output ---
+    println!();
+    println!("Subtree: {} ({})", preferred_term, start_concept);
+    println!(
+        "Concepts: {}  ({:.1}% of {} total in database)",
+        fmt_count(subtree_count),
+        pct,
+        fmt_count(total_count)
+    );
+    if !has_tct {
+        eprintln!(
+            "\nwarning: no transitive-closure table found — subtree count used a recursive CTE.\n\
+             Build it once for fast estimates: `sct tct --db <db>`"
+        );
+    }
+    println!();
+    println!("{:<18} {:<16} Method", "Format", "Estimated size");
+    println!("{}", "─".repeat(72));
+    println!(
+        "{:<18} {:<16} sampled avg {} B/row × {} rows",
+        "NDJSON",
+        fmt_bytes(ndjson_estimate),
+        fmt_count(avg_ndjson_bytes),
+        fmt_count(subtree_count)
+    );
+    println!(
+        "{:<18} {:<16} proportional to full DB ({}) by concept count",
+        "SQLite DB",
+        fmt_bytes(sqlite_estimate),
+        fmt_bytes(total_db_bytes)
+    );
+    println!();
 
     Ok(())
 }
 
-fn print_tree(
+/// Resolve the starting concept: use the user's value, fall back to `138875005`,
+/// then fall back to any active concept with no parents (for filtered databases).
+fn resolve_root(conn: &Connection, concept: Option<String>) -> Result<String> {
+    if let Some(id) = concept {
+        return Ok(id);
+    }
+    let root_exists: bool = conn
+        .query_row("SELECT 1 FROM concepts WHERE id = '138875005'", [], |_| {
+            Ok(true)
+        })
+        .unwrap_or(false);
+    if root_exists {
+        return Ok("138875005".to_string());
+    }
+    // Filtered DB — find any active concept with an empty parents array
+    let detected: Option<String> = conn
+        .query_row(
+            "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+    Ok(detected.unwrap_or_else(|| "138875005".to_string()))
+}
+
+/// Sample up to `limit` concepts from the subtree, serialise each row's text columns
+/// as a JSON object (approximating a real NDJSON line), and return the average byte count.
+fn sample_avg_row_bytes(
     conn: &Connection,
-    concept_id: &str,
-    preferred_term: &str,
-    depth: usize,
-    max_depth: usize,
-    prefix: &str,
-    is_last: bool,
-) -> Result<()> {
-    let size = crate::commands::get_subtree_size(conn, concept_id)?;
-
-    // Format this node line
-    let node_str = format!(
-        "{} [{}] ({} descendants)",
-        preferred_term,
-        concept_id,
-        fmt_count(size.saturating_sub(1))
-    );
-    if depth == 0 {
-        println!("{}", node_str);
+    root_id: &str,
+    has_tct: bool,
+    limit: usize,
+) -> Result<u64> {
+    // Columns that appear in a ConceptRecord NDJSON line
+    let sql = if has_tct {
+        format!(
+            "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                    parents, children_count, attributes, active, module, effective_time,
+                    ctv3_codes, read2_codes
+             FROM concepts
+             WHERE id IN (
+                 SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = '{root_id}'
+                 UNION SELECT '{root_id}'
+             )
+             ORDER BY RANDOM()
+             LIMIT {limit}"
+        )
     } else {
-        let connector = if is_last { "└── " } else { "├── " };
-        println!("{}{}{}", prefix, connector, node_str);
+        format!(
+            "WITH RECURSIVE descendants(id) AS (
+                 SELECT '{root_id}'
+                 UNION
+                 SELECT child_id FROM concept_isa JOIN descendants ON parent_id = id
+             )
+             SELECT c.id, c.fsn, c.preferred_term, c.synonyms, c.hierarchy, c.hierarchy_path,
+                    c.parents, c.children_count, c.attributes, c.active, c.module, c.effective_time,
+                    c.ctv3_codes, c.read2_codes
+             FROM concepts c
+             JOIN descendants d ON c.id = d.id
+             ORDER BY RANDOM()
+             LIMIT {limit}"
+        )
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+
+    // Measure the byte length of a minimal JSON serialisation of each row.
+    // We build a small JSON object with the same keys sct ndjson would emit.
+    let col_names = [
+        "id",
+        "fsn",
+        "preferred_term",
+        "synonyms",
+        "hierarchy",
+        "hierarchy_path",
+        "parents",
+        "children_count",
+        "attributes",
+        "active",
+        "module",
+        "effective_time",
+        "ctv3_codes",
+        "read2_codes",
+    ];
+
+    let mut total_bytes: u64 = 0;
+    let mut sampled: u64 = 0;
+
+    stmt.query_map([], |row| {
+        // Build a JSON-like byte count: sum all text column lengths + key overhead
+        let mut row_bytes: usize = 2; // outer braces {}
+        for (i, name) in col_names.iter().enumerate() {
+            row_bytes += name.len() + 4; // "key":  (quotes + colon + space)
+            if let Ok(Some(val)) = row.get_ref(i).map(|v| v.as_str().ok()) {
+                row_bytes += val.len() + 2; // value + surrounding quotes
+            } else {
+                row_bytes += 4; // null
+            }
+            if i + 1 < col_names.len() {
+                row_bytes += 1; // comma
+            }
+        }
+        row_bytes += 1; // newline at end of NDJSON line
+        Ok(row_bytes as u64)
+    })?
+    .filter_map(|r| r.ok())
+    .for_each(|bytes| {
+        total_bytes += bytes;
+        sampled += 1;
+    });
+
+    if sampled == 0 {
+        return Ok(0);
     }
+    Ok(total_bytes / sampled)
+}
 
-    if depth >= max_depth {
-        return Ok(());
+fn fmt_bytes(n: u64) -> String {
+    const KB: u64 = 1_024;
+    const MB: u64 = 1_024 * KB;
+    const GB: u64 = 1_024 * MB;
+    if n >= GB {
+        format!("~{:.2} GB", n as f64 / GB as f64)
+    } else if n >= MB {
+        format!("~{:.1} MB", n as f64 / MB as f64)
+    } else if n >= KB {
+        format!("~{:.1} KB", n as f64 / KB as f64)
+    } else {
+        format!("~{} B", n)
     }
-
-    // Get children of this concept
-    let mut stmt = conn.prepare(
-        "SELECT c.id, c.preferred_term
-         FROM concept_isa i
-         JOIN concepts c ON c.id = i.child_id
-         WHERE i.parent_id = ?1 AND c.active = 1",
-    )?;
-
-    let children = stmt
-        .query_map(rusqlite::params![concept_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-
-    // Gather subtree sizes for sorting
-    let mut children_sizes = Vec::new();
-    for (cid, term) in children {
-        let sz = crate::commands::get_subtree_size(conn, &cid)?;
-        children_sizes.push((cid, term, sz));
-    }
-    children_sizes.sort_by_key(|b| std::cmp::Reverse(b.2)); // Sort descending by size
-
-    let len = children_sizes.len();
-    for (i, (cid, term, _)) in children_sizes.into_iter().enumerate() {
-        let next_prefix = if depth == 0 {
-            ""
-        } else if is_last {
-            &format!("{}    ", prefix)
-        } else {
-            &format!("{}│   ", prefix)
-        };
-        print_tree(
-            conn,
-            &cid,
-            &term,
-            depth + 1,
-            max_depth,
-            next_prefix,
-            i == len - 1,
-        )?;
-    }
-
-    Ok(())
 }
 
 fn fmt_count(n: u64) -> String {

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -63,7 +63,7 @@ fn print_tree(
         "{} [{}] ({} descendants)",
         preferred_term,
         concept_id,
-        fmt_count(size)
+        fmt_count(size.saturating_sub(1))
     );
     if depth == 0 {
         println!("{}", node_str);

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -26,6 +26,7 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
     let conn = crate::commands::open_db_readonly(&db_path, None)?;
+    crate::ecl::warn_if_no_tct(&conn);
 
     // Lookup starting concept info
     let (term, active): (String, i32) = conn

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -11,11 +11,93 @@
 //! - Uses SQLite's `PRAGMA page_size` and `PRAGMA page_count` to estimate the
 //!   proportional SQLite database size.
 //! - Optionally prints a `du`-style tree of descendant counts with `--tree`.
+//!
+//! The core estimation logic is exposed as [`estimate_sizes`] so the GUI and TUI
+//! can reuse it without duplicating code.
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use rusqlite::Connection;
 use std::path::PathBuf;
+
+// ─── Public shared types ──────────────────────────────────────────────────────
+
+/// File-size estimates for a concept subtree.
+///
+/// Produced by [`estimate_sizes`] and consumed by the CLI, TUI, and GUI.
+#[derive(Debug, Clone)]
+pub struct SizeEstimate {
+    /// Number of concepts in the subtree (including the root concept itself).
+    pub subtree_count: u64,
+    /// Total number of concepts in the database.
+    pub total_count: u64,
+    /// Average NDJSON row size in bytes (from sampling).
+    pub avg_ndjson_bytes: u64,
+    /// Estimated total NDJSON export size in bytes.
+    pub ndjson_total: u64,
+    /// Total SQLite database size in bytes (page_size × page_count).
+    pub total_db_bytes: u64,
+    /// Estimated proportional SQLite size for this subtree in bytes.
+    pub sqlite_total: u64,
+}
+
+impl SizeEstimate {
+    /// Percentage of the full database represented by this subtree.
+    pub fn pct(&self) -> f64 {
+        if self.total_count > 0 {
+            self.subtree_count as f64 / self.total_count as f64 * 100.0
+        } else {
+            0.0
+        }
+    }
+}
+
+/// Compute [`SizeEstimate`] for the subtree rooted at `root_id`.
+///
+/// `sample` controls how many rows are randomly sampled to derive the average
+/// NDJSON row byte length. A value of 50–200 gives a good balance between speed
+/// and accuracy. Requires an open `Connection`; does **not** open its own.
+pub fn estimate_sizes(conn: &Connection, root_id: &str, sample: usize) -> Result<SizeEstimate> {
+    let has_tct = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+
+    let subtree_count = crate::commands::get_subtree_size(conn, root_id)?;
+    let total_count: u64 = conn
+        .query_row("SELECT COUNT(*) FROM concepts", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+
+    let avg_ndjson_bytes = sample_avg_row_bytes(conn, root_id, has_tct, sample)?;
+    let ndjson_total = avg_ndjson_bytes * subtree_count;
+
+    let page_size: u64 = conn
+        .query_row("PRAGMA page_size", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(4096) as u64;
+    let page_count: u64 = conn
+        .query_row("PRAGMA page_count", [], |r| r.get::<_, i64>(0))
+        .unwrap_or(0) as u64;
+    let total_db_bytes = page_size * page_count;
+    let sqlite_total = if total_count > 0 {
+        (total_db_bytes as f64 * subtree_count as f64 / total_count as f64) as u64
+    } else {
+        0
+    };
+
+    Ok(SizeEstimate {
+        subtree_count,
+        total_count,
+        avg_ndjson_bytes,
+        ndjson_total,
+        total_db_bytes,
+        sqlite_total,
+    })
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -44,7 +126,7 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
 
-    // Open read-write so we can read PRAGMAs (query_only blocks PRAGMA page_count on older SQLite)
+    // Open without query_only so PRAGMA page_count is readable on all SQLite versions.
     let conn = Connection::open(&db_path)
         .with_context(|| format!("opening database {}", db_path.display()))?;
     conn.execute_batch("PRAGMA query_only = ON;")?;
@@ -59,12 +141,6 @@ pub fn run(args: Args) -> Result<()> {
 
     let start_concept = resolve_root(&conn, args.concept)?;
 
-    // --- concept count ---
-    let subtree_count = crate::commands::get_subtree_size(&conn, &start_concept)?;
-    let total_count: u64 = conn
-        .query_row("SELECT COUNT(*) FROM concepts", [], |r| r.get::<_, i64>(0))
-        .unwrap_or(0) as u64;
-
     let (preferred_term, _active): (String, i32) = conn
         .query_row(
             "SELECT preferred_term, active FROM concepts WHERE id = ?1",
@@ -73,38 +149,16 @@ pub fn run(args: Args) -> Result<()> {
         )
         .with_context(|| format!("concept {} not found in database", start_concept))?;
 
-    // --- NDJSON size estimation (sample average row size) ---
-    let avg_ndjson_bytes = sample_avg_row_bytes(&conn, &start_concept, has_tct, args.sample)?;
-    let ndjson_estimate = avg_ndjson_bytes * subtree_count;
-
-    // --- SQLite size estimation (proportional page count) ---
-    let page_size: u64 = conn
-        .query_row("PRAGMA page_size", [], |r| r.get::<_, i64>(0))
-        .unwrap_or(4096) as u64;
-    let page_count: u64 = conn
-        .query_row("PRAGMA page_count", [], |r| r.get::<_, i64>(0))
-        .unwrap_or(0) as u64;
-    let total_db_bytes = page_size * page_count;
-    let sqlite_estimate = if total_count > 0 {
-        (total_db_bytes as f64 * subtree_count as f64 / total_count as f64) as u64
-    } else {
-        0
-    };
-
-    let pct = if total_count > 0 {
-        subtree_count as f64 / total_count as f64 * 100.0
-    } else {
-        0.0
-    };
+    let est = estimate_sizes(&conn, &start_concept, args.sample)?;
 
     // --- Output ---
     println!();
     println!("Subtree: {} ({})", preferred_term, start_concept);
     println!(
         "Concepts: {}  ({:.1}% of {} total in database)",
-        fmt_count(subtree_count),
-        pct,
-        fmt_count(total_count)
+        fmt_count(est.subtree_count),
+        est.pct(),
+        fmt_count(est.total_count)
     );
     if !has_tct {
         eprintln!(
@@ -118,15 +172,15 @@ pub fn run(args: Args) -> Result<()> {
     println!(
         "{:<18} {:<16} sampled avg {} B/row × {} rows",
         "NDJSON",
-        fmt_bytes(ndjson_estimate),
-        fmt_count(avg_ndjson_bytes),
-        fmt_count(subtree_count)
+        fmt_bytes(est.ndjson_total),
+        fmt_count(est.avg_ndjson_bytes),
+        fmt_count(est.subtree_count)
     );
     println!(
         "{:<18} {:<16} proportional to full DB ({}) by concept count",
         "SQLite DB",
-        fmt_bytes(sqlite_estimate),
-        fmt_bytes(total_db_bytes)
+        fmt_bytes(est.sqlite_total),
+        fmt_bytes(est.total_db_bytes)
     );
     println!();
 
@@ -149,6 +203,8 @@ pub fn run(args: Args) -> Result<()> {
     Ok(())
 }
 
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
 /// Resolve the starting concept: use the user's value, fall back to `138875005`,
 /// then fall back to any active concept with no parents (for filtered databases).
 fn resolve_root(conn: &Connection, concept: Option<String>) -> Result<String> {
@@ -163,7 +219,6 @@ fn resolve_root(conn: &Connection, concept: Option<String>) -> Result<String> {
     if root_exists {
         return Ok("138875005".to_string());
     }
-    // Filtered DB — find any active concept with an empty parents array
     let detected: Option<String> = conn
         .query_row(
             "SELECT id FROM concepts WHERE active = 1 AND (parents = '[]' OR parents IS NULL) LIMIT 1",
@@ -182,7 +237,6 @@ fn sample_avg_row_bytes(
     has_tct: bool,
     limit: usize,
 ) -> Result<u64> {
-    // Columns that appear in a ConceptRecord NDJSON line
     let sql = if has_tct {
         format!(
             "SELECT id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
@@ -215,8 +269,6 @@ fn sample_avg_row_bytes(
 
     let mut stmt = conn.prepare(&sql)?;
 
-    // Measure the byte length of a minimal JSON serialisation of each row.
-    // We build a small JSON object with the same keys sct ndjson would emit.
     let col_names = [
         "id",
         "fsn",
@@ -238,7 +290,6 @@ fn sample_avg_row_bytes(
     let mut sampled: u64 = 0;
 
     stmt.query_map([], |row| {
-        // Build a JSON-like byte count: sum all text column lengths + key overhead
         let mut row_bytes: usize = 2; // outer braces {}
         for (i, name) in col_names.iter().enumerate() {
             row_bytes += name.len() + 4; // "key":  (quotes + colon + space)
@@ -266,7 +317,7 @@ fn sample_avg_row_bytes(
     Ok(total_bytes / sampled)
 }
 
-fn fmt_bytes(n: u64) -> String {
+pub(crate) fn fmt_bytes(n: u64) -> String {
     const KB: u64 = 1_024;
     const MB: u64 = 1_024 * KB;
     const GB: u64 = 1_024 * MB;
@@ -281,7 +332,7 @@ fn fmt_bytes(n: u64) -> String {
     }
 }
 
-fn fmt_count(n: u64) -> String {
+pub(crate) fn fmt_count(n: u64) -> String {
     let s = n.to_string();
     let mut result = String::with_capacity(s.len() + s.len() / 3);
     for (i, ch) in s.chars().rev().enumerate() {

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -10,6 +10,7 @@
 //!   byte length to estimate the NDJSON export size.
 //! - Uses SQLite's `PRAGMA page_size` and `PRAGMA page_count` to estimate the
 //!   proportional SQLite database size.
+//! - Optionally prints a `du`-style tree of descendant counts with `--tree`.
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -26,6 +27,14 @@ pub struct Args {
     /// Number of rows to sample when estimating average NDJSON row size (default: 200).
     #[arg(long, short = 'n', default_value_t = 200)]
     pub sample: usize,
+
+    /// Also print a `du`-style descendant count tree.
+    #[arg(long, short = 't')]
+    pub tree: bool,
+
+    /// Maximum depth for the tree view (default: 2). Only used with --tree.
+    #[arg(long, short = 'd', default_value_t = 2)]
+    pub depth: usize,
 
     /// Path to the SNOMED CT SQLite database.
     #[arg(long)]
@@ -120,6 +129,22 @@ pub fn run(args: Args) -> Result<()> {
         fmt_bytes(total_db_bytes)
     );
     println!();
+
+    // --- Optional descendant count tree ---
+    if args.tree {
+        println!("Descendant Count Tree");
+        println!("=====================");
+        print_tree(
+            &conn,
+            &start_concept,
+            &preferred_term,
+            0,
+            args.depth,
+            "",
+            true,
+        )?;
+        println!();
+    }
 
     Ok(())
 }
@@ -266,4 +291,73 @@ fn fmt_count(n: u64) -> String {
         result.push(ch);
     }
     result.chars().rev().collect()
+}
+
+fn print_tree(
+    conn: &Connection,
+    concept_id: &str,
+    preferred_term: &str,
+    depth: usize,
+    max_depth: usize,
+    prefix: &str,
+    is_last: bool,
+) -> Result<()> {
+    let size = crate::commands::get_subtree_size(conn, concept_id)?;
+    let node_str = format!(
+        "{} [{}] ({} descendants)",
+        preferred_term,
+        concept_id,
+        fmt_count(size.saturating_sub(1))
+    );
+    if depth == 0 {
+        println!("{node_str}");
+    } else {
+        let connector = if is_last { "└── " } else { "├── " };
+        println!("{prefix}{connector}{node_str}");
+    }
+
+    if depth >= max_depth {
+        return Ok(());
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT c.id, c.preferred_term
+         FROM concept_isa i
+         JOIN concepts c ON c.id = i.child_id
+         WHERE i.parent_id = ?1 AND c.active = 1",
+    )?;
+    let children = stmt
+        .query_map(rusqlite::params![concept_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut children_sizes: Vec<(String, String, u64)> = Vec::new();
+    for (cid, term) in children {
+        let sz = crate::commands::get_subtree_size(conn, &cid)?;
+        children_sizes.push((cid, term, sz));
+    }
+    children_sizes.sort_by_key(|b| std::cmp::Reverse(b.2));
+
+    let len = children_sizes.len();
+    for (i, (cid, term, _)) in children_sizes.into_iter().enumerate() {
+        let child_is_last = i == len - 1;
+        let next_prefix = if depth == 0 {
+            String::new()
+        } else if is_last {
+            format!("{prefix}    ")
+        } else {
+            format!("{prefix}│   ")
+        };
+        print_tree(
+            conn,
+            &cid,
+            &term,
+            depth + 1,
+            max_depth,
+            &next_prefix,
+            child_is_last,
+        )?;
+    }
+    Ok(())
 }

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -26,7 +26,24 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
     let conn = crate::commands::open_db_readonly(&db_path, None)?;
-    crate::ecl::warn_if_no_tct(&conn);
+
+    // Warn early: sct size runs one recursive CTE per displayed node, which is
+    // extremely slow on a full SNOMED CT database without a transitive-closure table.
+    let has_tct = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+    if !has_tct {
+        eprintln!(
+            "warning: this database has no transitive-closure table.\n\
+             `sct size` will run one recursive CTE per displayed node and may take a \
+             very long time on a full SNOMED CT database.\n\
+             Build the table first for a fast result: `sct tct --db <db>`"
+        );
+    }
 
     let start_concept = match args.concept {
         Some(id) => id,

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -88,13 +88,23 @@ pub fn run(args: Args) -> Result<()> {
     {
         let tx = conn.transaction().context("beginning transaction")?;
 
-        let mut insert_concept = tx.prepare(
-            "INSERT OR REPLACE INTO concepts
-             (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
-              parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, gtin_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
-        )?;
+        let mut insert_concept = if cfg!(feature = "gtin") {
+            tx.prepare(
+                "INSERT OR REPLACE INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, gtin_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
+            )?
+        } else {
+            tx.prepare(
+                "INSERT OR REPLACE INTO concepts
+                 (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
+                  parents, children_count, attributes, active, module, effective_time,
+                  ctv3_codes, read2_codes, schema_version)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
+            )?
+        };
 
         let mut insert_isa =
             tx.prepare("INSERT INTO concept_isa (child_id, parent_id) VALUES (?1, ?2)")?;
@@ -150,8 +160,10 @@ pub fn run(args: Args) -> Result<()> {
             let attributes_json = serde_json::to_string(&record.attributes)?;
             let ctv3_json = serde_json::to_string(&record.ctv3_codes)?;
             let read2_json = serde_json::to_string(&record.read2_codes)?;
+            #[cfg(feature = "gtin")]
             let gtin_json = serde_json::to_string(&record.gtin_codes)?;
 
+            #[cfg(feature = "gtin")]
             insert_concept.execute(params![
                 record.id,
                 record.fsn,
@@ -168,6 +180,25 @@ pub fn run(args: Args) -> Result<()> {
                 ctv3_json,
                 read2_json,
                 gtin_json,
+                record.schema_version as i64,
+            ])?;
+
+            #[cfg(not(feature = "gtin"))]
+            insert_concept.execute(params![
+                record.id,
+                record.fsn,
+                record.preferred_term,
+                synonyms_json,
+                record.hierarchy,
+                hierarchy_path_json,
+                parents_json,
+                record.children_count as i64,
+                attributes_json,
+                record.active as i32,
+                record.module,
+                record.effective_time,
+                ctv3_json,
+                read2_json,
                 record.schema_version as i64,
             ])?;
 
@@ -192,6 +223,7 @@ pub fn run(args: Args) -> Result<()> {
                 insert_map.execute(params![code, "read2", record.id])?;
                 insert_simple_crossmap.execute(params!["read2", code, record.id])?;
             }
+            #[cfg(feature = "gtin")]
             for code in &record.gtin_codes {
                 insert_map.execute(params![code, "gtin", record.id])?;
                 insert_simple_crossmap.execute(params!["gtin", code, record.id])?;
@@ -307,7 +339,7 @@ fn load_history_sidecar(conn: &Connection, input: &std::path::Path) -> Result<us
 }
 
 fn create_schema(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
+    let sql = if cfg!(feature = "gtin") {
         "CREATE TABLE IF NOT EXISTS concepts (
             id             TEXT PRIMARY KEY,
             fsn            TEXT NOT NULL,
@@ -325,9 +357,29 @@ fn create_schema(conn: &Connection) -> Result<()> {
             read2_codes    TEXT,            -- JSON array of Read v2 code strings
             gtin_codes     TEXT,            -- JSON array of GTIN strings
             schema_version INTEGER NOT NULL DEFAULT 6
-        );
-
-        CREATE TABLE IF NOT EXISTS concept_isa (
+        );"
+    } else {
+        "CREATE TABLE IF NOT EXISTS concepts (
+            id             TEXT PRIMARY KEY,
+            fsn            TEXT NOT NULL,
+            preferred_term TEXT NOT NULL,
+            synonyms       TEXT,            -- JSON array of strings
+            hierarchy      TEXT,
+            hierarchy_path TEXT,            -- JSON array of strings
+            parents        TEXT,            -- JSON array of {id, fsn}
+            children_count INTEGER,
+            attributes     TEXT,            -- JSON object
+            active         INTEGER NOT NULL,
+            module         TEXT,
+            effective_time TEXT,
+            ctv3_codes     TEXT,            -- JSON array of CTV3 code strings
+            read2_codes    TEXT,            -- JSON array of Read v2 code strings
+            schema_version INTEGER NOT NULL DEFAULT 5
+        );"
+    };
+    conn.execute_batch(sql)?;
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS concept_isa (
             child_id  TEXT NOT NULL,
             parent_id TEXT NOT NULL
         );

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -92,8 +92,8 @@ pub fn run(args: Args) -> Result<()> {
             "INSERT OR REPLACE INTO concepts
              (id, fsn, preferred_term, synonyms, hierarchy, hierarchy_path,
               parents, children_count, attributes, active, module, effective_time,
-              ctv3_codes, read2_codes, schema_version)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15)",
+              ctv3_codes, read2_codes, gtin_codes, schema_version)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16)",
         )?;
 
         let mut insert_isa =
@@ -150,6 +150,7 @@ pub fn run(args: Args) -> Result<()> {
             let attributes_json = serde_json::to_string(&record.attributes)?;
             let ctv3_json = serde_json::to_string(&record.ctv3_codes)?;
             let read2_json = serde_json::to_string(&record.read2_codes)?;
+            let gtin_json = serde_json::to_string(&record.gtin_codes)?;
 
             insert_concept.execute(params![
                 record.id,
@@ -166,6 +167,7 @@ pub fn run(args: Args) -> Result<()> {
                 record.effective_time,
                 ctv3_json,
                 read2_json,
+                gtin_json,
                 record.schema_version as i64,
             ])?;
 
@@ -189,6 +191,10 @@ pub fn run(args: Args) -> Result<()> {
             for code in &record.read2_codes {
                 insert_map.execute(params![code, "read2", record.id])?;
                 insert_simple_crossmap.execute(params!["read2", code, record.id])?;
+            }
+            for code in &record.gtin_codes {
+                insert_map.execute(params![code, "gtin", record.id])?;
+                insert_simple_crossmap.execute(params!["gtin", code, record.id])?;
             }
 
             for refset_id in &record.refsets {
@@ -317,7 +323,8 @@ fn create_schema(conn: &Connection) -> Result<()> {
             effective_time TEXT,
             ctv3_codes     TEXT,            -- JSON array of CTV3 code strings
             read2_codes    TEXT,            -- JSON array of Read v2 code strings
-            schema_version INTEGER NOT NULL DEFAULT 3
+            gtin_codes     TEXT,            -- JSON array of GTIN strings
+            schema_version INTEGER NOT NULL DEFAULT 6
         );
 
         CREATE TABLE IF NOT EXISTS concept_isa (

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -378,8 +378,19 @@ fn create_schema(conn: &Connection) -> Result<()> {
         );"
     };
     conn.execute_batch(sql)?;
+    if cfg!(feature = "gtin") {
+        let has_gtin = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concepts' AND sql LIKE '%gtin_codes%'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+        if !has_gtin {
+            conn.execute("ALTER TABLE concepts ADD COLUMN gtin_codes TEXT", [])?;
+        }
+    }
     conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS concept_isa (
             child_id  TEXT NOT NULL,
             parent_id TEXT NOT NULL
         );

--- a/src/commands/transcode.rs
+++ b/src/commands/transcode.rs
@@ -66,7 +66,7 @@ pub fn transcode_one(
 fn to_snomed(conn: &Connection, from: &str, code: &str) -> Result<Vec<String>> {
     match from {
         "snomed" => Ok(vec![code.to_string()]),
-        "ctv3" | "read2" => {
+        "ctv3" | "read2" | "gtin" => {
             let from_crossmaps = legacy_to_snomed_from_crossmaps(conn, from, code)?;
             if !from_crossmaps.is_empty() || !table_exists(conn, "concept_maps") {
                 Ok(from_crossmaps)
@@ -92,7 +92,7 @@ fn to_snomed(conn: &Connection, from: &str, code: &str) -> Result<Vec<String>> {
 fn from_snomed(conn: &Connection, concept: &str, to: &str) -> Result<Vec<String>> {
     match to {
         "snomed" => Ok(vec![concept.to_string()]),
-        "ctv3" | "read2" => {
+        "ctv3" | "read2" | "gtin" => {
             let from_crossmaps = legacy_from_snomed_from_crossmaps(conn, concept, to)?;
             if !from_crossmaps.is_empty() || !table_exists(conn, "concept_maps") {
                 Ok(from_crossmaps)

--- a/src/commands/transcode.rs
+++ b/src/commands/transcode.rs
@@ -15,6 +15,9 @@ use anyhow::{bail, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::io::BufRead;
 
+#[cfg(feature = "gtin")]
+pub(crate) const SYSTEMS: [&str; 6] = ["snomed", "read2", "ctv3", "icd10", "opcs4", "gtin"];
+#[cfg(not(feature = "gtin"))]
 pub(crate) const SYSTEMS: [&str; 5] = ["snomed", "read2", "ctv3", "icd10", "opcs4"];
 
 /// One mapped output: the target code, the SNOMED pivot concept it went through,

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -199,10 +199,7 @@ impl App {
             } else {
                 None
             };
-            self.current_concept = Some(Concept {
-                size_estimate,
-                ..c
-            });
+            self.current_concept = Some(Concept { size_estimate, ..c });
             self.detail_scroll = 0;
         }
     }
@@ -418,6 +415,7 @@ fn fetch_concept(conn: &Connection, id: &str) -> Result<Option<Concept>> {
                 children_count,
                 attributes,
                 subtree_size,
+                size_estimate: None,
             }))
         }
     }

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -85,6 +85,7 @@ struct Concept {
     parents: Vec<(String, String)>, // (id, fsn)
     children_count: i64,
     attributes: Vec<(String, Vec<(String, String)>)>, // (attr_name, [(id, fsn)])
+    subtree_size: u64,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -97,7 +98,7 @@ enum Focus {
 struct App {
     conn: Connection,
     // Hierarchy panel
-    hierarchies: Vec<String>,
+    hierarchies: Vec<(String, u64)>,
     hierarchy_state: ListState,
     // Search panel
     search_query: String,
@@ -206,14 +207,17 @@ impl App {
 // DB queries
 // ---------------------------------------------------------------------------
 
-fn load_hierarchies(conn: &Connection) -> Result<Vec<String>> {
+fn load_hierarchies(conn: &Connection) -> Result<Vec<(String, u64)>> {
     let mut stmt = conn.prepare(
-        "SELECT DISTINCT hierarchy FROM concepts \
+        "SELECT hierarchy, COUNT(*) FROM concepts \
          WHERE hierarchy IS NOT NULL AND hierarchy != '' \
+         GROUP BY hierarchy \
          ORDER BY hierarchy",
     )?;
     let hierarchies = stmt
-        .query_map([], |row| row.get(0))?
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+        })?
         .filter_map(|r| r.ok())
         .collect();
     Ok(hierarchies)
@@ -360,6 +364,8 @@ fn fetch_concept(conn: &Connection, id: &str) -> Result<Option<Concept>> {
                     vec![]
                 };
 
+            let subtree_size = crate::commands::get_subtree_size(conn, &id).unwrap_or(0);
+
             Ok(Some(Concept {
                 id,
                 fsn,
@@ -370,6 +376,7 @@ fn fetch_concept(conn: &Connection, id: &str) -> Result<Option<Concept>> {
                 parents,
                 children_count,
                 attributes,
+                subtree_size,
             }))
         }
     }
@@ -477,7 +484,7 @@ fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
         KeyCode::Enter => match app.focus {
             Focus::Hierarchy => {
                 if let Some(i) = app.hierarchy_state.selected() {
-                    if let Some(h) = app.hierarchies.get(i).cloned() {
+                    if let Some((h, _)) = app.hierarchies.get(i).cloned() {
                         app.load_hierarchy_concepts(h);
                         app.focus = Focus::Search;
                     }
@@ -587,7 +594,7 @@ fn render_hierarchy(frame: &mut Frame, app: &mut App, area: Rect) {
     let items: Vec<ListItem> = app
         .hierarchies
         .iter()
-        .map(|h| ListItem::new(format!("  {}", h)))
+        .map(|(h, size)| ListItem::new(format!("  {} ({})", h, fmt_count(*size))))
         .collect();
 
     let list = List::new(items)
@@ -733,6 +740,10 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
             Span::styled("Children:  ", Style::default().fg(DIM)),
             Span::raw(concept.children_count.to_string()),
         ]),
+        Line::from(vec![
+            Span::styled("Subtree:   ", Style::default().fg(DIM)),
+            Span::raw(format!("{} descendants", fmt_count(concept.subtree_size))),
+        ]),
         Line::from(""),
     ];
 
@@ -830,4 +841,16 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         .scroll((app.detail_scroll, 0))
         .wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
+}
+
+fn fmt_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
 }

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -27,6 +27,8 @@ use rusqlite::{params, Connection, OpenFlags};
 use serde_json::Value;
 use std::{io, path::PathBuf, time::Duration};
 
+use crate::commands::size::{estimate_sizes, fmt_bytes, SizeEstimate};
+
 #[derive(Parser, Debug)]
 pub struct Args {
     /// Path to the SNOMED CT SQLite database produced by `sct sqlite`.
@@ -87,6 +89,7 @@ struct Concept {
     children_count: i64,
     attributes: Vec<(String, Vec<(String, String)>)>, // (attr_name, [(id, fsn)])
     subtree_size: u64,
+    size_estimate: Option<SizeEstimate>,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -110,6 +113,7 @@ struct App {
     // Detail panel
     current_concept: Option<Concept>,
     detail_scroll: u16,
+    show_size: bool,
     // Navigation
     history: Vec<String>,
     focus: Focus,
@@ -130,6 +134,7 @@ impl App {
             last_queried: String::new(),
             current_concept: None,
             detail_scroll: 0,
+            show_size: false,
             history: Vec::new(),
             focus: Focus::Hierarchy,
             should_quit: false,
@@ -189,7 +194,15 @@ impl App {
             }
         }
         if let Ok(Some(c)) = fetch_concept(&self.conn, &id) {
-            self.current_concept = Some(c);
+            let size_estimate = if self.show_size {
+                estimate_sizes(&self.conn, &id, 100).ok()
+            } else {
+                None
+            };
+            self.current_concept = Some(Concept {
+                size_estimate,
+                ..c
+            });
             self.detail_scroll = 0;
         }
     }
@@ -531,6 +544,12 @@ fn handle_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
 
         KeyCode::Char('b') => app.go_back(),
         KeyCode::Char('h') => app.focus = Focus::Hierarchy,
+        KeyCode::Char('s') => {
+            app.show_size = !app.show_size;
+            if let Some(id) = app.current_concept.as_ref().map(|c| c.id.clone()) {
+                app.load_concept(id);
+            }
+        }
 
         _ => {}
     }
@@ -583,7 +602,7 @@ fn render(frame: &mut Frame, app: &mut App) {
 
     // Title bar
     let title = Paragraph::new(
-        "  sct - SNOMED CT Explorer        [/] search  [Tab] switch panel  [q] quit",
+        "  sct - SNOMED CT Explorer        [/] search  [Tab] switch panel  [s] size  [q] quit",
     )
     .style(Style::default().fg(Color::White).bg(NHS_BLUE));
     frame.render_widget(title, outer[0]);
@@ -606,7 +625,7 @@ fn render(frame: &mut Frame, app: &mut App) {
 
     // Status bar
     let status = Paragraph::new(
-        " [/] search  [↑↓] navigate  [Enter] select  [Tab] panels  [b] back  [q] quit",
+        " [/] search  [↑↓] navigate  [Enter] select  [Tab] panels  [b] back  [s] size  [q] quit",
     )
     .style(Style::default().fg(DIM).bg(Color::Rgb(20, 20, 30)));
     frame.render_widget(status, outer[2]);
@@ -739,6 +758,17 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let width = inner.width as usize;
     let rule = "─".repeat(width.min(60));
+    let size_line = if app.show_size {
+        concept.size_estimate.as_ref().map(|size| {
+            format!(
+                "NDJSON {}  ·  SQLite {}",
+                fmt_bytes(size.ndjson_total),
+                fmt_bytes(size.sqlite_total)
+            )
+        })
+    } else {
+        None
+    };
 
     let mut lines: Vec<Line> = vec![
         Line::from(Span::styled(
@@ -775,6 +805,14 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
                 fmt_count(concept.subtree_size.saturating_sub(1))
             )),
         ]),
+        if let Some(size) = size_line {
+            Line::from(vec![
+                Span::styled("Size:      ", Style::default().fg(DIM)),
+                Span::raw(size),
+            ])
+        } else {
+            Line::from("")
+        },
         Line::from(""),
     ];
 

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -43,6 +43,7 @@ pub fn run(args: Args) -> Result<()> {
     )
     .with_context(|| format!("opening database {}", db_path.display()))?;
     conn.execute_batch("PRAGMA cache_size = -32768;")?;
+    crate::ecl::warn_if_no_tct(&conn);
 
     let mut app = App::new(conn)?;
 

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -215,13 +215,24 @@ fn load_hierarchies(conn: &Connection) -> Result<Vec<(String, u64)>> {
          GROUP BY hierarchy \
          ORDER BY hierarchy",
     )?;
-    let hierarchies = stmt
+    let hierarchies: Vec<(String, u64)> = stmt
         .query_map([], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
         })?
         .filter_map(|r| r.ok())
         .collect();
-    Ok(hierarchies)
+
+    if hierarchies.is_empty() {
+        // Filtered/subset DB has no hierarchy labels — show a single catch-all entry
+        let total: u64 = conn
+            .query_row("SELECT COUNT(*) FROM concepts", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap_or(0) as u64;
+        Ok(vec![("(All concepts)".to_string(), total)])
+    } else {
+        Ok(hierarchies)
+    }
 }
 
 fn sanitise_fts(q: &str) -> String {
@@ -270,6 +281,22 @@ fn fetch_hierarchy_concepts(
     hierarchy: &str,
     limit: usize,
 ) -> Result<Vec<ConceptSummary>> {
+    // "(All concepts)" is a synthetic sentinel emitted when no hierarchy labels exist
+    if hierarchy == "(All concepts)" {
+        let mut stmt = conn
+            .prepare("SELECT id, preferred_term FROM concepts ORDER BY preferred_term LIMIT ?1")?;
+        let rows = stmt
+            .query_map(params![limit as i64], |row| {
+                Ok(ConceptSummary {
+                    id: row.get(0)?,
+                    preferred_term: row.get(1)?,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        return Ok(rows);
+    }
+
     let mut stmt = conn.prepare(
         "SELECT id, preferred_term FROM concepts \
          WHERE hierarchy = ?1 ORDER BY preferred_term LIMIT ?2",

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -742,7 +742,10 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("Subtree:   ", Style::default().fg(DIM)),
-            Span::raw(format!("{} descendants", fmt_count(concept.subtree_size))),
+            Span::raw(format!(
+                "{} descendants",
+                fmt_count(concept.subtree_size.saturating_sub(1))
+            )),
         ]),
         Line::from(""),
     ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,9 @@ enum Command {
     /// Print shell completion scripts (bash, zsh, fish, powershell, elvish).
     Completions(commands::completions::Args),
 
+    /// View size of SNOMED CT concepts and their subtree distributions.
+    Size(commands::size::Args),
+
     /// Launch an interactive terminal UI for exploring SNOMED CT (requires --features tui).
     #[cfg(feature = "tui")]
     Tui(commands::tui::Args),
@@ -146,6 +149,7 @@ fn main() -> Result<()> {
         Command::Lexical(args) => commands::lexical::run(args),
         Command::Semantic(args) => commands::semantic::run(args),
         Command::Completions(args) => commands::completions::run(args, Cli::command()),
+        Command::Size(args) => commands::size::run(args),
         #[cfg(feature = "tui")]
         Command::Tui(args) => commands::tui::run(args),
         #[cfg(feature = "gui")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ enum Command {
     /// Convert an RF2 Snapshot directory to a canonical NDJSON artefact.
     Ndjson(commands::ndjson::Args),
 
+    /// Filter a SNOMED CT NDJSON artefact and remap GTINs.
+    Filter(commands::filter::Args),
+
     /// Load a SNOMED CT NDJSON artefact into a SQLite database with FTS5.
     Sqlite(commands::sqlite::Args),
 
@@ -128,6 +131,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Command::Ndjson(args) => commands::ndjson::run(args),
+        Command::Filter(args) => commands::filter::run(args),
         Command::Sqlite(args) => commands::sqlite::run(args),
         Command::Parquet(args) => commands::parquet::run(args),
         Command::Markdown(args) => commands::markdown::run(args),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -91,7 +91,7 @@ pub struct HistoryRecord {
 /// The per-concept JSON record written to the NDJSON artefact.
 ///
 /// One record per line, sorted by `id` (ascending numeric SCTID).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConceptRecord {
     pub id: String,
     pub fsn: String,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -21,7 +21,10 @@ use serde::{Deserialize, Serialize};
 /// Additive - older records parse with an empty list.
 /// v6: adds `gtin_codes` (Global Trade Item Numbers).
 /// Additive - older records parse with an empty list.
+#[cfg(feature = "gtin")]
 pub const SCHEMA_VERSION: u32 = 6;
+#[cfg(not(feature = "gtin"))]
+pub const SCHEMA_VERSION: u32 = 5;
 
 /// A lightweight reference to another concept (used in parents and attributes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,9 +131,37 @@ pub struct ConceptRecord {
     pub crossmaps: Vec<CrossMapEntry>,
     /// GTIN (Global Trade Item Number) codes mapped to this concept.
     /// Additive - older records parse with an empty list.
+    #[cfg(feature = "gtin")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub gtin_codes: Vec<String>,
     pub schema_version: u32,
+}
+
+impl Default for ConceptRecord {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            fsn: String::new(),
+            preferred_term: String::new(),
+            synonyms: vec![],
+            hierarchy: String::new(),
+            hierarchy_path: vec![],
+            parents: vec![],
+            children_count: 0,
+            attributes: indexmap::IndexMap::new(),
+            active: true,
+            module: String::new(),
+            effective_time: String::new(),
+            ctv3_codes: vec![],
+            read2_codes: vec![],
+            refsets: vec![],
+            relationships: vec![],
+            crossmaps: vec![],
+            #[cfg(feature = "gtin")]
+            gtin_codes: vec![],
+            schema_version: SCHEMA_VERSION,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -169,8 +200,7 @@ mod tests {
                 advice: "ALWAYS I21.9".into(),
                 correlation: String::new(),
             }],
-            gtin_codes: vec![],
-            schema_version: SCHEMA_VERSION,
+            ..Default::default()
         }
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,7 +19,9 @@ use serde::{Deserialize, Serialize};
 /// ECL attribute refinement. Additive - older records parse with an empty list.
 /// v5: adds `crossmaps` (SNOMED CT → ICD-10 / OPCS-4 ExtendedMap targets).
 /// Additive - older records parse with an empty list.
-pub const SCHEMA_VERSION: u32 = 5;
+/// v6: adds `gtin_codes` (Global Trade Item Numbers).
+/// Additive - older records parse with an empty list.
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// A lightweight reference to another concept (used in parents and attributes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -124,6 +126,10 @@ pub struct ConceptRecord {
     /// Populated with `--refsets all`. Empty on records from schema v4 and earlier.
     #[serde(default)]
     pub crossmaps: Vec<CrossMapEntry>,
+    /// GTIN (Global Trade Item Number) codes mapped to this concept.
+    /// Additive - older records parse with an empty list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gtin_codes: Vec<String>,
     pub schema_version: u32,
 }
 
@@ -163,6 +169,7 @@ mod tests {
                 advice: "ALWAYS I21.9".into(),
                 correlation: String::new(),
             }],
+            gtin_codes: vec![],
             schema_version: SCHEMA_VERSION,
         }
     }

--- a/tests/ecl_eval.rs
+++ b/tests/ecl_eval.rs
@@ -8,7 +8,7 @@
 use indexmap::IndexMap;
 use sct_rs::commands::sqlite;
 use sct_rs::ecl;
-use sct_rs::schema::{ConceptRecord, ConceptRef, Relationship, SCHEMA_VERSION};
+use sct_rs::schema::{ConceptRecord, ConceptRef, Relationship};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -52,8 +52,7 @@ fn rec(
             })
             .collect(),
         crossmaps: vec![],
-        gtin_codes: vec![],
-        schema_version: SCHEMA_VERSION,
+        ..Default::default()
     }
 }
 

--- a/tests/ecl_eval.rs
+++ b/tests/ecl_eval.rs
@@ -52,6 +52,7 @@ fn rec(
             })
             .collect(),
         crossmaps: vec![],
+        gtin_codes: vec![],
         schema_version: SCHEMA_VERSION,
     }
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -11,6 +11,7 @@
 
 use rusqlite::Connection;
 use sct_rs::commands::ndjson::{self, RefsetMode};
+use sct_rs::commands::size;
 use sct_rs::commands::sqlite;
 use sct_rs::ecl;
 use sct_rs::schema::ConceptRecord;
@@ -376,4 +377,17 @@ fn sqlite_fts5_maps_relationships_and_tct() {
         .map(|r| r.unwrap())
         .collect();
     assert_eq!(members, ["44054006", "46635009"]);
+}
+
+#[test]
+fn size_estimate_for_root() {
+    let (_d, _ndjson, db) = build("en-GB");
+    let conn = Connection::open(&db).unwrap();
+
+    let est = size::estimate_sizes(&conn, "138875005", 50).unwrap();
+    assert_eq!(est.subtree_count, est.total_count);
+    assert_eq!(est.pct(), 100.0);
+    assert!(est.avg_ndjson_bytes > 0);
+    assert_eq!(est.sqlite_total, est.total_db_bytes);
+    assert!(est.ndjson_total > 0);
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -377,3 +377,84 @@ fn sqlite_fts5_maps_relationships_and_tct() {
         .collect();
     assert_eq!(members, ["44054006", "46635009"]);
 }
+
+#[test]
+fn database_filtering_and_gtin_remapping() {
+    let (dir, ndjson, _db) = build("en-GB");
+
+    // 1. Create a keep-ids file containing "73211009" (Diabetes mellitus)
+    let keep_file = dir.path().join("keep.txt");
+    std::fs::write(&keep_file, "73211009\n138875005\n404684003\n").unwrap();
+
+    // 2. Create a GTIN map file mapping GTIN "5012345678901" to concept "46635009" (Type 1 diabetes)
+    // and GTIN "5012345678902" to concept "73211009" (Diabetes mellitus)
+    let gtin_file = dir.path().join("gtin.csv");
+    std::fs::write(
+        &gtin_file,
+        "5012345678901,46635009\n5012345678902,73211009\n",
+    )
+    .unwrap();
+
+    // 3. Run the filter command
+    let filtered_ndjson = dir.path().join("filtered.ndjson");
+    sct_rs::commands::filter::run(sct_rs::commands::filter::Args {
+        input: ndjson,
+        output: filtered_ndjson.clone(),
+        keep_ecl: None,
+        keep_ids: Some(keep_file),
+        db: None,
+        gtin_map: Some(gtin_file),
+    })
+    .unwrap();
+
+    // 4. Read the filtered records
+    let records = read_records(&filtered_ndjson);
+
+    // Concept "46635009" should be filtered out
+    assert!(records.iter().all(|r| r.id != "46635009"));
+
+    // Concept "73211009" should be kept and have both GTINs mapped to it
+    let dm_rec = records
+        .iter()
+        .find(|r| r.id == "73211009")
+        .expect("Diabetes record should be kept");
+    assert_eq!(dm_rec.gtin_codes.len(), 2);
+    assert!(dm_rec.gtin_codes.contains(&"5012345678901".to_string()));
+    assert!(dm_rec.gtin_codes.contains(&"5012345678902".to_string()));
+
+    // 5. Build filtered SQLite database from the filtered ndjson
+    let filtered_db = dir.path().join("filtered.db");
+    sqlite::run(sqlite::Args {
+        input: filtered_ndjson,
+        output: filtered_db.clone(),
+        transitive_closure: true,
+        include_self: false,
+    })
+    .unwrap();
+
+    // 6. Verify that lookups and maps work on the filtered DB
+    let conn = Connection::open(&filtered_db).unwrap();
+
+    // Reverse map lookup in concept_maps: GTIN "5012345678901" should map to "73211009"
+    let mapped_snomed: String = conn
+        .query_row(
+            "SELECT concept_id FROM concept_maps WHERE code = '5012345678901' AND terminology = 'gtin'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(mapped_snomed, "73211009");
+
+    // Check concepts table gtin_codes column
+    let gtin_codes_json: String = conn
+        .query_row(
+            "SELECT gtin_codes FROM concepts WHERE id = '73211009'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let gtins: Vec<String> = serde_json::from_str(&gtin_codes_json).unwrap();
+    assert_eq!(gtins.len(), 2);
+    assert!(gtins.contains(&"5012345678901".to_string()));
+    assert!(gtins.contains(&"5012345678902".to_string()));
+}

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -422,6 +422,12 @@ fn database_filtering_and_gtin_remapping() {
     assert!(dm_rec.gtin_codes.contains(&"5012345678901".to_string()));
     assert!(dm_rec.gtin_codes.contains(&"5012345678902".to_string()));
 
+    // Verify parent FSNs are preserved and not empty
+    assert!(!dm_rec.parents.is_empty());
+    for p in &dm_rec.parents {
+        assert!(!p.fsn.is_empty(), "Parent {} FSN should not be empty", p.id);
+    }
+
     // 5. Build filtered SQLite database from the filtered ndjson
     let filtered_db = dir.path().join("filtered.db");
     sqlite::run(sqlite::Args {


### PR DESCRIPTION
This PR implements the `sct filter` command to prune large SNOMED CT NDJSON datasets using ECL expressions and ID keep-lists. 
When filtering out concepts, it automatically collapses the hierarchy paths (rewriting parents to their nearest kept ancestor) and remaps any associated GTIN barcodes from pruned child concepts onto their nearest kept ancestors.

As this PR includes GTIN and size filtering support, it is stacked on those PRs/branches, which should be merged first. It is also capable of remapping GTINs to a VMP/VMM, which saves reduces the size significantly, while still allowing lookup of a product by GTIN barcode.

Also adds `database_filtering_and_gtin_remapping` test verifying ECL matching, barcode remapping, parent collapsing, and parent FSN preservation.