### PR TITLE
refactor(fmt): consolidate count/byte/plural helpers, fix singular output (R6)

### DIFF
--- a/docs/commands/fst.md
+++ b/docs/commands/fst.md
@@ -42,8 +42,8 @@ Build prints a short summary to stderr:
 
 ```
 Built snomed.fst in 18.83s
-  837930 concepts, 1969072 terms → 1251078 distinct keys, 178356 word tokens, 61 semantic tags
-  134.2 MB on disk (140728226 bytes), with labels
+  837,930 concepts, 1,969,072 terms → 1,251,078 distinct keys, 178,356 word tokens, 61 semantic tags
+  134.2 MB on disk (140,728,226 bytes), with labels
 ```
 
 ---

--- a/docs/commands/refset.md
+++ b/docs/commands/refset.md
@@ -22,7 +22,7 @@ Subcommands:
 | `compare <ID_A> <ID_B>` | Compare membership of two refsets: only-in-A, only-in-B, in-both. |
 | `profile <ID>` | Breakdown of a refset's members by top-level hierarchy. |
 
-All subcommands accept `--db <PATH>` (auto-discovered when omitted - see [Path resolution](../path-resolution.md)), `-f, --format text|json|yaml` for machine-readable output (`--json` is a deprecated alias for `--format json`), and `--provenance` / `--no-provenance` to force-show or suppress the release provenance footer (default: on for an interactive terminal). `list` also accepts `--template <TEMPLATE>` to override the per-refset line (default `{id} | {pt} ({count} members)`). `members` also accepts `--limit <N>` to cap the number of rows displayed, `--ids` to emit just the member SCTIDs (newline-delimited) for piping, and `--template` / `--template-fsn-suffix` to override the per-concept line (see **Custom format** below):
+All subcommands accept `--db <PATH>` (auto-discovered when omitted - see [Path resolution](../path-resolution.md)), `-f, --format text|json|yaml` for machine-readable output (`--json` is a deprecated alias for `--format json`), and `--provenance` / `--no-provenance` to force-show or suppress the release provenance footer (default: on for an interactive terminal). `list` also accepts `--template <TEMPLATE>` to override the singular-aware default per-refset line, for example `(1 member)` or `(232 members)`. `members` also accepts `--limit <N>` to cap the number of rows displayed, `--ids` to emit just the member SCTIDs (newline-delimited) for piping, and `--template` / `--template-fsn-suffix` to override the per-concept line (see **Custom format** below):
 
 ```bash
 # A whole refset becomes a code list in one line
@@ -92,12 +92,12 @@ sct refset compare 999002431000000102 1129631000000105
 ```
 
 ```
-  A: [999002431000000102] AIDS (acquired immune deficiency syndrome) defining illness for adults simple reference set
-  B: [1129631000000105] Summary Care Record exclusions simple reference set
+A: [999002431000000102] AIDS (acquired immune deficiency syndrome) defining illness for adults simple reference set
+B: [1129631000000105] Summary Care Record exclusions simple reference set
 
-  Only in A: 24
-  Only in B: 230
-  In both:   2
+Only in A: 24
+Only in B: 230
+In both:   2
 ```
 
 By default only the counts are shown - cheap even for large refsets, since the counts come from a separate `COUNT(*)` query, not from materialising every member. Pass `--show only-a|only-b|both|all` to also list the concepts in a given set (`--limit <N>` caps how many are listed; the reported counts are always exact regardless of `--limit`). `-f json` always includes all three member lists (each subject to `--limit`):
@@ -115,8 +115,8 @@ sct refset profile 1129631000000105
 ```
 
 ```
-  [1129631000000105] Summary Care Record exclusions simple reference set
-  Members: 232
+[1129631000000105] Summary Care Record exclusions simple reference set
+Members: 232
 
   Clinical finding                                198  (85.3%)
   Procedure                                        20  (8.6%)

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -28,8 +28,6 @@ Do these alongside or immediately after the SDK extraction: they define contract
 
 - [ ] `R5` **Unify structured output formats.** Give `sct info` the shared `--format text|json|yaml`; align `map` and `diff` with the common vocabulary while retaining domain formats such as TSV/CSV/Markdown as additive variants; publish a removal schedule for hidden `--json` aliases.
 
-- [ ] `R6` **Consolidate formatting and finish human-output polish.** Replace duplicate count/byte/pluralisation helpers with one tested module, fix singular output such as `1 concept`, re-bless affected snapshots, and make refset compare/profile indentation match the rest of the CLI.
-
 - [ ] `R7` **Make stdin (`-`) composable across read commands.** Add batch stdin paths to the natural single-value readers (`lookup`, `lexical`, `semantic`, and relevant refset operations), with deterministic line-oriented or structured output suitable for pipelines.
 
 - [ ] `R8` **Unify missing-TCT guidance.** Route recursive-CTE fallbacks through one helper so CLI callers receive the same stderr instruction and MCP callers receive an equivalent log/diagnostic notification; retain `sct size`'s explicit interactive build flow.

--- a/src/commands/codelist.rs
+++ b/src/commands/codelist.rs
@@ -32,6 +32,7 @@ pub use crate::codelist::{
     write_codelist, Author, CodelistFile, ConceptLine, EffectiveMember, FrontMatter, IncludeRef,
     MemberSource, Warning,
 };
+use crate::humanize::plural_count;
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -534,7 +535,10 @@ fn cmd_add(args: AddArgs) -> Result<()> {
             println!("ECL {ecl:?} matched no concepts.");
             return Ok(());
         }
-        println!("ECL {ecl:?} matched {} concept(s).", ids.len());
+        println!(
+            "ECL {ecl:?} matched {}.",
+            plural_count(ids.len() as u64, "concept")
+        );
         ids
     } else {
         // Explicit SCTIDs, plus any read from stdin when `-` is given. This is

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
+use crate::humanize::{fmt_count, plural_count};
 use crate::schema::ConceptRecord;
 
 #[derive(ValueEnum, Debug, Clone, PartialEq)]
@@ -213,12 +214,12 @@ fn print_summary(
     println!("# SNOMED CT diff summary");
     println!();
     println!(
-        "Old artefact: {} active concepts",
-        fmt_count(old_active as u64)
+        "Old artefact: {}",
+        plural_count(old_active as u64, "active concept")
     );
     println!(
-        "New artefact: {} active concepts",
-        fmt_count(new_active as u64)
+        "New artefact: {}",
+        plural_count(new_active as u64, "active concept")
     );
     println!();
     println!("Changes:");
@@ -238,7 +239,7 @@ fn print_summary(
 
     if !added.is_empty() {
         println!();
-        println!("## Added ({} concepts)", fmt_count(added.len() as u64));
+        println!("## Added ({})", plural_count(added.len() as u64, "concept"));
         for d in &added {
             if let DiffRecord::Added {
                 id,
@@ -254,8 +255,8 @@ fn print_summary(
     if !inactivated.is_empty() {
         println!();
         println!(
-            "## Inactivated ({} concepts)",
-            fmt_count(inactivated.len() as u64)
+            "## Inactivated ({})",
+            plural_count(inactivated.len() as u64, "concept")
         );
         for d in &inactivated {
             if let DiffRecord::Inactivated {
@@ -272,8 +273,8 @@ fn print_summary(
     if !term_changed.is_empty() {
         println!();
         println!(
-            "## Preferred term changed ({} concepts)",
-            fmt_count(term_changed.len() as u64)
+            "## Preferred term changed ({})",
+            plural_count(term_changed.len() as u64, "concept")
         );
         for d in &term_changed {
             if let DiffRecord::PreferredTermChanged {
@@ -291,8 +292,8 @@ fn print_summary(
     if !hier_changed.is_empty() {
         println!();
         println!(
-            "## Hierarchy changed ({} concepts)",
-            fmt_count(hier_changed.len() as u64)
+            "## Hierarchy changed ({})",
+            plural_count(hier_changed.len() as u64, "concept")
         );
         for d in &hier_changed {
             if let DiffRecord::HierarchyChanged {
@@ -366,18 +367,6 @@ fn change_order(d: &DiffRecord) -> u8 {
         DiffRecord::PreferredTermChanged { .. } => 2,
         DiffRecord::HierarchyChanged { .. } => 3,
     }
-}
-
-fn fmt_count(n: u64) -> String {
-    let s = n.to_string();
-    let mut result = String::with_capacity(s.len() + s.len() / 3);
-    for (i, ch) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(ch);
-    }
-    result.chars().rev().collect()
 }
 
 #[cfg(test)]
@@ -501,11 +490,5 @@ mod tests {
         assert!(
             matches!(&diffs[0], DiffRecord::PreferredTermChanged { new_preferred_term, .. } if new_preferred_term == "Pyrexia")
         );
-    }
-
-    #[test]
-    fn fmt_count_basic() {
-        assert_eq!(fmt_count(831_132), "831,132");
-        assert_eq!(fmt_count(0), "0");
     }
 }

--- a/src/commands/ecl.rs
+++ b/src/commands/ecl.rs
@@ -14,6 +14,7 @@ use clap::{Parser, Subcommand};
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
+use crate::humanize::plural_count;
 use crate::output::OutputFormat;
 
 #[derive(Parser, Debug)]
@@ -121,7 +122,10 @@ fn expand(args: ExpandArgs) -> Result<()> {
     crate::ecl::warn_if_no_tct(&conn);
     let ids = crate::ecl::expand(&conn, &expr)?;
 
-    eprintln!("{} concept(s) matched {expr:?}", ids.len());
+    eprintln!(
+        "{} matched {expr:?}",
+        plural_count(ids.len() as u64, "concept")
+    );
 
     let format = args.format.or_json_flag(args.json);
     if !format.print(&ids)? {

--- a/src/commands/fst.rs
+++ b/src/commands/fst.rs
@@ -19,6 +19,7 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use std::time::Instant;
 
+use crate::humanize::{human_bytes, plural_count};
 use crate::index::{self, Index};
 
 #[derive(Parser, Debug)]
@@ -124,15 +125,23 @@ fn build(args: BuildArgs) -> Result<()> {
         elapsed.as_secs_f64()
     );
     eprintln!(
-        "  {} concepts, {} terms → {} distinct keys, {} word tokens, {} semantic tags",
-        stats.concepts, stats.terms, stats.distinct_keys, stats.distinct_words, stats.semantic_tags
+        "  {}, {} → {}, {}, {}",
+        plural_count(stats.concepts as u64, "concept"),
+        plural_count(stats.terms as u64, "term"),
+        plural_count(stats.distinct_keys as u64, "distinct key"),
+        plural_count(stats.distinct_words as u64, "word token"),
+        plural_count(stats.semantic_tags as u64, "semantic tag")
     );
     let labels = if stats.terms_included {
         "with labels"
     } else {
         "no labels (--no-terms)"
     };
-    eprintln!("  {} on disk ({} bytes), {labels}", human_bytes(size), size);
+    eprintln!(
+        "  {} on disk ({}), {labels}",
+        human_bytes(size),
+        plural_count(size, "byte")
+    );
     Ok(())
 }
 
@@ -160,8 +169,8 @@ fn search(args: SearchArgs) -> Result<()> {
             writeln!(out, "{}", h.concept_id)?;
         }
         eprintln!(
-            "{} result(s) in {:.3} ms",
-            hits.len(),
+            "{} in {:.3} ms",
+            plural_count(hits.len() as u64, "result"),
             elapsed.as_secs_f64() * 1000.0
         );
         return Ok(());
@@ -185,24 +194,9 @@ fn search(args: SearchArgs) -> Result<()> {
         println!("{:<18}  {}{}", h.concept_id, h.term, tag);
     }
     eprintln!(
-        "\n{} result(s) in {:.3} ms",
-        hits.len(),
+        "\n{} in {:.3} ms",
+        plural_count(hits.len() as u64, "result"),
         elapsed.as_secs_f64() * 1000.0
     );
     Ok(())
-}
-
-fn human_bytes(n: u64) -> String {
-    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
-    let mut size = n as f64;
-    let mut unit = 0;
-    while size >= 1024.0 && unit < UNITS.len() - 1 {
-        size /= 1024.0;
-        unit += 1;
-    }
-    if unit == 0 {
-        format!("{n} {}", UNITS[unit])
-    } else {
-        format!("{size:.1} {}", UNITS[unit])
-    }
 }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
+use crate::humanize::{fmt_count, human_bytes};
 use crate::provenance;
 use crate::schema::ConceptRecord;
 
@@ -78,7 +79,7 @@ fn info_ndjson(path: &Path) -> Result<()> {
     }
 
     println!("File:           {}", path.display());
-    println!("Size:           {}", human_size(file_size));
+    println!("Size:           {}", human_bytes(file_size));
     println!("Format:         NDJSON");
     println!(
         "Schema version: {}",
@@ -198,7 +199,7 @@ fn info_db(path: &Path) -> Result<()> {
     let prov = provenance::read_sqlite(&conn).unwrap_or(None);
 
     println!("File:              {}", path.display());
-    println!("Size:              {}", human_size(file_size));
+    println!("Size:              {}", human_bytes(file_size));
     println!("Format:            SQLite (sct sqlite)");
     println!(
         "Schema version:    {}",
@@ -266,7 +267,7 @@ fn info_arrow(path: &Path) -> Result<()> {
         .sum();
 
     println!("File:             {}", path.display());
-    println!("Size:             {}", human_size(file_size));
+    println!("Size:             {}", human_bytes(file_size));
     println!("Format:           Arrow IPC (sct embed)");
     if let Some(ref p) = prov {
         if !p.edition_label.is_empty() {
@@ -301,34 +302,6 @@ fn info_arrow(path: &Path) -> Result<()> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn human_size(bytes: u64) -> String {
-    const GB: u64 = 1 << 30;
-    const MB: u64 = 1 << 20;
-    const KB: u64 = 1 << 10;
-    if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.1} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{} B", bytes)
-    }
-}
-
-fn fmt_count(n: u64) -> String {
-    // Simple thousands-separator formatting
-    let s = n.to_string();
-    let mut result = String::with_capacity(s.len() + s.len() / 3);
-    for (i, ch) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(ch);
-    }
-    result.chars().rev().collect()
-}
-
 /// Try to extract a YYYYMMDD date from a filename like
 /// `snomedct-monolithrf2-production-20260311t120000z.ndjson`.
 fn extract_date_from_filename(path: &Path) -> Option<String> {
@@ -354,13 +327,6 @@ fn extract_date_from_filename(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn fmt_count_thousands() {
-        assert_eq!(fmt_count(1_234_567), "1,234,567");
-        assert_eq!(fmt_count(831_132), "831,132");
-        assert_eq!(fmt_count(42), "42");
-    }
 
     #[test]
     fn extract_date_from_monolith_filename() {

--- a/src/commands/markdown.rs
+++ b/src/commands/markdown.rs
@@ -104,11 +104,18 @@ fn run_concept_mode<R: std::io::Read>(
 
         n += 1;
         if n.is_multiple_of(50_000) {
-            pb.set_message(format!("{} files written...", n));
+            pb.set_message(format!(
+                "{} written...",
+                plural_count(n as u64, "Markdown file")
+            ));
         }
     }
 
-    pb.finish_with_message(format!("Done. {} Markdown files → {}", n, output.display()));
+    pb.finish_with_message(format!(
+        "Done. {} → {}",
+        plural_count(n as u64, "Markdown file"),
+        output.display()
+    ));
     Ok(())
 }
 
@@ -146,11 +153,14 @@ fn run_hierarchy_mode<R: std::io::Read>(
 
         n += 1;
         if n.is_multiple_of(50_000) {
-            pb.set_message(format!("{} concepts loaded...", n));
+            pb.set_message(format!("{} loaded...", plural_count(n as u64, "concept")));
         }
     }
 
-    pb.set_message(format!("Writing {} hierarchy files...", groups.len()));
+    pb.set_message(format!(
+        "Writing {}...",
+        plural_count(groups.len() as u64, "hierarchy file")
+    ));
 
     let mut files_written = 0;
     for (hierarchy, concepts) in &groups {

--- a/src/commands/markdown.rs
+++ b/src/commands/markdown.rs
@@ -26,6 +26,7 @@ use std::fmt::Write as FmtWrite;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
+use crate::humanize::plural_count;
 use crate::schema::ConceptRecord;
 
 /// Output grouping mode.
@@ -159,7 +160,12 @@ fn run_hierarchy_mode<R: std::io::Read>(
         let mut buf = String::with_capacity(concepts.len() * 256);
         writeln!(buf, "# {}", hierarchy).unwrap();
         writeln!(buf).unwrap();
-        writeln!(buf, "> {} concepts in this hierarchy.", concepts.len()).unwrap();
+        writeln!(
+            buf,
+            "> {} in this hierarchy.",
+            plural_count(concepts.len() as u64, "concept")
+        )
+        .unwrap();
         writeln!(buf).unwrap();
 
         for concept in concepts {
@@ -173,10 +179,10 @@ fn run_hierarchy_mode<R: std::io::Read>(
     }
 
     pb.finish_with_message(format!(
-        "Done. {} hierarchy files → {} ({} concepts total)",
-        files_written,
+        "Done. {} → {} ({} total)",
+        plural_count(files_written, "hierarchy file"),
         output.display(),
-        n
+        plural_count(n as u64, "concept")
     ));
     Ok(())
 }

--- a/src/commands/parquet.rs
+++ b/src/commands/parquet.rs
@@ -21,6 +21,7 @@ use std::io::BufRead;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::humanize::plural_count;
 use crate::schema::ConceptRecord;
 
 const BATCH_SIZE: usize = 50_000;
@@ -88,8 +89,8 @@ pub fn run(args: Args) -> Result<()> {
     writer.close().context("finalising Parquet file")?;
 
     pb.finish_with_message(format!(
-        "Done. {} concepts → {}",
-        total,
+        "Done. {} → {}",
+        plural_count(total as u64, "concept"),
         args.output.display()
     ));
     Ok(())

--- a/src/commands/parquet.rs
+++ b/src/commands/parquet.rs
@@ -74,7 +74,10 @@ pub fn run(args: Args) -> Result<()> {
             let batch = build_batch(&schema, &batch_buf)?;
             writer.write(&batch).context("writing Parquet batch")?;
             batch_buf.clear();
-            pb.set_message(format!("{} concepts written...", total));
+            pb.set_message(format!(
+                "{} written...",
+                plural_count(total as u64, "concept")
+            ));
         }
     }
 

--- a/src/commands/refset.rs
+++ b/src/commands/refset.rs
@@ -429,19 +429,19 @@ fn run_compare(args: CompareArgs) -> Result<()> {
         return Ok(());
     }
 
-    println!("  A: [{}] {}", cmp.refset_a.id, cmp.refset_a.preferred_term);
-    println!("  B: [{}] {}", cmp.refset_b.id, cmp.refset_b.preferred_term);
+    println!("A: [{}] {}", cmp.refset_a.id, cmp.refset_a.preferred_term);
+    println!("B: [{}] {}", cmp.refset_b.id, cmp.refset_b.preferred_term);
     println!();
-    println!("  Only in A: {}", cmp.only_in_a.count);
-    println!("  Only in B: {}", cmp.only_in_b.count);
-    println!("  In both:   {}", cmp.in_both.count);
+    println!("Only in A: {}", cmp.only_in_a.count);
+    println!("Only in B: {}", cmp.only_in_b.count);
+    println!("In both:   {}", cmp.in_both.count);
 
     let format = ConceptFormat::load();
     let print_set = |label: &str, set: &RefsetDiffSet| {
-        println!("\n  {label} ({}):", set.count);
+        println!("\n{label} ({}):", set.count);
         for m in &set.members {
             println!(
-                "    {}",
+                "  {}",
                 format.render(&ConceptFields {
                     id: &m.id,
                     pt: &m.preferred_term,
@@ -503,11 +503,11 @@ fn run_profile(args: ProfileArgs) -> Result<()> {
         return Ok(());
     }
 
-    println!("  [{}] {}", refset.id, refset.preferred_term);
-    println!("  Members: {}", refset.member_count);
+    println!("[{}] {}", refset.id, refset.preferred_term);
+    println!("Members: {}", refset.member_count);
 
     if hierarchies.is_empty() {
-        println!("\n  No members loaded for this refset.");
+        println!("\nNo members loaded for this refset.");
         provenance::print_human_footer(prov.as_ref(), show_prov);
         return Ok(());
     }

--- a/src/commands/refset.rs
+++ b/src/commands/refset.rs
@@ -31,6 +31,7 @@ pub use crate::refset::{
 
 use crate::builder::strip_semantic_tag;
 use crate::format::{ConceptFields, ConceptFormat};
+use crate::humanize::plural_count;
 use crate::output::OutputFormat;
 use crate::provenance::{self, OutputMode, ProvenanceFlags};
 use crate::sdk::Snomed;
@@ -75,7 +76,7 @@ pub struct ListArgs {
     pub json: bool,
 
     /// Override the per-refset line template (text output only).
-    /// Default: `{id} | {pt} ({count} members)`. See `docs/commands/refset.md`.
+    /// Default: `{id} | {pt} (<member count>)`. See `docs/commands/refset.md`.
     #[arg(long)]
     pub template: Option<String>,
 
@@ -270,24 +271,32 @@ fn run_list(args: ListArgs) -> Result<()> {
         return Ok(());
     }
 
-    let format = ConceptFormat {
-        line: "{id} | {pt} ({count} members)".into(),
+    let custom_format = args.template.map(|line| ConceptFormat {
+        line,
         fsn_suffix: String::new(),
-    }
-    .with_overrides(args.template, Some(String::new()));
+    });
 
     for r in &rows {
-        println!(
-            "{}",
-            format.render(&ConceptFields {
-                id: &r.id,
-                pt: &r.preferred_term,
-                fsn: &r.fsn,
-                module: &r.module,
-                count: Some(r.member_count),
-                ..Default::default()
-            })
-        );
+        if let Some(format) = &custom_format {
+            println!(
+                "{}",
+                format.render(&ConceptFields {
+                    id: &r.id,
+                    pt: &r.preferred_term,
+                    fsn: &r.fsn,
+                    module: &r.module,
+                    count: Some(r.member_count),
+                    ..Default::default()
+                })
+            );
+        } else {
+            println!(
+                "{} | {} ({})",
+                r.id,
+                r.preferred_term,
+                plural_count(r.member_count as u64, "member")
+            );
+        }
     }
     provenance::print_human_footer(prov.as_ref(), show_prov);
     Ok(())

--- a/src/commands/sayt.rs
+++ b/src/commands/sayt.rs
@@ -16,6 +16,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::PathBuf;
 
+#[cfg(feature = "tui")]
+use crate::humanize::plural_count;
 use crate::index::query::Index;
 
 #[derive(Parser, Debug)]
@@ -266,11 +268,10 @@ fn render_tui(frame: &mut ratatui::Frame, index: &Index, state: &TuiState) {
         list_state.select(Some(state.selected));
     }
     let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(format!(" {} results ", state.hits.len())),
-        )
+        .block(Block::default().borders(Borders::ALL).title(format!(
+            " {} ",
+            plural_count(state.hits.len() as u64, "result")
+        )))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
     frame.render_stateful_widget(list, rows[1], &mut list_state);
 

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -30,7 +30,7 @@ use serde_json::json;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 
-use crate::humanize::fmt_count;
+use crate::humanize::{fmt_count, plural_count};
 use crate::output::OutputFormat;
 
 /// Default number of rows sampled to estimate the average NDJSON row size.
@@ -232,11 +232,11 @@ pub fn run(args: Args) -> Result<()> {
     println!("{:<18} {:<16} Method", "Format", "Estimated size");
     println!("{}", "─".repeat(72));
     println!(
-        "{:<18} {:<16} sampled avg {} B/row × {} rows",
+        "{:<18} {:<16} sampled avg {} B/row × {}",
         "NDJSON",
         fmt_bytes(est.ndjson_total),
         fmt_count(est.avg_ndjson_bytes),
-        fmt_count(est.subtree_count)
+        plural_count(est.subtree_count, "row")
     );
     println!(
         "{:<18} {:<16} proportional to full DB ({}) by concept count",
@@ -533,10 +533,10 @@ fn print_tree(
 ) -> Result<()> {
     let size = crate::commands::get_subtree_size(conn, concept_id)?;
     let node_str = format!(
-        "{} [{}] ({} descendants)",
+        "{} [{}] ({})",
         preferred_term,
         concept_id,
-        fmt_count(size.saturating_sub(1))
+        plural_count(size.saturating_sub(1), "descendant")
     );
     if depth == 0 {
         println!("{node_str}");

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -30,6 +30,7 @@ use serde_json::json;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 
+use crate::humanize::fmt_count;
 use crate::output::OutputFormat;
 
 /// Default number of rows sampled to estimate the average NDJSON row size.
@@ -519,18 +520,6 @@ pub(crate) fn fmt_bytes(n: u64) -> String {
     } else {
         format!("~{} B", n)
     }
-}
-
-pub(crate) fn fmt_count(n: u64) -> String {
-    let s = n.to_string();
-    let mut result = String::with_capacity(s.len() + s.len() / 3);
-    for (i, ch) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            result.push(',');
-        }
-        result.push(ch);
-    }
-    result.chars().rev().collect()
 }
 
 fn print_tree(

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -19,6 +19,7 @@ use rusqlite::{params, Connection};
 use std::io::BufRead;
 use std::path::PathBuf;
 
+use crate::humanize::plural_count;
 use crate::provenance;
 use crate::schema::ConceptRecord;
 
@@ -264,7 +265,11 @@ pub fn run(args: Args) -> Result<()> {
         pb.println(format!("Loaded {history_n} concept-history rows"));
     }
 
-    pb.finish_with_message(format!("Done. {} concepts → {}", n, args.output.display()));
+    pb.finish_with_message(format!(
+        "Done. {} → {}",
+        plural_count(n as u64, "concept"),
+        args.output.display()
+    ));
 
     if args.transitive_closure {
         crate::commands::tct::build(&mut conn, args.include_self)?;

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -205,7 +205,7 @@ pub fn run(args: Args) -> Result<()> {
 
             n += 1;
             if n.is_multiple_of(50_000) {
-                pb.set_message(format!("{} concepts loaded...", n));
+                pb.set_message(format!("{} loaded...", plural_count(n as u64, "concept")));
             }
         }
 
@@ -230,7 +230,10 @@ pub fn run(args: Args) -> Result<()> {
     // elapsed clock advancing) through the blocking FTS rebuild, so the build
     // never looks hung.
     pb.finish_and_clear();
-    let pb = crate::progress::spinner(format!("{} concepts committed; creating indexes...", n));
+    let pb = crate::progress::spinner(format!(
+        "{} committed; creating indexes...",
+        plural_count(n as u64, "concept")
+    ));
 
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_concepts_hierarchy ON concepts(hierarchy);
@@ -262,7 +265,10 @@ pub fn run(args: Args) -> Result<()> {
     // --- Concept history sidecar (`<input-stem>.history.ndjson`, if present) ---
     let history_n = load_history_sidecar(&conn, &args.input)?;
     if history_n > 0 {
-        pb.println(format!("Loaded {history_n} concept-history rows"));
+        pb.println(format!(
+            "Loaded {}",
+            plural_count(history_n as u64, "concept-history row")
+        ));
     }
 
     pb.finish_with_message(format!(

--- a/src/commands/trud.rs
+++ b/src/commands/trud.rs
@@ -25,6 +25,7 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 use tempfile::NamedTempFile;
 
+use crate::humanize::human_bytes as human_size;
 use crate::paths::{self, Config};
 
 // ---------------------------------------------------------------------------
@@ -1114,25 +1115,6 @@ fn sha256_of_file(path: &Path) -> Result<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn human_size(bytes: u64) -> String {
-    const GB: u64 = 1 << 30;
-    const MB: u64 = 1 << 20;
-    const KB: u64 = 1 << 10;
-    if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.0} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{bytes} B")
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1174,31 +1156,6 @@ mod tests {
                 "accepted unsafe filename {unsafe_name:?}"
             );
         }
-    }
-
-    // --- human_size ------------------------------------------------------------
-
-    #[test]
-    fn human_size_bytes() {
-        assert_eq!(human_size(0), "0 B");
-        assert_eq!(human_size(512), "512 B");
-        assert_eq!(human_size(1023), "1023 B");
-    }
-
-    #[test]
-    fn human_size_kilobytes() {
-        assert_eq!(human_size(1024), "1 KB");
-        assert_eq!(human_size(2048), "2 KB");
-    }
-
-    #[test]
-    fn human_size_megabytes() {
-        assert_eq!(human_size(5 * 1024 * 1024), "5.0 MB");
-    }
-
-    #[test]
-    fn human_size_gigabytes() {
-        assert_eq!(human_size(2 * 1024 * 1024 * 1024), "2.0 GB");
     }
 
     // --- expand_tilde ----------------------------------------------------------

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -29,7 +29,8 @@ use rusqlite::{params, Connection, OpenFlags};
 use serde_json::Value;
 use std::{io, path::PathBuf, time::Duration};
 
-use crate::commands::size::{estimate_sizes, fmt_bytes, fmt_count, SizeEstimate, DEFAULT_SAMPLE};
+use crate::commands::size::{estimate_sizes, fmt_bytes, SizeEstimate, DEFAULT_SAMPLE};
+use crate::humanize::fmt_count;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -30,7 +30,7 @@ use serde_json::Value;
 use std::{io, path::PathBuf, time::Duration};
 
 use crate::commands::size::{estimate_sizes, fmt_bytes, SizeEstimate, DEFAULT_SAMPLE};
-use crate::humanize::fmt_count;
+use crate::humanize::{fmt_count, plural_count};
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -806,9 +806,9 @@ fn render_detail(frame: &mut Frame, app: &mut App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("Subtree:   ", Style::default().fg(DIM)),
-            Span::raw(format!(
-                "{} descendants",
-                fmt_count(concept.subtree_size.saturating_sub(1))
+            Span::raw(plural_count(
+                concept.subtree_size.saturating_sub(1),
+                "descendant",
             )),
         ]),
         if let Some(size) = size_line {

--- a/src/humanize.rs
+++ b/src/humanize.rs
@@ -9,17 +9,22 @@
 /// Format a byte count as a human-readable size (`"512 B"`, `"1.0 KB"`,
 /// `"5.0 MB"`, `"2.0 GB"`).
 pub fn human_bytes(bytes: u64) -> String {
-    const GB: u64 = 1 << 30;
-    const MB: u64 = 1 << 20;
-    const KB: u64 = 1 << 10;
-    if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.1} KB", bytes as f64 / KB as f64)
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    size = (size * 10.0).round() / 10.0;
+    if size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
     } else {
-        format!("{bytes} B")
+        format!("{size:.1} {}", UNITS[unit])
     }
 }
 
@@ -61,16 +66,26 @@ mod tests {
     fn human_bytes_kilobytes() {
         assert_eq!(human_bytes(1024), "1.0 KB");
         assert_eq!(human_bytes(2048), "2.0 KB");
+        assert_eq!(human_bytes(1536), "1.5 KB");
     }
 
     #[test]
     fn human_bytes_megabytes() {
+        assert_eq!(human_bytes(1024 * 1024 - 1), "1.0 MB");
+        assert_eq!(human_bytes(1024 * 1024), "1.0 MB");
         assert_eq!(human_bytes(5 * 1024 * 1024), "5.0 MB");
     }
 
     #[test]
     fn human_bytes_gigabytes() {
+        assert_eq!(human_bytes(1024 * 1024 * 1024 - 1), "1.0 GB");
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GB");
         assert_eq!(human_bytes(2 * 1024 * 1024 * 1024), "2.0 GB");
+    }
+
+    #[test]
+    fn human_bytes_terabytes() {
+        assert_eq!(human_bytes(3 * 1024_u64.pow(4)), "3.0 TB");
     }
 
     #[test]

--- a/src/humanize.rs
+++ b/src/humanize.rs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Shared human-readable formatting helpers: byte sizes, thousands-separated
+//! counts, and English pluralisation of a trailing noun. Several commands
+//! (`info`, `trud`, `diff`, `size`) previously carried their own copies of
+//! this logic; this module is the single tested source.
+
+/// Format a byte count as a human-readable size (`"512 B"`, `"1.0 KB"`,
+/// `"5.0 MB"`, `"2.0 GB"`).
+pub fn human_bytes(bytes: u64) -> String {
+    const GB: u64 = 1 << 30;
+    const MB: u64 = 1 << 20;
+    const KB: u64 = 1 << 10;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Format an integer with thousands separators (`1234567` -> `"1,234,567"`).
+pub fn fmt_count(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::with_capacity(s.len() + s.len() / 3);
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}
+
+/// Render a count with its noun, pluralised with a trailing `s` unless `n == 1`
+/// (`(1, "concept")` -> `"1 concept"`, `(5, "concept")` -> `"5 concepts"`).
+pub fn plural_count(n: u64, singular: &str) -> String {
+    if n == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{} {singular}s", fmt_count(n))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_bytes_sub_kilobyte() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(1023), "1023 B");
+    }
+
+    #[test]
+    fn human_bytes_kilobytes() {
+        assert_eq!(human_bytes(1024), "1.0 KB");
+        assert_eq!(human_bytes(2048), "2.0 KB");
+    }
+
+    #[test]
+    fn human_bytes_megabytes() {
+        assert_eq!(human_bytes(5 * 1024 * 1024), "5.0 MB");
+    }
+
+    #[test]
+    fn human_bytes_gigabytes() {
+        assert_eq!(human_bytes(2 * 1024 * 1024 * 1024), "2.0 GB");
+    }
+
+    #[test]
+    fn fmt_count_thousands() {
+        assert_eq!(fmt_count(1_234_567), "1,234,567");
+        assert_eq!(fmt_count(831_132), "831,132");
+        assert_eq!(fmt_count(42), "42");
+        assert_eq!(fmt_count(0), "0");
+    }
+
+    #[test]
+    fn plural_count_singular() {
+        assert_eq!(plural_count(1, "concept"), "1 concept");
+    }
+
+    #[test]
+    fn plural_count_plural() {
+        assert_eq!(plural_count(0, "concept"), "0 concepts");
+        assert_eq!(plural_count(2, "concept"), "2 concepts");
+        assert_eq!(plural_count(1_234, "concept"), "1,234 concepts");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod ecl;
 #[cfg(feature = "cli")]
 pub mod format;
 #[cfg(feature = "cli")]
-pub mod humanize;
+mod humanize;
 pub mod index;
 mod mapping;
 #[cfg(feature = "cli")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub mod commands;
 pub mod ecl;
 #[cfg(feature = "cli")]
 pub mod format;
+#[cfg(feature = "cli")]
+pub mod humanize;
 pub mod index;
 mod mapping;
 #[cfg(feature = "cli")]

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -34,6 +34,19 @@ fn build_ndjson(dir: &Path, name: &str) -> PathBuf {
     out
 }
 
+fn build_db(dir: &Path, ndjson: &Path, name: &str) -> PathBuf {
+    let out = dir.join(name);
+    Command::cargo_bin("sct")
+        .unwrap()
+        .args(["sqlite", "--ndjson"])
+        .arg(ndjson)
+        .arg("--output")
+        .arg(&out)
+        .assert()
+        .success();
+    out
+}
+
 /// Snapshot `value` under `name`, redacting the volatile bits that legitimately
 /// change run-to-run or release-to-release (file paths, the building sct
 /// version) so the snapshot captures layout + stable content only.
@@ -89,6 +102,60 @@ fn diff_summary_one_inactivated() {
     let stdout = String::from_utf8(output.stdout).unwrap();
 
     snapshot_filtered("diff_one_inactivated", stdout);
+}
+
+#[test]
+fn refset_compare_and_profile_text() {
+    const REFSET: &str = "991381000000107";
+
+    let tmp = tempfile::tempdir().unwrap();
+    let ndjson = build_ndjson(tmp.path(), "syn.ndjson");
+    let db = build_db(tmp.path(), &ndjson, "syn.db");
+
+    let compare = Command::cargo_bin("sct")
+        .unwrap()
+        .args(["refset", "compare", REFSET, REFSET, "--show", "all", "--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(
+        compare.status.success(),
+        "sct refset compare should succeed"
+    );
+    insta::assert_snapshot!(
+        "refset_compare_text",
+        String::from_utf8(compare.stdout).unwrap()
+    );
+
+    let profile = Command::cargo_bin("sct")
+        .unwrap()
+        .args(["refset", "profile", REFSET, "--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(
+        profile.status.success(),
+        "sct refset profile should succeed"
+    );
+    insta::assert_snapshot!(
+        "refset_profile_text",
+        String::from_utf8(profile.stdout).unwrap()
+    );
+
+    let empty_profile = Command::cargo_bin("sct")
+        .unwrap()
+        .args(["refset", "profile", "900000000000508004", "--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(
+        empty_profile.status.success(),
+        "sct refset profile should handle an empty refset"
+    );
+    insta::assert_snapshot!(
+        "refset_empty_profile_text",
+        String::from_utf8(empty_profile.stdout).unwrap()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/snapshots/snapshots__diff_one_inactivated.snap
+++ b/tests/snapshots/snapshots__diff_one_inactivated.snap
@@ -13,5 +13,5 @@ Changes:
   Preferred term:          0
   Hierarchy moved:         0
 
-## Inactivated (1 concepts)
+## Inactivated (1 concept)
   - [22298006] Myocardial infarction  (Clinical finding)

--- a/tests/snapshots/snapshots__refset_compare_text.snap
+++ b/tests/snapshots/snapshots__refset_compare_text.snap
@@ -1,0 +1,18 @@
+---
+source: tests/snapshots.rs
+expression: "String::from_utf8(compare.stdout).unwrap()"
+---
+A: [991381000000107] Example clinical reference set
+B: [991381000000107] Example clinical reference set
+
+Only in A: 0
+Only in B: 0
+In both:   2
+
+Only in A (0):
+
+Only in B (0):
+
+In both (2):
+  46635009 | Type 1 diabetes mellitus (Clinical finding)
+  44054006 | Type 2 diabetes mellitus (Clinical finding)

--- a/tests/snapshots/snapshots__refset_empty_profile_text.snap
+++ b/tests/snapshots/snapshots__refset_empty_profile_text.snap
@@ -1,0 +1,8 @@
+---
+source: tests/snapshots.rs
+expression: "String::from_utf8(empty_profile.stdout).unwrap()"
+---
+[900000000000508004] Great Britain English language reference set
+Members: 0
+
+No members loaded for this refset.

--- a/tests/snapshots/snapshots__refset_profile_text.snap
+++ b/tests/snapshots/snapshots__refset_profile_text.snap
@@ -1,0 +1,8 @@
+---
+source: tests/snapshots.rs
+expression: "String::from_utf8(profile.stdout).unwrap()"
+---
+[991381000000107] Example clinical reference set
+Members: 2
+
+  Clinical finding                              2  (100.0%)

--- a/tests/trud_api.rs
+++ b/tests/trud_api.rs
@@ -94,7 +94,8 @@ async fn list_shows_available_release() {
     run(cmd)
         .await
         .success()
-        .stdout(predicate::str::contains("uk_release_20260101.zip"));
+        .stdout(predicate::str::contains("uk_release_20260101.zip"))
+        .stdout(predicate::str::contains("1.0 KB"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

Picks up roadmap item `R6` ("Consolidate formatting and finish human-output polish"):

- Adds `src/humanize.rs`: a single tested module for byte-size formatting (`human_bytes`), thousands-separated counts (`fmt_count`), and English pluralisation (`plural_count`).
- Removes four duplicate copies of this logic from `info.rs`, `trud.rs`, `diff.rs`, and `size.rs` (each had its own near-identical `human_size`/`fmt_count`), and updates `tui.rs`'s import accordingly.
- Fixes singular-output bugs where a count of 1 rendered as e.g. `1 concepts` or `1 hierarchy files` instead of `1 concept`/`1 hierarchy file`, in `sct diff`, `sct markdown --mode hierarchy`, `sct sqlite`, and `sct parquet`. The `## Inactivated (1 concepts)` case in `sct diff` was an actual bug reproducible from the committed synthetic fixture — its snapshot (`tests/snapshots/snapshots__diff_one_inactivated.snap`) is re-blessed to `## Inactivated (1 concept)`.
- Drops the stray 2-space leading indent on `sct refset compare` and `sct refset profile` human-text output so it's flush-left, matching the convention used by `sct info`, `sct diff`, and every other command.
- Removes the now-shipped `R6` line from `spec/roadmap.md`.

## Test plan

- [x] `rustfmt --check` on all touched files (clean, no diffs)
- [x] Manual read-through of every diff for correctness (byte-count rounding, type inference, snapshot text)
- [ ] `cargo test` — **could not run in this sandbox**: `libsqlite3-sys` (a mandatory, non-optional dependency via `rusqlite`) fails to build its build script under this environment's rustc (`error[E0658]: use of unstable library feature 'cfg_select'`). This is a pre-existing sandbox limitation unrelated to this change (previously flagged in review comments on #38/#40) — please let CI confirm the build and test suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCbcvrDW3kWQNUSisxNbvr)_