### PR TITLE
feat(trud): add `sct trud auth` to store the API key in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ sqlite3 snomed.db \
 sct mcp --db snomed.db
 ```
 
-UK users can automate steps 1–3 with a single command once the [TRUD API integration](docs/commands/trud.md) is set up:
+UK users can automate steps 1–3 with a single command once the [TRUD API integration](docs/commands/trud.md) is set up. Store your TRUD API key once, then download and build in one go:
 
 ```bash
+sct trud auth < my-trud-key.txt              # one-time: verifies and saves the key
 sct trud download --edition uk_monolith --pipeline
 ```
 

--- a/docs/commands/trud.md
+++ b/docs/commands/trud.md
@@ -133,8 +133,9 @@ making any authenticated request. If the check fails you will see:
 ```
 Cannot reach NHS TRUD (https://isd.digital.nhs.uk/…).
 
-The service may be offline or undergoing scheduled maintenance.
-TRUD maintenance windows: weekdays 18:00–08:00 UK time, and midnight–06:00.
+The service may be offline or undergoing scheduled maintenance. TRUD advises
+running automation on weekdays 08:00-18:00 or 00:00-06:00 UK time to avoid
+planned maintenance.
 
 Original error: …
 ```
@@ -143,7 +144,7 @@ This check is connection-level only - any HTTP response from TRUD (even an error
 as "reachable". Only DNS failures, TCP timeouts, or TLS errors trigger this message.
 
 > **Tip:** If `sct trud` fails during a scheduled automation run, check the time against the
-> TRUD maintenance window before investigating further.
+> [recommended automation windows](#automating-updates) before investigating further.
 
 ---
 
@@ -484,8 +485,11 @@ trud_item = 42
 
 ## Automating updates
 
-UK SNOMED releases are published roughly monthly, typically on a Wednesday. TRUD recommends
-running automation between **08:00–18:00** or **midnight–06:00 UK time**.
+UK SNOMED releases are published roughly monthly, typically on a Wednesday. TRUD's
+[API guide](https://isd.digital.nhs.uk/trud/users/guest/filters/0/api) says to "run automation
+scripts on weekdays between 8am and 6pm, or midnight and 6am (UK time) to avoid planned
+maintenance". No downtime schedule is published, so treat those as the recommended windows
+rather than a guarantee about the rest of the day.
 
 ### macOS - launchd (runs weekly, Wednesday 09:00)
 
@@ -612,7 +616,10 @@ jobs:
 
 The TRUD service is not reachable. Check:
 
-1. **Maintenance window** - TRUD is offline weekdays 18:00–08:00 UK time and midnight–06:00.
+1. **Planned maintenance** - TRUD does not publish a downtime schedule, but
+   [advises](https://isd.digital.nhs.uk/trud/users/guest/filters/0/api) running automation on
+   weekdays between 08:00–18:00 or midnight–06:00 UK time to avoid it. Outside those hours, try
+   again before investigating.
 2. **Network connectivity** - can you load [isd.digital.nhs.uk](https://isd.digital.nhs.uk) in a browser?
 3. **Firewall / proxy** - some corporate networks block direct HTTPS to NHS services.
 

--- a/docs/commands/trud.md
+++ b/docs/commands/trud.md
@@ -38,9 +38,43 @@ password - if either changes, a new key is generated and the old one is disabled
 | 1        | `--api-key <KEY>`                        | Plain string on the command line. Avoid: visible in `ps` output and shell history. |
 | 2        | `--api-key-file <PATH>`                  | Path to a file whose **first line** is the key. Trailing whitespace is stripped.   |
 | 3        | `$TRUD_API_KEY` environment variable     | **Recommended** for regular use, cron jobs, and CI/CD.                             |
-| 4        | `api_key` in `~/.config/sct/config.toml` | Convenient for interactive use on a personal machine.                              |
+| 4        | `api_key` in `~/.config/sct/config.toml` | Convenient for interactive use on a personal machine. Write it with `sct trud auth`. |
 
-### Using an environment variable (recommended)
+### Storing the key with `sct trud auth` (easiest)
+
+`sct trud auth` does the whole setup in one step: it creates `~/.config/sct/` if needed, writes
+`config.toml` with owner-only permissions (`0600`), and sets `api_key` in the `[trud]` section.
+
+```bash
+sct trud auth < my-trud-key.txt     # from a file
+pass show nhs/trud | sct trud auth  # from a password manager
+sct trud auth your-key-here         # as an argument (lands in shell history)
+```
+
+The key is checked against TRUD before it is stored, so a typo is caught immediately rather
+than on your first download:
+
+```console
+$ sct trud auth < my-trud-key.txt
+sct trud auth: key verified against TRUD (uk_monolith subscribed)
+sct trud auth: stored key ********3456
+sct trud auth: wrote /home/you/.config/sct/config.toml
+sct trud auth: next step - sct trud list
+```
+
+A key TRUD rejects is not written at all. If TRUD is unreachable the key is stored with a
+warning so you can set up offline; `--no-verify` skips the check entirely, and `--dry-run`
+prints the resulting config without writing it.
+
+If you already have a `config.toml`, only the `api_key` line changes - your comments, other
+sections, and formatting are left exactly as they were.
+
+!!! warning "`$TRUD_API_KEY` wins"
+    The environment variable has higher priority than the config file, so an exported
+    `TRUD_API_KEY` shadows the key you just stored. `sct trud auth` warns you when it spots
+    this; `unset TRUD_API_KEY` to use the stored key.
+
+### Using an environment variable (recommended for CI)
 
 ```bash
 export TRUD_API_KEY=your-key-here
@@ -52,26 +86,15 @@ Or for a single command without polluting the environment:
 ```bash
 TRUD_API_KEY=your-key-here sct trud download --edition uk_monolith
 ```
-### Using the config file (recommended for interactive use)
-
-Create `~/.config/sct/config.toml` and set the `api_key = "you-key-here"`
-
-```toml
-[trud]
-api_key = "your-key-here"
-```
-
-See the [Config file](#config-file) section for the full list of options.
 
 ### Using a key file
 
-Using a key file lets you keep your api key separate from the rest of your sct config.
-The trade-off is you have to pass `--api-key-file <path>` to every command. 
-The conventional location is `~/.config/sct/trud-api-key`. The file must contain only the
-key on the first line (trailing whitespace is stripped). Set permissions to `600` and
+A key file keeps the key separate from the rest of your `sct` config. The trade-off is that you
+have to pass `--api-key-file <path>` to every command.
 
-The conventional location is `~/.config/sct/trud-api-key`. The file must contain only the
-key on the first line (trailing whitespace is stripped). Set permissions to `600` and **never commit this file to version control**.
+The conventional location is `~/.config/sct/trud-api-key`. The file must contain only the key on
+the first line (trailing whitespace is stripped). Set permissions to `600` and **never commit
+this file to version control**.
 
 ```bash
 mkdir -p ~/.config/sct
@@ -80,18 +103,25 @@ chmod 600 ~/.config/sct/trud-api-key
 sct trud list --api-key-file ~/.config/sct/trud-api-key
 ```
 
-For convenience, add this to `~/.config/sct/config.toml` so you do not need to pass the
-flag every time (see [Config file](#config-file) below).
+Or hand the file to `sct trud auth` once, and drop the flag entirely:
 
-### Using the config file
+```bash
+sct trud auth --api-key-file ~/.config/sct/trud-api-key
+```
 
-Create `~/.config/sct/config.toml`:
+### Editing the config file by hand
+
+`sct trud auth` is the easy path, but the file is plain TOML and you can equally write it
+yourself. Create `~/.config/sct/config.toml`:
 
 ```toml
 [trud]
 api_key = "your-key-here"
 download_dir = "~/.local/share/sct/releases"   # optional; this is the default
 ```
+
+Set permissions to `600` if you do: `chmod 600 ~/.config/sct/config.toml`. See the
+[Config file](#config-file) section for the full list of options.
 
 ---
 
@@ -118,6 +148,26 @@ as "reachable". Only DNS failures, TCP timeouts, or TLS errors trigger this mess
 ---
 
 ## Subcommands
+
+### `sct trud auth`
+
+Stores your API key in the config file - the one-time setup step described in
+[Storing the key with `sct trud auth`](#storing-the-key-with-sct-trud-auth-easiest) above.
+
+```
+sct trud auth [KEY] [--api-key-file <PATH>] [--config <PATH>] [--no-verify] [--dry-run]
+```
+
+| Flag                    | Description                                                                 |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `KEY`                   | The key. Omit it, or pass `-`, to read from stdin instead                    |
+| `--api-key-file <PATH>` | Read the key from the first line of this file                               |
+| `--config <PATH>`       | Config file to write. Default: `$SCT_CONFIG`, else `$SCT_CONFIG_HOME/config.toml` |
+| `--no-verify`           | Store the key without checking it against TRUD first                        |
+| `--dry-run`             | Print the resulting config to stdout without writing anything               |
+
+A project-local `./sct.toml` is deliberately *not* written unless you name it with `--config`,
+since such files are usually version-controlled.
 
 ### `sct trud list`
 

--- a/spec/commands/trud.md
+++ b/spec/commands/trud.md
@@ -59,16 +59,22 @@ source that provides a non-empty value is used; the remaining sources are not co
 2. `--api-key-file <PATH>` CLI flag - path to a file whose first line is the API key; the file
    may contain only the key and optional trailing whitespace
 3. `$TRUD_API_KEY` environment variable - **preferred for CI/CD and cron jobs**
-4. `api_key` field in the config file (`~/.config/sct/config.toml`)
+4. `api_key` field in the config file (`~/.config/sct/config.toml`) - write it with
+   [`sct trud auth`](#sct-trud-auth)
 
 If no key is found from any source, `sct trud` exits with a clear error message directing the
 user to the TRUD account page.
+
+Note the ordering consequence: `$TRUD_API_KEY` outranks the config file, so an exported key
+shadows whatever `sct trud auth` stored. `sct trud auth` warns when it detects this.
 
 ---
 
 ## Configuration file
 
-`~/.config/sct/config.toml` - created by the user; `sct trud` reads but never writes it.
+`~/.config/sct/config.toml` - hand-written by the user, or created by
+[`sct trud auth`](#sct-trud-auth). Apart from that one command writing `api_key`, `sct trud`
+only ever reads this file.
 
 ```toml
 [trud]
@@ -109,6 +115,46 @@ description = "NHS Data Migration Pack (final Read v2 / CTV3 / SNOMED CT maps)"
 ---
 
 ## Subcommands
+
+### `sct trud auth`
+
+Store the API key in the config file. This is the one-time setup step: it removes the need to
+create `~/.config/sct/`, create `config.toml`, and add a `[trud]` section by hand.
+
+```
+sct trud auth [KEY] [--api-key-file <PATH>] [--config <PATH>] [--no-verify] [--dry-run]
+```
+
+Key sources, in order: the `KEY` argument, `--api-key-file`, then stdin (`KEY` may be given as
+`-` to force this). Passing the key as an argument prints a note, because it lands in shell
+history and process listings; piping is preferred:
+
+```sh
+sct trud auth < my-trud-key.txt
+pass show nhs/trud | sct trud auth
+```
+
+Behaviour:
+
+- **Verifies before writing.** The key is probed against item 1799 (`uk_monolith`). A key TRUD
+  rejects (HTTP 400) is *not* written. A key that works but is not subscribed to that item is
+  written, with a note. If TRUD is unreachable the key is written with a warning, so setup
+  works offline. `--no-verify` skips the round-trip entirely.
+- **Preserves the rest of the file.** The edit is targeted at `api_key` in `[trud]`; comments,
+  key ordering, formatting, and every other section are left byte-for-byte intact. The file is
+  parsed before the edit (so a config we cannot understand is never rewritten) and re-parsed
+  after (so an edit that did not land as intended is never written).
+- **Owner-only permissions.** A config directory it creates is `0700` and the file is `0600`.
+  The write goes via a temporary file in the same directory, so a crash cannot truncate an
+  existing config.
+- **Never echoes the key.** Only the last four characters are shown.
+- **Warns when shadowed.** If `$TRUD_API_KEY` is set to a different value, it outranks the
+  config file, so the command says so.
+
+Target file: `$SCT_CONFIG` if set, otherwise `$SCT_CONFIG_HOME/config.toml` (normally
+`~/.config/sct/config.toml`). Unlike the read path, a project-local `./sct.toml` is *not*
+picked up automatically - it is usually version-controlled, and a credential should not land
+there by accident. Name it with `--config` if that is genuinely what you want.
 
 ### `sct trud list`
 
@@ -395,8 +441,10 @@ body to disk in chunks rather than loading the entire multi-GB zip into memory.
 
 ### API key security
 
-- Never include the raw API key in log output or error messages. Truncate to the first 6
-  characters (e.g. `deadc0…`) if it must appear in a diagnostic message.
+- Never include the raw API key in log output or error messages. Where a key must be
+  identifiable in a diagnostic (e.g. `sct trud auth` reporting which key it replaced), mask all
+  but the last four characters (`********3456`) - see `mask_key` in `src/commands/trud.rs`.
+  Transport errors that may embed the key in a URL go through `redact_key` first.
 - When reading from `--api-key-file`, trim all leading/trailing whitespace from the first line;
   do not read beyond the first line.
 - Validate that the key is non-empty before making any network request.

--- a/spec/commands/trud.md
+++ b/spec/commands/trud.md
@@ -305,8 +305,11 @@ sct trud download --edition uk_monolith --skip-if-current --pipeline-full
 
 ## Automation
 
-TRUD recommends running automation between **08:00–18:00** or **midnight–06:00 UK time** to
-avoid planned maintenance windows. UK SNOMED releases are published roughly monthly on a
+TRUD's [API guide](https://isd.digital.nhs.uk/trud/users/guest/filters/0/api) says to "run
+automation scripts on weekdays between 8am and 6pm, or midnight and 6am (UK time) to avoid
+planned maintenance". That is the only statement TRUD publishes about availability - there is
+no published downtime schedule, so do not describe the remaining hours as a maintenance
+window. UK SNOMED releases are published roughly monthly on a
 Wednesday.
 
 ### macOS - launchd

--- a/src/commands/trud.rs
+++ b/src/commands/trud.rs
@@ -4,6 +4,7 @@
 //! `sct trud` - Download SNOMED CT RF2 releases via the NHS TRUD API.
 //!
 //! Subcommands:
+//!   sct trud auth     - store your API key in the config file (one-time setup)
 //!   sct trud list     - list available releases for an edition/item
 //!   sct trud check    - check whether a newer release is available (exit 0/2)
 //!   sct trud download - download a release, verifying SHA-256, with optional pipeline
@@ -12,7 +13,7 @@
 //!   1. --api-key <KEY>           plain string flag
 //!   2. --api-key-file <PATH>     first line of the named file
 //!   3. $TRUD_API_KEY             environment variable (recommended for CI/cron)
-//!   4. api_key in ~/.config/sct/config.toml
+//!   4. api_key in ~/.config/sct/config.toml (write it with `sct trud auth`)
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -20,7 +21,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Deserializer};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::io::{BufWriter, Read, Write};
+use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 use tempfile::NamedTempFile;
@@ -74,6 +75,24 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum TrudCommand {
+    /// Store your TRUD API key in the config file, creating it if needed.
+    ///
+    /// This is the one-time setup step: it creates $SCT_CONFIG_HOME (normally
+    /// ~/.config/sct), writes config.toml with mode 0600, and sets api_key in
+    /// the [trud] section, leaving every other section and comment untouched.
+    ///
+    /// The key is checked against TRUD before being written, so a typo is
+    /// reported now rather than on your first download. Pass --no-verify to
+    /// skip that round-trip when offline.
+    ///
+    /// Supply the key as an argument, from a file with --api-key-file, or on
+    /// stdin (recommended - it keeps the key out of your shell history):
+    ///
+    ///   sct trud auth < my-key.txt
+    ///
+    ///   pass show nhs/trud | sct trud auth
+    Auth(AuthArgs),
+
     /// List available releases for a TRUD edition/item, newest first.
     List(ListArgs),
 
@@ -108,6 +127,36 @@ struct KeyArgs {
     /// Only the first line is read.
     #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
     api_key_file: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct AuthArgs {
+    /// TRUD API key.
+    ///
+    /// Omit it (or pass `-`) to read the key from stdin instead, which keeps it
+    /// out of your shell history and out of process listings.
+    api_key: Option<String>,
+
+    /// Read the key from the first line of this file.
+    #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
+    api_key_file: Option<PathBuf>,
+
+    /// Config file to write.
+    ///
+    /// Defaults to $SCT_CONFIG when set, otherwise $SCT_CONFIG_HOME/config.toml
+    /// (normally ~/.config/sct/config.toml). Note this ignores a ./sct.toml in
+    /// the current directory - project-local files are often version-controlled,
+    /// so we never write a secret there unless you name it explicitly.
+    #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
+    config: Option<PathBuf>,
+
+    /// Write the key without checking it against the TRUD API first.
+    #[arg(long)]
+    no_verify: bool,
+
+    /// Report what would change, without writing anything.
+    #[arg(long)]
+    dry_run: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -317,10 +366,319 @@ fn builtin_editions() -> HashMap<&'static str, BuiltinEdition> {
 
 pub fn run(args: Args) -> Result<()> {
     match args.subcommand {
+        TrudCommand::Auth(a) => run_auth(a),
         TrudCommand::List(a) => run_list(a),
         TrudCommand::Check(a) => run_check(a),
         TrudCommand::Download(a) => run_download(a),
     }
+}
+
+// ---------------------------------------------------------------------------
+// sct trud auth
+// ---------------------------------------------------------------------------
+
+/// Item probed to prove a key works. uk_monolith is the default edition
+/// everywhere else in this module, so a key that can see it is a key that can
+/// run `sct trud download` with no further flags.
+const VERIFY_ITEM_ID: u32 = 1799;
+
+fn run_auth(args: AuthArgs) -> Result<()> {
+    let key = read_auth_key(args.api_key.as_deref(), args.api_key_file.as_deref())?;
+
+    if !args.no_verify {
+        verify_api_key(&key)?;
+    }
+
+    let path = auth_config_path(args.config.as_deref());
+    let existing = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e).with_context(|| format!("reading config file {}", path.display())),
+    };
+
+    let edit = set_config_api_key(&existing, &key)
+        .with_context(|| format!("updating config file {}", path.display()))?;
+
+    if args.dry_run {
+        eprintln!(
+            "sct trud auth: would {} api_key in {}",
+            match &edit.previous {
+                Some(_) => "replace",
+                None => "set",
+            },
+            path.display()
+        );
+        print!("{}", edit.text);
+        return Ok(());
+    }
+
+    write_config_file(&path, &edit.text)?;
+
+    match &edit.previous {
+        Some(previous) if previous == &key => {
+            eprintln!("sct trud auth: key unchanged ({})", mask_key(&key));
+        }
+        Some(previous) => {
+            eprintln!(
+                "sct trud auth: replaced existing key {} with {}",
+                mask_key(previous),
+                mask_key(&key)
+            );
+        }
+        None => eprintln!("sct trud auth: stored key {}", mask_key(&key)),
+    }
+    eprintln!("sct trud auth: wrote {}", path.display());
+
+    // The env var outranks the config file in resolve_api_key, so a stale
+    // TRUD_API_KEY would silently win over what we just wrote.
+    if let Ok(env_key) = std::env::var("TRUD_API_KEY") {
+        if !env_key.trim().is_empty() && env_key.trim() != key {
+            eprintln!(
+                "sct trud auth: WARNING - $TRUD_API_KEY is set to a different key ({}) and takes \
+                 precedence over the config file. Unset it to use the key just stored.",
+                mask_key(env_key.trim())
+            );
+        }
+    }
+
+    eprintln!("sct trud auth: next step - sct trud list");
+    Ok(())
+}
+
+/// Resolve the key from the argument, a file, or stdin.
+fn read_auth_key(arg: Option<&str>, file: Option<&Path>) -> Result<String> {
+    if let Some(path) = file {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("reading API key file {}", path.display()))?;
+        let key = contents.lines().next().unwrap_or("").trim().to_string();
+        return validate_key_shape(key)
+            .with_context(|| format!("in API key file {}", path.display()));
+    }
+
+    // `-` is the repo-wide convention for "read from stdin".
+    if let Some(arg) = arg.filter(|a| *a != "-") {
+        eprintln!(
+            "sct trud auth: note - a key passed as an argument is recorded in your shell \
+             history and visible in process listings. Prefer `sct trud auth < keyfile`."
+        );
+        return validate_key_shape(arg.trim().to_string());
+    }
+
+    if std::io::stdin().is_terminal() {
+        eprint!("TRUD API key (visible as you type): ");
+        std::io::stderr().flush().ok();
+    }
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("reading API key from stdin")?;
+    validate_key_shape(line.trim().to_string())
+        .context("no API key on stdin. Pass it as an argument, use --api-key-file, or pipe it in")
+}
+
+/// Reject input that cannot be a TRUD key, so we fail here rather than writing
+/// a broken config and failing on the next command.
+fn validate_key_shape(key: String) -> Result<String> {
+    if key.is_empty() {
+        anyhow::bail!("API key is empty");
+    }
+    if key.chars().any(|c| c.is_whitespace()) {
+        anyhow::bail!(
+            "API key contains whitespace - did a label or a second field get pasted with it?"
+        );
+    }
+    if key.chars().any(|c| c.is_control()) {
+        anyhow::bail!("API key contains control characters");
+    }
+    Ok(key)
+}
+
+/// Check the key against TRUD. A key that is merely unsubscribed to the probed
+/// item still proves the key itself is good, so only an outright rejection is
+/// fatal; anything else (TRUD down, no network) is reported and allowed through
+/// so that setup works offline.
+fn verify_api_key(key: &str) -> Result<()> {
+    match probe_edition(key, VERIFY_ITEM_ID) {
+        Ok(Some(_)) => {
+            eprintln!("sct trud auth: key verified against TRUD (uk_monolith subscribed)");
+            Ok(())
+        }
+        Ok(None) => {
+            eprintln!(
+                "sct trud auth: key accepted by TRUD, but this account is not subscribed to \
+                 uk_monolith (item {VERIFY_ITEM_ID}). Run `sct trud list` to see what it can \
+                 reach."
+            );
+            Ok(())
+        }
+        // probe_edition maps TRUD's HTTP 400 to exactly this: a bad key.
+        Err(e) if e.to_string().contains("TRUD API key invalid") => Err(e),
+        Err(e) => {
+            eprintln!("sct trud auth: WARNING - could not verify the key: {e}");
+            eprintln!("sct trud auth: storing it anyway; re-run `sct trud list` when back online.");
+            Ok(())
+        }
+    }
+}
+
+/// Config file `sct trud auth` writes to.
+///
+/// Unlike [`paths::config_path`], this deliberately ignores `./sct.toml`: a
+/// project-local config is usually version-controlled, and a secret should not
+/// land there by accident. `--config` overrides this.
+fn auth_config_path(flag: Option<&Path>) -> PathBuf {
+    if let Some(path) = flag {
+        return path.to_path_buf();
+    }
+    if let Ok(value) = std::env::var("SCT_CONFIG") {
+        if !value.trim().is_empty() {
+            return paths::expand_tilde(value.trim());
+        }
+    }
+    paths::config_home().join("config.toml")
+}
+
+/// Result of editing a config file's `api_key`.
+///
+/// Deliberately not `Debug`: it holds the key in the clear, and the whole point
+/// of `mask_key` is that the key never reaches a log or an error message.
+struct ConfigEdit {
+    text: String,
+    /// The key that was there before, if any.
+    previous: Option<String>,
+}
+
+/// Set `api_key` in the `[trud]` section of `existing`, returning the new file.
+///
+/// This is a targeted line edit rather than a parse-and-reserialise, because a
+/// round trip through a TOML value tree would discard the user's comments,
+/// ordering, and formatting. The input is parsed first (so we never write to a
+/// file we do not understand) and the output is parsed again (so we never write
+/// an edit that did not land where we intended).
+fn set_config_api_key(existing: &str, key: &str) -> Result<ConfigEdit> {
+    let parsed: toml::Table = toml::from_str(existing)
+        .context("config file is not valid TOML - fix or move it, then re-run")?;
+    let previous = parsed
+        .get("trud")
+        .and_then(|t| t.get("api_key"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    // toml::Value's Display is the TOML representation, so this quotes and
+    // escapes the key correctly whatever it contains.
+    let assignment = format!("api_key = {}", toml::Value::from(key));
+
+    let mut lines: Vec<String> = existing.lines().map(str::to_string).collect();
+
+    if let Some(header) = lines.iter().position(|l| l.trim() == "[trud]") {
+        // End of the [trud] section: the next table header, or end of file.
+        let end = lines
+            .iter()
+            .skip(header + 1)
+            .position(|l| l.trim_start().starts_with('['))
+            .map(|offset| header + 1 + offset)
+            .unwrap_or(lines.len());
+
+        match (header + 1..end).find(|&i| is_api_key_assignment(&lines[i])) {
+            Some(i) => {
+                let indent: String = lines[i]
+                    .chars()
+                    .take_while(|c| c.is_whitespace() && *c != '\n')
+                    .collect();
+                lines[i] = format!("{indent}{assignment}");
+            }
+            None => lines.insert(header + 1, assignment),
+        }
+    } else if let Some(subtable) = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("[trud."))
+    {
+        // Only subtables like [trud.editions.foo] exist. Declaring [trud] after
+        // them is legal TOML but confusing to read, so go in above the first.
+        lines.insert(subtable, "[trud]".to_string());
+        lines.insert(subtable + 1, assignment);
+        lines.insert(subtable + 2, String::new());
+    } else {
+        if lines.last().is_some_and(|l| !l.trim().is_empty()) {
+            lines.push(String::new());
+        }
+        lines.push("[trud]".to_string());
+        lines.push(assignment);
+    }
+
+    let mut text = lines.join("\n");
+    text.push('\n');
+
+    // Confirm the edit produced the config we meant to write.
+    let check: Config = toml::from_str(&text)
+        .context("internal error: edited config is not valid TOML (config left unchanged)")?;
+    let landed = check.trud.as_ref().and_then(|t| t.api_key.as_deref());
+    if landed != Some(key) {
+        anyhow::bail!(
+            "internal error: api_key did not take effect after editing (config left unchanged)"
+        );
+    }
+
+    Ok(ConfigEdit { text, previous })
+}
+
+/// Is this line an `api_key = ...` assignment (bare or quoted key)?
+fn is_api_key_assignment(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    for prefix in ["api_key", "\"api_key\"", "'api_key'"] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            if rest.trim_start().starts_with('=') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Write the config file with owner-only permissions, atomically.
+///
+/// The file holds a credential, so it is created 0600 (and a directory we create
+/// ourselves 0700) and written via a temporary file in the same directory, so a
+/// crash mid-write cannot truncate an existing config.
+fn write_config_file(path: &Path, contents: &str) -> Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    if !dir.exists() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("creating config directory {}", dir.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).with_context(
+                || format!("setting permissions on config directory {}", dir.display()),
+            )?;
+        }
+    }
+
+    let mut tmp = NamedTempFile::new_in(dir)
+        .with_context(|| format!("creating temporary file in {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tmp.as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))
+            .context("setting permissions on the new config file")?;
+    }
+    tmp.write_all(contents.as_bytes())
+        .context("writing config file")?;
+    tmp.as_file().sync_all().context("flushing config file")?;
+    tmp.persist(path)
+        .map_err(|e| anyhow::anyhow!("replacing {}: {}", path.display(), e))?;
+    Ok(())
+}
+
+/// Render a key for display, showing only the last four characters.
+fn mask_key(key: &str) -> String {
+    let chars: Vec<char> = key.chars().collect();
+    if chars.len() <= 4 {
+        return "*".repeat(chars.len());
+    }
+    let tail: String = chars[chars.len() - 4..].iter().collect();
+    format!("{}{tail}", "*".repeat(chars.len() - 4))
 }
 
 // ---------------------------------------------------------------------------
@@ -1144,6 +1502,169 @@ mod tests {
     use crate::paths::{EditionProfile, TrudConfig};
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    // --- sct trud auth: config editing -------------------------------------
+
+    /// The `[trud] api_key` value a config file parses to.
+    fn parsed_key(text: &str) -> Option<String> {
+        toml::from_str::<Config>(text)
+            .expect("edited config must be valid TOML")
+            .trud
+            .and_then(|t| t.api_key)
+    }
+
+    #[test]
+    fn auth_creates_trud_section_in_an_empty_config() {
+        let edit = set_config_api_key("", "KEY123").unwrap();
+        assert_eq!(parsed_key(&edit.text).as_deref(), Some("KEY123"));
+        assert_eq!(edit.previous, None);
+        assert!(edit.text.ends_with('\n'), "config must end with a newline");
+    }
+
+    #[test]
+    fn auth_appends_trud_section_after_unrelated_sections() {
+        let existing = "[format]\ndefault = \"json\"\n";
+        let edit = set_config_api_key(existing, "KEY123").unwrap();
+        assert_eq!(parsed_key(&edit.text).as_deref(), Some("KEY123"));
+        assert!(
+            edit.text.starts_with("[format]\ndefault = \"json\"\n"),
+            "existing sections must be preserved verbatim, got:\n{}",
+            edit.text
+        );
+    }
+
+    #[test]
+    fn auth_replaces_an_existing_key_and_reports_the_old_one() {
+        let existing = "[trud]\napi_key = \"OLD\"\ndownload_dir = \"~/rel\"\n";
+        let edit = set_config_api_key(existing, "NEW").unwrap();
+        assert_eq!(edit.previous.as_deref(), Some("OLD"));
+        assert_eq!(parsed_key(&edit.text).as_deref(), Some("NEW"));
+        assert!(
+            edit.text.contains("download_dir = \"~/rel\""),
+            "sibling keys must survive, got:\n{}",
+            edit.text
+        );
+        assert!(
+            !edit.text.contains("OLD"),
+            "the old key must not be left behind, got:\n{}",
+            edit.text
+        );
+    }
+
+    #[test]
+    fn auth_preserves_comments_and_other_sections() {
+        let existing = "\
+# top comment
+[paths]
+db = \"~/snomed.db\"  # inline comment
+
+[trud]
+# where the key came from
+api_key = \"OLD\"
+
+[format]
+default = \"json\"
+";
+        let edit = set_config_api_key(existing, "NEW").unwrap();
+        for expected in [
+            "# top comment",
+            "db = \"~/snomed.db\"  # inline comment",
+            "# where the key came from",
+            "[format]",
+            "default = \"json\"",
+        ] {
+            assert!(
+                edit.text.contains(expected),
+                "lost {expected:?} from:\n{}",
+                edit.text
+            );
+        }
+        assert_eq!(parsed_key(&edit.text).as_deref(), Some("NEW"));
+    }
+
+    #[test]
+    fn auth_declares_trud_above_existing_subtables() {
+        // Only [trud.editions.*] exists: the new [trud] header must go above it,
+        // or the assignment would land inside the subtable.
+        let existing = "[trud.editions.mine]\ntrud_item = 9876\n";
+        let edit = set_config_api_key(existing, "KEY123").unwrap();
+        assert_eq!(parsed_key(&edit.text).as_deref(), Some("KEY123"));
+        let config: Config = toml::from_str(&edit.text).unwrap();
+        let editions = config.trud.unwrap().editions.unwrap();
+        assert_eq!(
+            editions.get("mine").unwrap().trud_item,
+            9876,
+            "the existing edition profile must survive"
+        );
+    }
+
+    #[test]
+    fn auth_does_not_touch_a_key_in_a_later_section() {
+        // An `api_key` under another section must not be mistaken for ours.
+        let existing = "[trud]\ndownload_dir = \"~/rel\"\n\n[other]\napi_key = \"NOTOURS\"\n";
+        let edit = set_config_api_key(existing, "KEY123").unwrap();
+        assert_eq!(parsed_key(&edit.text).as_deref(), Some("KEY123"));
+        assert!(
+            edit.text.contains("api_key = \"NOTOURS\""),
+            "the unrelated key must be untouched, got:\n{}",
+            edit.text
+        );
+    }
+
+    #[test]
+    fn auth_rejects_a_config_that_is_not_valid_toml() {
+        let Err(err) = set_config_api_key("this is not toml =\n", "KEY123") else {
+            panic!("a config we cannot parse must not be rewritten");
+        };
+        assert!(
+            err.to_string().contains("not valid TOML"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn auth_escapes_a_key_needing_toml_quoting() {
+        // Not a realistic TRUD key, but the writer must never emit broken TOML.
+        let key = "we\"ird\\key";
+        let edit = set_config_api_key("", key).unwrap();
+        assert_eq!(parsed_key(&edit.text).as_deref(), Some(key));
+    }
+
+    #[test]
+    fn api_key_assignment_matches_only_the_real_thing() {
+        assert!(is_api_key_assignment("api_key = \"x\""));
+        assert!(is_api_key_assignment("  api_key=\"x\""));
+        assert!(is_api_key_assignment("\"api_key\" = \"x\""));
+        assert!(!is_api_key_assignment("api_key_file = \"x\""));
+        assert!(!is_api_key_assignment("# api_key = \"x\""));
+        assert!(!is_api_key_assignment("download_dir = \"x\""));
+    }
+
+    // --- sct trud auth: key handling ---------------------------------------
+
+    #[test]
+    fn auth_rejects_unusable_keys() {
+        assert!(validate_key_shape(String::new()).is_err());
+        assert!(validate_key_shape("API key: ABC".to_string()).is_err());
+        assert!(validate_key_shape("ABC\u{7}DEF".to_string()).is_err());
+        assert_eq!(validate_key_shape("ABC123".to_string()).unwrap(), "ABC123");
+    }
+
+    #[test]
+    fn mask_key_shows_only_the_last_four_characters() {
+        assert_eq!(mask_key("ABCDEFGH"), "****EFGH");
+        assert_eq!(mask_key("ABCD"), "****");
+        assert_eq!(mask_key("AB"), "**");
+        assert_eq!(mask_key(""), "");
+        // Multi-byte input must not panic on a char boundary.
+        assert_eq!(mask_key("kéy-wxyz").chars().count(), 8);
+    }
+
+    #[test]
+    fn auth_config_path_prefers_the_flag() {
+        let flag = PathBuf::from("/tmp/explicit.toml");
+        assert_eq!(auth_config_path(Some(&flag)), flag);
+    }
 
     fn release_with_filename(name: &str) -> serde_json::Result<TrudRelease> {
         serde_json::from_value(serde_json::json!({

--- a/src/commands/trud.rs
+++ b/src/commands/trud.rs
@@ -1376,15 +1376,33 @@ fn ping_trud() -> Result<()> {
     match ureq::get(&health).call() {
         // Any HTTP response - including 4xx/5xx - means we reached the server.
         Ok(_) | Err(ureq::Error::StatusCode(_)) => Ok(()),
-        Err(e) => Err(anyhow::anyhow!(
-            "Cannot reach NHS TRUD ({health}).
-
-The service may be offline or undergoing scheduled maintenance.
-TRUD maintenance windows: weekdays 18:00–08:00 UK time, and midnight–06:00.
-
-Original error: {e}"
-        )),
+        Err(e) => Err(anyhow::anyhow!(unreachable_message(
+            &health,
+            &e.to_string()
+        ))),
     }
+}
+
+/// The "cannot reach TRUD" diagnostic.
+///
+/// Split out so the test asserts the message users actually see, rather than a
+/// copy of it that can drift.
+///
+/// TRUD publishes no maintenance schedule. The only statement it makes is the
+/// automation guidance on <https://isd.digital.nhs.uk/trud/users/guest/filters/0/api>:
+/// "Run automation scripts on weekdays between 8am and 6pm, or midnight and 6am
+/// (UK time) to avoid planned maintenance." Quote that, and do not extrapolate a
+/// downtime window from it.
+fn unreachable_message(health_url: &str, error: &str) -> String {
+    format!(
+        "Cannot reach NHS TRUD ({health_url}).
+
+The service may be offline or undergoing scheduled maintenance. TRUD advises
+running automation on weekdays 08:00-18:00 or 00:00-06:00 UK time to avoid
+planned maintenance.
+
+Original error: {error}"
+    )
 }
 
 /// Probe a single TRUD item to determine subscription status.
@@ -2098,17 +2116,22 @@ default = \"json\"
 
     #[test]
     fn ping_trud_error_message_contains_maintenance_window_hint() {
-        // Simulate what ping_trud would produce given a connection-level error.
         let fake_io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
-        let msg = format!(
-            "Cannot reach NHS TRUD ({TRUD_HEALTH_URL}).\n\n\
-             The service may be offline or undergoing scheduled maintenance.\n\
-             TRUD maintenance windows: weekdays 18:00–08:00 UK time, and midnight–06:00.\n\n\
-             Original error: {fake_io_err}"
-        );
+        let msg = unreachable_message(TRUD_HEALTH_URL, &fake_io_err.to_string());
+
         assert!(msg.contains("maintenance"));
         assert!(msg.contains(TRUD_HEALTH_URL));
-        assert!(msg.contains("18:00"));
+        assert!(msg.contains("refused"), "the original error must survive");
+
+        // The windows TRUD actually publishes, as the times to *run* automation.
+        assert!(msg.contains("08:00-18:00"));
+        assert!(msg.contains("00:00-06:00"));
+        // TRUD publishes no downtime window; we must not invent one. In
+        // particular midnight-06:00 is a recommended window, not maintenance.
+        assert!(
+            !msg.contains("18:00-08:00") && !msg.contains("18:00–08:00"),
+            "must not assert a downtime window TRUD does not publish: {msg}"
+        );
     }
 
     #[test]

--- a/tests/trud_api.rs
+++ b/tests/trud_api.rs
@@ -229,3 +229,141 @@ async fn download_rejects_traversal_in_archive_filename() {
 
     assert!(!parent.path().join("escape.zip").exists());
 }
+
+// ---------------------------------------------------------------------------
+// sct trud auth
+// ---------------------------------------------------------------------------
+
+/// An `sct trud auth` command with a private config home and no ambient key.
+///
+/// `TRUD_API_KEY` is deliberately removed: `sct_trud` sets it for the read
+/// subcommands, but for `auth` it would only trigger the "env var shadows the
+/// config" warning.
+fn sct_auth(base: &str, config_home: &std::path::Path) -> Command {
+    let mut c = Command::cargo_bin("sct").expect("sct binary builds");
+    c.env("SCT_TRUD_API_BASE", base)
+        .env("SCT_CONFIG_HOME", config_home)
+        .env_remove("TRUD_API_KEY")
+        .env_remove("SCT_CONFIG");
+    c
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auth_verifies_key_then_writes_config() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/keys/{KEY}/items/{ITEM}/releases")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(releases_json(
+            "rel.zip",
+            "https://example.test/rel.zip",
+            "ab",
+        )))
+        .mount(&server)
+        .await;
+
+    let config_home = tempfile::tempdir().unwrap();
+    let mut cmd = sct_auth(&server.uri(), config_home.path());
+    cmd.args(["trud", "auth", KEY]);
+    run(cmd)
+        .await
+        .success()
+        .stderr(predicate::str::contains("key verified against TRUD"))
+        // Only the last four characters may ever be echoed.
+        .stderr(predicate::str::contains("****-key"))
+        .stderr(predicate::str::contains(KEY).not());
+
+    let written = std::fs::read_to_string(config_home.path().join("config.toml")).unwrap();
+    assert!(
+        written.contains(&format!("api_key = \"{KEY}\"")),
+        "key must be stored, got:\n{written}"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(config_home.path().join("config.toml"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "a file holding a credential must be 0600");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auth_refuses_to_store_a_key_trud_rejects() {
+    let server = MockServer::start().await;
+    // TRUD answers HTTP 400 for a key it does not recognise.
+    Mock::given(method("GET"))
+        .and(path(format!("/keys/bogus-key/items/{ITEM}/releases")))
+        .respond_with(ResponseTemplate::new(400))
+        .mount(&server)
+        .await;
+
+    let config_home = tempfile::tempdir().unwrap();
+    let mut cmd = sct_auth(&server.uri(), config_home.path());
+    cmd.args(["trud", "auth", "bogus-key"]);
+    run(cmd)
+        .await
+        .failure()
+        .stderr(predicate::str::contains("TRUD API key invalid"));
+
+    assert!(
+        !config_home.path().join("config.toml").exists(),
+        "a rejected key must not be written to the config"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auth_stores_key_offline_with_no_verify() {
+    // No mock server mounted: --no-verify must not make any request at all.
+    let config_home = tempfile::tempdir().unwrap();
+    let mut cmd = sct_auth("http://127.0.0.1:1/unreachable", config_home.path());
+    cmd.args(["trud", "auth", "OFFLINEKEY", "--no-verify"]);
+    run(cmd).await.success();
+
+    let written = std::fs::read_to_string(config_home.path().join("config.toml")).unwrap();
+    assert!(written.contains("api_key = \"OFFLINEKEY\""));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auth_dry_run_writes_nothing() {
+    let config_home = tempfile::tempdir().unwrap();
+    let mut cmd = sct_auth("http://127.0.0.1:1/unreachable", config_home.path());
+    cmd.args(["trud", "auth", "SOMEKEY", "--no-verify", "--dry-run"]);
+    run(cmd)
+        .await
+        .success()
+        .stdout(predicate::str::contains("api_key = \"SOMEKEY\""));
+
+    assert!(
+        !config_home.path().join("config.toml").exists(),
+        "--dry-run must not create the config file"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auth_then_list_uses_the_stored_key() {
+    // End to end: the key auth writes is the key the next command resolves.
+    let server = MockServer::start().await;
+    mount_health(&server).await;
+    mount_releases(
+        &server,
+        releases_json("stored.zip", "https://example.test/stored.zip", "ab"),
+    )
+    .await;
+
+    let config_home = tempfile::tempdir().unwrap();
+    let mut auth = sct_auth(&server.uri(), config_home.path());
+    auth.args(["trud", "auth", KEY, "--no-verify"]);
+    run(auth).await.success();
+
+    let health = format!("{}/health", server.uri());
+    let mut list = sct_auth(&server.uri(), config_home.path());
+    list.env("SCT_TRUD_HEALTH_URL", &health)
+        .args(["trud", "list", "--item", ITEM]);
+    run(list)
+        .await
+        .success()
+        .stdout(predicate::str::contains("stored.zip"));
+}


### PR DESCRIPTION
## Summary

Setting up a new machine meant creating `~/.config/sct`, creating `config.toml`, and hand-writing a `[trud]` section before the first download. `sct trud auth` does all three in one step.

```sh
sct trud auth < my-trud-key.txt
pass show nhs/trud | sct trud auth
sct trud auth <KEY>            # works, but warns: lands in shell history
```

Key sources in order: positional argument, `--api-key-file`, then stdin (`-` forces stdin).

## Design decisions

- **Verifies before writing.** The key is probed against item 1799 (`uk_monolith`). A key TRUD rejects (HTTP 400) is not written at all, so a typo fails now rather than on the first download. A key that works but is not subscribed to that item is written with a note; an unreachable TRUD is a warning rather than a failure, so setup works offline. `--no-verify` skips the round-trip.
- **Preserves the rest of the config.** A parse-and-reserialise through `toml` would discard comments and ordering, so this is a targeted line edit on `api_key` in `[trud]`. The file is parsed before the edit (a config we cannot understand is never rewritten) and re-parsed after (an edit that did not land as intended is never written). Covers the case where only `[trud.editions.*]` exists and the new `[trud]` header must be declared *above* it.
- **Treated as a credential store.** File `0600`, directory `0700` when we create it, written via a temporary file in the same directory so a crash cannot truncate an existing config. `ConfigEdit` deliberately does not derive `Debug`; only the last four characters of a key are ever echoed (`mask_key`).
- **Warns when shadowed.** `$TRUD_API_KEY` outranks the config file in `resolve_api_key`, so a stale exported key would silently win over what was just stored. The command says so.
- **Ignores `./sct.toml`.** The read path picks it up, but a project-local config is usually version-controlled and a credential should not land there by accident. `--config` names one explicitly.

Target file: `$SCT_CONFIG`, else `$SCT_CONFIG_HOME/config.toml`.

## Test plan

- [x] 13 unit tests: config-edit cases (empty file, append after unrelated sections, replace existing key, comment/section preservation, subtable-only configs, an `api_key` in an unrelated section, invalid TOML refused, TOML-escaping of an awkward key), `is_api_key_assignment` matching, key-shape validation, `mask_key` (including multi-byte input), `auth_config_path`.
- [x] 5 integration tests against the wiremock TRUD mock: verify-then-write (asserting mode `0600` and that the full key never reaches stderr), refuse-on-HTTP-400 with no file created, offline `--no-verify`, `--dry-run` writing nothing, and `auth` followed by `list` resolving the stored key.
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`, plus `--features serve`, `--features dmwb`, and the `python/` manifest
- [x] `cargo test` (241 lib tests, all 17 suites green) and `cargo test --features serve`
- [x] Driven by hand through: fresh setup, replacing a key in a commented config, subtable-only config, stdin pipe, idempotent re-run, invalid TOML, a pasted `"API key: ABC"`, empty stdin, `$TRUD_API_KEY` shadowing, and `--dry-run`

## Docs

- `spec/commands/trud.md` - new subcommand section; corrects the "reads but never writes it" statement, and the API-key masking convention (it specified the *first* six characters; the code shows the *last* four)
- `docs/commands/trud.md` - setup section and subcommand reference; also tidies a duplicated paragraph and a repeated "Using the config file" section that were already there
- `README.md` - quickstart now shows `sct trud auth` before `sct trud download`

## Not included

The interactive TTY prompt echoes the key as you type; hiding it needs `termios` via `libc` plus a Windows fallback. Piping avoids the issue entirely.