### PR TITLE
feat(info): unify sct info output with shared --format (R5)

### DIFF
--- a/docs/commands/info.md
+++ b/docs/commands/info.md
@@ -9,8 +9,10 @@ Accepts `.ndjson`, `.db`, and `.arrow` files.
 ## Usage
 
 ```
-sct info <FILE>
+sct info <FILE> [--format text|json|yaml]
 ```
+
+`--format` (`-f`) defaults to `text`. Use `json` or `yaml` for scripts and agents - the field names below (`concept_count`, `hierarchies`, `tct_row_count`, etc.) are stable across all three file types where they apply.
 
 ---
 
@@ -20,6 +22,7 @@ sct info <FILE>
 sct info snomed-uk-20260311.ndjson
 sct info snomed.db
 sct info snomed-embeddings.arrow
+sct info snomed.db --format json | jq .tct_row_count
 ```
 
 ---

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -20,7 +20,7 @@ The SDK programme has shipped native Rust and Python APIs over the same engine. 
 
 Do these alongside or immediately after the SDK extraction: they define contracts every adapter and binding should inherit rather than reimplement.
 
-- [ ] `R5` **Unify structured output formats.** Give `sct info` the shared `--format text|json|yaml`; align `map` and `diff` with the common vocabulary while retaining domain formats such as TSV/CSV/Markdown as additive variants; publish a removal schedule for hidden `--json` aliases.
+- [x] `R5` **Unify structured output formats.** Shipped: `sct info` now takes the shared `--format text|json|yaml` (all three file types - `.ndjson`, `.db`, `.arrow`); `map` and `diff` already used the common vocabulary with domain formats (TSV/CSV/Markdown) as additive variants. Removal schedule for the hidden `--json` aliases still present on `ecl`, `lookup`, and `refset`'s subcommands (`info`/`members`/`compare`/`profile`): keep them through the 0.x series for backward compatibility, remove no earlier than `v1.0.0`; `--format json` is the documented replacement today.
 
 - [ ] `R7` **Make stdin (`-`) composable across read commands.** Add batch stdin paths to the natural single-value readers (`lookup`, `lexical`, `semantic`, and relevant refset operations), with deterministic line-oriented or structured output suitable for pipelines.
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -10,11 +10,13 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use crate::humanize::{fmt_count, human_bytes};
+use crate::output::OutputFormat;
 use crate::provenance;
 use crate::schema::ConceptRecord;
 
@@ -23,6 +25,10 @@ pub struct Args {
     /// Path to a `.ndjson`, `.db`, or `.arrow` file produced by `sct`.
     #[arg(value_parser = crate::paths::tilde_pathbuf)]
     pub file: PathBuf,
+
+    /// Output format.
+    #[arg(long, short = 'f', value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
 }
 
 pub fn run(args: Args) -> Result<()> {
@@ -30,9 +36,9 @@ pub fn run(args: Args) -> Result<()> {
     anyhow::ensure!(path.exists(), "file not found: {}", path.display());
 
     match path.extension().and_then(|e| e.to_str()) {
-        Some("ndjson") => info_ndjson(path),
-        Some("db") => info_db(path),
-        Some("arrow") => info_arrow(path),
+        Some("ndjson") => info_ndjson(path, args.format),
+        Some("db") => info_db(path, args.format),
+        Some("arrow") => info_arrow(path, args.format),
         other => anyhow::bail!(
             "unrecognised file extension {:?}; expected .ndjson, .db, or .arrow",
             other
@@ -44,7 +50,7 @@ pub fn run(args: Args) -> Result<()> {
 // NDJSON
 // ---------------------------------------------------------------------------
 
-fn info_ndjson(path: &Path) -> Result<()> {
+fn info_ndjson(path: &Path, format: OutputFormat) -> Result<()> {
     let file = std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
     let file_size = file.metadata()?.len();
     let reader = BufReader::new(file);
@@ -76,6 +82,32 @@ fn info_ndjson(path: &Path) -> Result<()> {
         *hierarchy_counts
             .entry(record.hierarchy.clone())
             .or_insert(0) += 1;
+    }
+
+    // Sort by count descending, reused for both text and structured output.
+    let mut sorted: Vec<(&String, &u64)> = hierarchy_counts.iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(a.1));
+
+    if format.is_structured() {
+        let value = json!({
+            "file": path.display().to_string(),
+            "size_bytes": file_size,
+            "size_human": human_bytes(file_size),
+            "format": "ndjson",
+            "schema_version": schema_version,
+            "edition": prov.as_ref().map(|p| &p.edition_label).filter(|s| !s.is_empty()),
+            "release_date": prov.as_ref().map(|p| &p.release_date).filter(|s| !s.is_empty()),
+            "release_id": prov.as_ref().map(|p| &p.release_id).filter(|s| !s.is_empty()),
+            "built_by": prov.as_ref().map(|p| &p.sct_version).filter(|s| !s.is_empty()),
+            "release_date_inferred_from_filename": prov.is_none().then(|| extract_date_from_filename(path)).flatten(),
+            "concept_count": count,
+            "inactive_count": inactive_count,
+            "hierarchies": sorted.iter().map(|(h, n)| json!({"hierarchy": h, "count": n})).collect::<Vec<_>>(),
+        });
+        if let Some(s) = format.render(&value)? {
+            println!("{s}");
+        }
+        return Ok(());
     }
 
     println!("File:           {}", path.display());
@@ -114,9 +146,6 @@ fn info_ndjson(path: &Path) -> Result<()> {
         hierarchy_counts.len()
     );
 
-    // Sort by count descending for display
-    let mut sorted: Vec<(&String, &u64)> = hierarchy_counts.iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(a.1));
     for (hierarchy, n) in sorted {
         println!("  {:<45} {:>7}", hierarchy, fmt_count(*n));
     }
@@ -128,7 +157,7 @@ fn info_ndjson(path: &Path) -> Result<()> {
 // SQLite
 // ---------------------------------------------------------------------------
 
-fn info_db(path: &Path) -> Result<()> {
+fn info_db(path: &Path, format: OutputFormat) -> Result<()> {
     let file_size = std::fs::metadata(path)
         .with_context(|| format!("stat {}", path.display()))?
         .len();
@@ -198,6 +227,29 @@ fn info_db(path: &Path) -> Result<()> {
 
     let prov = provenance::read_sqlite(&conn).unwrap_or(None);
 
+    if format.is_structured() {
+        let value = json!({
+            "file": path.display().to_string(),
+            "size_bytes": file_size,
+            "size_human": human_bytes(file_size),
+            "format": "sqlite",
+            "schema_version": schema_version,
+            "edition": prov.as_ref().map(|p| &p.edition_label).filter(|s| !s.is_empty()),
+            "release_date": prov.as_ref().map(|p| &p.release_date).filter(|s| !s.is_empty()),
+            "release_id": prov.as_ref().map(|p| &p.release_id).filter(|s| !s.is_empty()),
+            "built_by": prov.as_ref().map(|p| &p.sct_version).filter(|s| !s.is_empty()),
+            "concept_count": concept_count,
+            "fts_row_count": fts_count,
+            "isa_edge_count": isa_count,
+            "tct_row_count": tct_count,
+            "hierarchies": rows.iter().map(|(h, n)| json!({"hierarchy": h, "count": n})).collect::<Vec<_>>(),
+        });
+        if let Some(s) = format.render(&value)? {
+            println!("{s}");
+        }
+        return Ok(());
+    }
+
     println!("File:              {}", path.display());
     println!("Size:              {}", human_bytes(file_size));
     println!("Format:            SQLite (sct sqlite)");
@@ -241,7 +293,7 @@ fn info_db(path: &Path) -> Result<()> {
 // Arrow IPC
 // ---------------------------------------------------------------------------
 
-fn info_arrow(path: &Path) -> Result<()> {
+fn info_arrow(path: &Path, format: OutputFormat) -> Result<()> {
     use arrow::ipc::reader::FileReader;
 
     let file = std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
@@ -265,6 +317,29 @@ fn info_arrow(path: &Path) -> Result<()> {
     let row_count: u64 = reader
         .map(|b| b.map(|b| b.num_rows() as u64).unwrap_or(0))
         .sum();
+
+    if format.is_structured() {
+        let value = json!({
+            "file": path.display().to_string(),
+            "size_bytes": file_size,
+            "size_human": human_bytes(file_size),
+            "format": "arrow",
+            "edition": prov.as_ref().map(|p| &p.edition_label).filter(|s| !s.is_empty()),
+            "release_date": prov.as_ref().map(|p| &p.release_date).filter(|s| !s.is_empty()),
+            "release_id": prov.as_ref().map(|p| &p.release_id).filter(|s| !s.is_empty()),
+            "built_by": prov.as_ref().map(|p| &p.sct_version).filter(|s| !s.is_empty()),
+            "embedding_count": row_count,
+            "dimension": dim,
+            "fields": schema.fields().iter().map(|f| json!({
+                "name": f.name(),
+                "data_type": f.data_type().to_string(),
+            })).collect::<Vec<_>>(),
+        });
+        if let Some(s) = format.render(&value)? {
+            println!("{s}");
+        }
+        return Ok(());
+    }
 
     println!("File:             {}", path.display());
     println!("Size:             {}", human_bytes(file_size));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -139,6 +139,28 @@ fn ndjson_sqlite_info_pipeline() {
 }
 
 #[test]
+fn info_format_json_emits_structured_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ndjson = build_ndjson(tmp.path());
+
+    let output = sct()
+        .args(["info", "--format", "json"])
+        .arg(&ndjson)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "sct info --format json should succeed"
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("stdout should be valid JSON, not the human-readable text layout");
+    assert_eq!(value["format"], "ndjson");
+    assert!(value["concept_count"].as_u64().unwrap() > 0);
+    assert!(value["hierarchies"].is_array());
+}
+
+#[test]
 fn sqlite_default_output_name_is_snomed_db() {
     let tmp = tempfile::tempdir().unwrap();
     let ndjson = tmp.path().join("out.ndjson");


### PR DESCRIPTION
## Summary

Nightly roadmap pick from `spec/roadmap.md` (`R5`, "Unify structured output formats"). `map` and `diff` already used the shared `crate::output::OutputFormat` (`text|json|yaml`); `sct info` was the one remaining command with hardcoded `println!` text output and no format flag.

- Add `--format`/`-f` (`text|json|yaml`, default `text`) to `sct info`, covering all three supported file types (`.ndjson`, `.db`, `.arrow`), following the exact pattern already used in `size.rs`.
- Text output is byte-for-byte unchanged (existing snapshot test `info_ndjson_summary` untouched).
- JSON/YAML output exposes the same data as the text layout: file/size, schema version, provenance (edition/release date/release id/built-by), concept/FTS/IS-A/TCT counts (`.db`), embedding count/dimension/field list (`.arrow`), and a `hierarchies` array for the hierarchy breakdown.
- Marked `R5` done in `spec/roadmap.md`, and recorded a removal schedule for the remaining hidden `--json` aliases on `ecl`/`lookup`/`refset` (kept through the 0.x series, earliest removal at `v1.0.0`).
- Updated `docs/commands/info.md` with the new flag and a `--format json | jq` example.
- Added `tests/cli.rs::info_format_json_emits_structured_output` asserting the JSON output parses and carries `format`/`concept_count`/`hierarchies`.

## Note on verification

This sandbox's default Rust toolchain (`rustc 1.94.1`) can't compile `libsqlite3-sys` (`cfg_select` unstable-feature error in its build script) — a pre-existing environment issue unrelated to this change (already flagged in review notes on #38/#40). I confirmed with an older pinned toolchain (`1.90.0`) that this is not new, then verified this change by:
- `rustfmt --check` on both edited Rust files (clean)
- careful manual review of borrow/ownership and type correctness in the new `json!(...)` blocks (all fields are `Copy` or read via `.as_ref()`/`.iter()`, so nothing here conflicts with the existing text-printing code that runs on the non-structured path)

Please run the full test suite / CI, since I could not execute `cargo test` locally here.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy`, `cargo test` (includes new `info_format_json_emits_structured_output` and existing `info_ndjson_summary` snapshot)
- [x] `rustfmt --check` on changed files (local, passed)
- [ ] Manual: `sct info <db> --format json | jq .` / `--format yaml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUKZ4dE2P6H3f7Z7LfYeE)_