### PR TITLE
fix(cli)!: exit non-zero on single-lookup miss (R4)

### DIFF
--- a/docs/commands/lookup.md
+++ b/docs/commands/lookup.md
@@ -22,6 +22,8 @@ sct lookup <CODE> [--db <FILE>] [-f text|json|yaml]
 | `--ids` | off | Emit only the resolved SCTID(s), newline-delimited, for piping. With a CTV3 code, prints the mapped SNOMED concept id(s). |
 | `--provenance` / `--no-provenance` | auto | Show or hide the release provenance footer (default: on for an interactive terminal). |
 
+**Exit codes:** an unresolved `<CODE>` (unknown SCTID, or a CTV3 code with no mapping) writes a hint to stderr and exits `1`, so `sct lookup` fails loudly in scripts instead of succeeding with no output.
+
 ---
 
 ## Examples

--- a/docs/commands/refset.md
+++ b/docs/commands/refset.md
@@ -29,6 +29,8 @@ All subcommands accept `--db <PATH>` (auto-discovered when omitted - see [Path r
 sct refset members 447562003 --ids | sct codelist add list.codelist -
 ```
 
+**Exit codes:** `info <ID>` and `profile <ID>` name a single refset, so an `<ID>` that isn't in the `concepts` table writes a hint to stderr and exits `1`, rather than succeeding with no useful output.
+
 ---
 
 ## Examples

--- a/src/commands/lookup.rs
+++ b/src/commands/lookup.rs
@@ -12,7 +12,7 @@
 //!   sct lookup --db snomed.db 22298006
 //!   sct lookup XE0Uh
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Parser;
 use rusqlite::{params, Connection};
 use std::path::PathBuf;
@@ -84,18 +84,16 @@ pub fn run(args: Args) -> Result<()> {
         if let Some(concept) = snomed.concept(code)? {
             return print_concept(concept, format, prov.as_ref(), show_prov);
         }
-        println!("Concept {code} not found.");
-        return Ok(());
+        bail!("Concept {code} not found.");
     }
 
     // Non-numeric: try CTV3 mapping.
     let mapped = lookup_ctv3(snomed.connection(), code)?;
     if mapped.is_empty() {
-        println!("No SNOMED CT mapping found for CTV3 code '{code}'.");
-        println!(
-            "Mappings are only present when the database was built from a UK Monolith RF2 release."
+        bail!(
+            "No SNOMED CT mapping found for CTV3 code '{code}'.\n\
+             Mappings are only present when the database was built from a UK Monolith RF2 release."
         );
-        return Ok(());
     }
 
     if mapped.len() == 1 {

--- a/src/commands/refset.rs
+++ b/src/commands/refset.rs
@@ -17,7 +17,7 @@
 //! The [`list_refsets`] and [`list_refset_members`] query helpers are shared
 //! with the `sct mcp` server so the two surfaces always return the same data.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -318,10 +318,7 @@ fn run_info(args: InfoArgs) -> Result<()> {
 
     let r = match meta {
         Some(r) => r,
-        None => {
-            println!("Refset {} not found in concepts table.", args.id);
-            return Ok(());
-        }
+        None => bail!("Refset {} not found in concepts table.", args.id),
     };
 
     if r.member_count == 0 && !out.is_structured() {
@@ -493,10 +490,7 @@ fn run_profile(args: ProfileArgs) -> Result<()> {
     let refset = snomed.refset(&args.id)?;
     let refset = match refset {
         Some(r) => r,
-        None => {
-            println!("Refset {} not found in concepts table.", args.id);
-            return Ok(());
-        }
+        None => bail!("Refset {} not found in concepts table.", args.id),
     };
     let hierarchies = snomed.refset_profile(&args.id)?;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -204,3 +204,67 @@ fn codelist_validate_missing_file_fails() {
         .assert()
         .failure();
 }
+
+// --- R4: single-lookup miss exit-code contracts ------------------------------
+//
+// A single-item lookup that finds nothing is an error, not an empty success:
+// it writes a hint to stderr and exits non-zero, unlike a search command's
+// zero-results case (which stays exit 0 with machine-clean stdout).
+
+#[test]
+fn lookup_missing_sctid_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = build_db(tmp.path());
+    sct()
+        .args(["lookup", "999999999"])
+        .arg("--db")
+        .arg(&db)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn lookup_missing_ctv3_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = build_db(tmp.path());
+    sct()
+        .args(["lookup", "ZZZZZ"])
+        .arg("--db")
+        .arg(&db)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "No SNOMED CT mapping found for CTV3 code",
+        ));
+}
+
+#[test]
+fn refset_info_missing_refset_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = build_db(tmp.path());
+    sct()
+        .args(["refset", "info", "999999999"])
+        .arg("--db")
+        .arg(&db)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn refset_profile_missing_refset_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = build_db(tmp.path());
+    sct()
+        .args(["refset", "profile", "999999999"])
+        .arg("--db")
+        .arg(&db)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("not found"));
+}


### PR DESCRIPTION
## Summary

Roadmap item `R4` ("Make stdout and exit status reliable"): `sct lookup` and `sct refset info`/`profile` printed a "not found" message to **stdout** and exited **0** when the identifier didn't resolve, so scripts piping their output couldn't distinguish a miss from a hit. This PR makes single-item lookups fail loudly, matching the convention `sct diagram` already used (`anyhow::bail!` on a missing concept).

- `sct lookup <CODE>`: unresolved SCTID or CTV3-with-no-mapping now writes the hint to stderr and exits `1`.
- `sct refset info <ID>` / `sct refset profile <ID>`: unknown refset ID now writes the hint to stderr and exits `1`.
- Search-style commands (`lexical`, `fst search`, `codelist search`) were audited and are **unchanged** — an empty result set is not an error there, and they already keep stdout machine-clean under `--format json`, per the roadmap item's own carve-out.
- Usage errors already exit `2` via clap; no change needed.

This is a **breaking behaviour change** (exit code + which stream carries the message), flagged in the commit trailer so it surfaces correctly in the git-cliff changelog.

## Test plan

- [x] Added CLI contract tests in `tests/cli.rs` (`lookup_missing_sctid_fails`, `lookup_missing_ctv3_fails`, `refset_info_missing_refset_fails`, `refset_profile_missing_refset_fails`) asserting exit code `1` and stderr content, following the existing `codelist_validate_missing_file_fails` pattern.
- [x] Updated `docs/commands/lookup.md` and `docs/commands/refset.md` with the new exit-code behaviour.
- [ ] Could not run `cargo build`/`cargo test` in this sandbox — `libsqlite3-sys 0.38.1`'s build script uses the unstable `cfg_select!` macro against the sandbox's `rustc 1.94.1`, a pre-existing environment issue unrelated to this change (already noted in prior automated reviews on #38/#40). `cargo fmt --check` passes on the touched files. Please let CI (and/or a local build on a newer toolchain) confirm compilation.

## Scope note

The roadmap item also calls for applying this consistently across "lookup, refset, lexical, FST, and codelist commands" and documenting "the convention." I audited all of them: `lexical`, `fst search`, and `codelist search` were already compliant (empty-result stays exit 0, stdout stays clean under structured formats), so no code changes were needed there — I did not add contract tests for those pre-existing paths to keep this PR focused on the actual gap. I left `spec/roadmap.md` untouched rather than removing `R4` myself; happy to follow up if you'd like the entry closed out or the doc convention written up more formally (e.g. a dedicated exit-codes page) beyond the per-command notes added here.


---
_Generated by [Claude Code](https://claude.ai/code/session_019LzzsQhhcNocrHNRLwjxok)_