### PR TITLE
fix(size): fall back to recursive CTE when TCT table is missing (R8)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -63,7 +63,7 @@ pub(crate) fn get_subtree_size(conn: &Connection, concept_id: &str) -> Result<u6
             "SELECT COUNT(*) FROM (
                 SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = ?1
                 UNION
-                SELECT ?1
+                SELECT CAST(?1 AS INTEGER)
              )",
             rusqlite::params![concept_id],
             |r| r.get(0),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -58,13 +58,7 @@ pub(crate) fn open_db_readonly(path: &Path, cache_size_kib: Option<u32>) -> Resu
 /// Get the total size of a concept's subtree (including itself).
 /// Uses the transitive closure table if available, falling back to a recursive query.
 pub(crate) fn get_subtree_size(conn: &Connection, concept_id: &str) -> Result<u64> {
-    let has_tct = conn.query_row(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
-        [],
-        |_| Ok(true),
-    )?;
-
-    let count: u64 = if has_tct {
+    let count: u64 = if crate::ecl::eval::has_tct(conn) {
         let cnt: i64 = conn.query_row(
             "SELECT COUNT(*) FROM (
                 SELECT descendant_id FROM concept_ancestors WHERE ancestor_id = ?1

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -75,13 +75,7 @@ impl SizeEstimate {
 /// NDJSON row byte length. A value of 50–200 gives a good balance between speed
 /// and accuracy. Requires an open `Connection`; does **not** open its own.
 pub fn estimate_sizes(conn: &Connection, root_id: &str, sample: usize) -> Result<SizeEstimate> {
-    let has_tct = conn
-        .query_row(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
-            [],
-            |_| Ok(true),
-        )
-        .unwrap_or(false);
+    let has_tct = crate::ecl::eval::has_tct(conn);
 
     let subtree_count = crate::commands::get_subtree_size(conn, root_id)?;
     let total_count: u64 = conn
@@ -155,13 +149,7 @@ pub fn run(args: Args) -> Result<()> {
     let db_path = crate::paths::resolve_db(args.db.as_deref())?.path;
     let mut conn = crate::commands::open_db_readonly(&db_path, None)?;
 
-    let mut has_tct = conn
-        .query_row(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
-            [],
-            |_| Ok(true),
-        )
-        .unwrap_or(false);
+    let mut has_tct = crate::ecl::eval::has_tct(&conn);
 
     let start_concept = resolve_root(&conn, args.concept)?;
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -13,8 +13,8 @@
 
 use rusqlite::Connection;
 use sct_rs::commands::ndjson::{self, RefsetMode};
-use sct_rs::commands::size;
 use sct_rs::commands::sqlite;
+use sct_rs::commands::{size, tct};
 use sct_rs::ecl;
 use sct_rs::schema::ConceptRecord;
 use std::path::{Path, PathBuf};
@@ -491,6 +491,16 @@ fn size_estimate_for_root() {
     assert!(est.avg_ndjson_bytes > 0);
     assert_eq!(est.sqlite_total, est.total_db_bytes);
     assert!(est.ndjson_total > 0);
+}
+
+#[test]
+fn size_estimate_with_self_inclusive_transitive_closure_table() {
+    let (_d, _ndjson, db) = build_all("en-GB");
+    let mut conn = Connection::open(&db).unwrap();
+    tct::build(&mut conn, true).unwrap();
+
+    let est = size::estimate_sizes(&conn, "73211009", 50).unwrap();
+    assert_eq!(est.subtree_count, 3);
 }
 
 /// Regression test: without a transitive-closure table, the subtree count

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -493,6 +493,33 @@ fn size_estimate_for_root() {
     assert!(est.ndjson_total > 0);
 }
 
+/// Regression test: without a transitive-closure table, the subtree count
+/// must fall back to a recursive CTE rather than erroring out. It previously
+/// propagated SQLite's "query returned no rows" through `?` instead of
+/// treating a missing `concept_ancestors` table as `has_tct = false`.
+#[test]
+fn size_estimate_without_transitive_closure_table() {
+    let (_d, _ndjson, db) = build_all("en-GB");
+    let conn = Connection::open(&db).unwrap();
+
+    let has_tct: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap_or(false);
+    assert!(
+        !has_tct,
+        "fixture db unexpectedly has a transitive-closure table"
+    );
+
+    // Diabetes mellitus (73211009) plus its two children = 3 concepts,
+    // matching the `<<73211009` ECL result asserted elsewhere in this suite.
+    let est = size::estimate_sizes(&conn, "73211009", 50).unwrap();
+    assert_eq!(est.subtree_count, 3);
+}
+
 #[test]
 fn size_builds_tct_when_missing() {
     use sct_rs::commands::size::{self, Args};


### PR DESCRIPTION
## Summary

- `get_subtree_size()` propagated SQLite's `QueryReturnedNoRows` through `?` instead of treating a missing `concept_ancestors` table as `has_tct = false`. On any database without a transitive-closure table, `sct size`, `sct gui`, and `sct tui` would error outright on subtree counts instead of degrading to the slower recursive-CTE path as the doc comment promises.
- All existing tests build fixtures with `--transitive-closure`, so this path was never exercised — verified by reverting just the fix and confirming the new test panics with exactly this error.
- Reused the existing `ecl::eval::has_tct()` helper (which correctly degrades via `.is_ok()`) in `get_subtree_size` and in `size.rs`'s two duplicate raw `has_tct` queries, instead of three near-identical copies of the same `sqlite_master` lookup.

This is a small, self-contained piece of the missing-TCT unification tracked as `R8` in `spec/roadmap.md` — it fixes the underlying correctness bug (a broken fallback path) but does **not** attempt the fuller CLI/MCP guidance-message unification `R8` also calls for, which is a larger, separate piece of work.

## Test plan

- [x] Added `size_estimate_without_transitive_closure_table` in `tests/end_to_end.rs`, which builds a fixture DB without a TCT and calls `size::estimate_sizes` against it.
- [x] Confirmed the new test panics on the pre-fix code (`Result::unwrap` on `QueryReturnedNoRows`) and passes after the fix.
- [x] Full test suite (`cargo test`) passes locally (needed a nightly toolchain in this sandbox to work around an unrelated pre-existing `libsqlite3-sys` build-script issue on stable; CI uses `stable` so should be unaffected).
- [x] `cargo fmt` applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tvv64a3wuEs3mesY7cxJLS)_