### PR TITLE
feat(cli)!: name every build artefact after its input

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,18 @@ sct ndjson --rf2 SnomedCT_MonolithRF2_PRODUCTION_20260311T120000Z.zip
 # ✓  837,930 concepts written → snomedct-monolithrf2-production-20260311t120000z.ndjson
 
 # 3. Load into SQLite with FTS5
+#    The release name carries through - every build command names its output
+#    after its input, and prints the name it chose
 sct sqlite --ndjson snomedct-monolithrf2-production-20260311t120000z.ndjson
+# ✓  Output: snomedct-monolithrf2-production-20260311t120000z.db
 
 # 4. Query with standard tools - no custom binary needed
-sqlite3 snomed.db \
+sqlite3 snomedct-monolithrf2-production-20260311t120000z.db \
   "SELECT id, preferred_term FROM concepts_fts WHERE concepts_fts MATCH 'heart attack' LIMIT 5"
 
 # 5. Start the MCP server for Claude Desktop
-sct mcp --db snomed.db
+#    No --db needed: sct discovers the database you just built
+sct mcp
 ```
 
 UK users can automate steps 1–3 with a single command once the [TRUD API integration](docs/commands/trud.md) is set up. Store your TRUD API key once, then download and build in one go:

--- a/docs/commands/embed.md
+++ b/docs/commands/embed.md
@@ -21,7 +21,7 @@ sct embed --ndjson <NDJSON> [--output <FILE>] [--model <MODEL>] [--batch-size <N
 | Flag | Default | Description |
 |---|---|---|
 | `--ndjson <FILE>` | *(required)* | NDJSON file produced by `sct ndjson`. Use `-` for stdin. Accepts `--input` as an alias. |
-| `--output <FILE>` | `snomed-embeddings.arrow` | Output Arrow IPC file. |
+| `--output <FILE>` | *(input name + `-embeddings.arrow`)* | Output Arrow IPC file. `uk-monolith-42.ndjson` → `uk-monolith-42-embeddings.arrow`; stdin input gives `snomed-embeddings.arrow`. |
 | `--model <MODEL>` | `nomic-embed-text` | Ollama model name to use for embeddings. |
 | `--batch-size <N>` | `64` | Number of concepts to embed per Ollama API call. |
 | `--ollama-url <URL>` | `http://localhost:11434` | Ollama base URL. |

--- a/docs/commands/fst.md
+++ b/docs/commands/fst.md
@@ -29,7 +29,7 @@ sct fst search <QUERY> [--index <FST>] [--prefix | --fuzzy <N> | --words] [--lim
 | Flag | Default | Description |
 |---|---|---|
 | `--ndjson <FILE>` | *(required)* | NDJSON file produced by `sct ndjson`. Use `-` for stdin. Accepts `--input` as an alias. |
-| `--output <FILE>` | `snomed.fst` | Output index file. |
+| `--output <FILE>` | *(input name + `.fst`)* | Output index file. `uk-monolith-42.ndjson` → `uk-monolith-42.fst`; stdin input gives `snomed.fst`. |
 | `--no-terms` | off | Omit the display side-tables (preferred-term labels). Produces a much smaller, search-only index for use alongside SQLite, where labels are resolved from the database. `sct fst search` on such an index returns SCTIDs without labels. |
 
 ```bash
@@ -53,7 +53,7 @@ Built snomed.fst in 18.83s
 | Argument / Flag | Default | Description |
 |---|---|---|
 | `<QUERY>` | *(required)* | The term or words to search for. |
-| `--index <FILE>` | `snomed.fst` | Index file produced by `sct fst build`. |
+| `--index <FILE>` | *(`snomed.fst`, else newest `*.fst` in the directory)* | Index file produced by `sct fst build`. |
 | `--prefix` | off | Prefix (autocomplete) search. |
 | `--fuzzy <N>` | off | Fuzzy search up to `N` edits (Levenshtein distance 1 or 2). |
 | `--words` | off | Word-intersection: whitespace-split the query; return concepts whose terms contain **every** word. |

--- a/docs/commands/markdown.md
+++ b/docs/commands/markdown.md
@@ -17,7 +17,7 @@ sct markdown --ndjson <NDJSON> [--output <DIR>] [--mode <MODE>]
 | Flag | Default | Description |
 |---|---|---|
 | `--ndjson <FILE>` | *(required)* | NDJSON file produced by `sct ndjson`. Use `-` for stdin. Accepts `--input` as an alias. |
-| `--output <DIR>` | `snomed-concepts` | Output directory. |
+| `--output <DIR>` | *(input name + `-concepts`)* | Output directory. `uk-monolith-42.ndjson` → `uk-monolith-42-concepts/`; stdin input gives `snomed-concepts/`. |
 | `--mode <MODE>` | `concept` | Output grouping: `concept` (one file per concept) or `hierarchy` (one file per top-level hierarchy). |
 
 ---

--- a/docs/commands/parquet.md
+++ b/docs/commands/parquet.md
@@ -17,7 +17,7 @@ sct parquet --ndjson <NDJSON> [--output <PARQUET>]
 | Flag | Default | Description |
 |---|---|---|
 | `--ndjson <FILE>` | *(required)* | NDJSON file produced by `sct ndjson`. Use `-` for stdin. Accepts `--input` as an alias. |
-| `--output <FILE>` | `snomed.parquet` | Output Parquet file path. |
+| `--output <FILE>` | *(input name + `.parquet`)* | Output Parquet file path. `uk-monolith-42.ndjson` → `uk-monolith-42.parquet`; stdin input gives `snomed.parquet`. |
 
 ---
 

--- a/docs/commands/sayt.md
+++ b/docs/commands/sayt.md
@@ -82,7 +82,7 @@ $ curl 'http://localhost:8080/autocomplete?q=myocard&count=5'
 
 | Flag | Default | Description |
 |---|---|---|
-| `--index <FILE>` | `snomed.fst` | FST index produced by `sct fst build`. |
+| `--index <FILE>` | *(`snomed.fst`, else newest `*.fst` in the directory)* | FST index produced by `sct fst build`. |
 | `-l, --limit <N>` | `10` | Maximum results shown / returned. |
 | `--min-chars <N>` | `1` | Minimum query length before results are computed. |
 | `--fuzzy` | off | Enable typo-tolerant fuzzy fallback (broader, still sub-ms). |

--- a/docs/commands/sqlite.md
+++ b/docs/commands/sqlite.md
@@ -4,7 +4,7 @@ Load a SNOMED CT NDJSON artefact into a SQLite database with full-text search (F
 
 **When to use:** you want keyword/phrase search, SQL queries, or to run the MCP server or UIs. For meaning-based search, see [`sct embed`](embed.md) + [`sct semantic`](semantic.md).
 
-The resulting `snomed.db` is a single portable file queryable with `sqlite3` or any SQLite library - no custom binary needed at query time.
+The resulting database is a single portable file queryable with `sqlite3` or any SQLite library - no custom binary needed at query time. It is named after the NDJSON it was built from, and the name is printed as `Output: …` when you do not pass `--output`.
 
 ---
 
@@ -19,7 +19,7 @@ sct sqlite --ndjson <NDJSON> [--output <DB>]
 | Flag | Default | Description |
 |---|---|---|
 | `--ndjson <FILE>` | *(required)* | NDJSON file produced by `sct ndjson`. Use `-` for stdin. Accepts `--input` as an alias. |
-| `--output <FILE>` | `snomed.db` | Output SQLite database path. |
+| `--output <FILE>` | *(input name + `.db`)* | Output SQLite database path. `uk-monolith-42.ndjson` → `uk-monolith-42.db`; stdin input gives `snomed.db`. |
 | `--transitive-closure` | off | Build the transitive closure table (`concept_ancestors`) after loading - same as running [`sct tct`](tct.md) immediately after. Adds build time and size; needed for subsumption-heavy workloads. |
 | `--include-self` | off | Include reflexive rows (`ancestor_id = descendant_id`, depth 0) in the TCT. Only meaningful with `--transitive-closure`. |
 

--- a/docs/path-resolution.md
+++ b/docs/path-resolution.md
@@ -36,10 +36,13 @@ When `--db` is not supplied, `sct` walks this chain and uses the first match:
 3. **`[paths] db = "..."`** in the config file
 4. **`$SCT_DATA_HOME/data/snomed.db`**
 5. **Newest `*.db`** in `$SCT_DATA_HOME/data/`
+6. **Newest `*.db`** in the current directory
 
 If `$SCT_DB` is set but points at a missing file, `sct` errors out rather than silently falling through - that almost always means a typo.
 
 Step 5 is the one that makes `sct trud download --pipeline` followed by `sct tui` (or `sct lookup`, or any other read-side command) Just Work.
+
+Step 6 does the same for a database you just built by hand. Build commands name their output after their input, so `sct sqlite --ndjson uk-monolith-42.ndjson` writes `uk-monolith-42.db`, which step 2 (an exact match on `./snomed.db`) will not find. Because it runs last, it can never shadow a path you chose explicitly - and `sct paths` will tell you when it was the rule that matched.
 
 ## Embeddings resolution (`--embeddings`)
 
@@ -93,6 +96,7 @@ No SNOMED CT database found. Searched (in order):
   config [paths]                           (unset)
   ~/.local/share/sct/data/snomed.db        (not present)
   ~/.local/share/sct/data/*.db (newest)    (no matches)
+  ./*.db (newest)                          (no matches)
 
 Build one with:
   sct trud download --edition uk_monolith --pipeline
@@ -124,17 +128,34 @@ The right-hand column says exactly *which* resolution rule matched. Useful when 
 
 ---
 
-## Write paths (unchanged)
+## Write paths: names carry through the pipeline
 
-This convention covers **read** discovery only. Commands that *write* files keep their existing defaults:
+Every build command names its output after its input, so you can tell which release an artefact came from without opening it:
+
+```console
+$ sct ndjson --rf2 SnomedCT_MonolithRF2_PRODUCTION_20260701T120000Z.zip
+Output: snomedct-monolithrf2-production-20260701t120000z.ndjson
+
+$ sct sqlite --ndjson snomedct-monolithrf2-production-20260701t120000z.ndjson
+Output: snomedct-monolithrf2-production-20260701t120000z.db
+```
 
 | Command | Default output |
 |---|---|
-| `sct sqlite` | `./snomed.db` |
-| `sct ndjson` | Slugified name of the first `--rf2` input (e.g. `snomedct-monolithrf2-production-...ndjson`); use `-o` to pick your own |
-| `sct parquet` | `./snomed.parquet` |
-| `sct embed` | `./snomed-embeddings.arrow` |
+| `sct ndjson` | Slugified name of the first `--rf2` input, e.g. `snomedct-monolithrf2-production-...ndjson` |
+| `sct sqlite` | `<input stem>.db` |
+| `sct parquet` | `<input stem>.parquet` |
+| `sct fst build` | `<input stem>.fst` |
+| `sct embed` | `<input stem>-embeddings.arrow` |
+| `sct markdown` | `<input stem>-concepts/` |
 | `sct trud download` | `$SCT_DATA_HOME/releases/<zip>` |
-| `sct trud download --pipeline` artefacts | `$SCT_DATA_HOME/data/<name>.db` etc. |
+| `sct trud download --pipeline` artefacts | `$SCT_DATA_HOME/data/<slug>.db` etc. |
 
-In other words, one-shot interactive runs default to the current directory; the `sct trud` automation pipeline defaults to the data home. Either way, the read chain finds the result.
+Notes:
+
+- Feed a command `snomed.ndjson` and you get `snomed.db`, `snomed.parquet`, `snomed-embeddings.arrow` - the familiar names are just this rule applied to a canonically named input.
+- Output lands in the **current directory**, not next to the input.
+- Reading from stdin (`-`) leaves nothing to inherit, so the `snomed` stem is used.
+- `--output`/`-o` overrides all of it. A derived name is always printed as `Output: …` on stderr.
+
+One-shot runs write to the current directory; the `sct trud` pipeline writes to the data home. Either way the read chain finds the result, and `sct paths` shows which rule matched.

--- a/spec/path-resolution.md
+++ b/spec/path-resolution.md
@@ -48,7 +48,10 @@ When a command takes `--db` and the flag is *not* supplied, it walks the followi
 2. **`./snomed.db`** - preserves local-dev ergonomics. A project-local DB always beats a global one.
 3. **`[paths] db = "…"`** from the config file (see [Config](#config-file)).
 4. **`$SCT_DATA_HOME/data/snomed.db`** - canonical name if a user (or future `sct trud --link-latest`) has placed/symlinked one there.
-5. **Newest `*.db` in `$SCT_DATA_HOME/data/`** - auto-discovers `sct trud download --pipeline` output, which writes files like `uk_sct2mo_42.1.0_20260506000001z.db`. Newest by `mtime`.
+5. **Newest `*.db` in `$SCT_DATA_HOME/data/`** - auto-discovers `sct trud download --pipeline` output, which writes files like `snomedct-monolithrf2-production-20260701t120000z.db`. Newest by `mtime`.
+6. **Newest `*.db` in the working directory** - last resort. Build commands name their output after their input (see [Write paths](#write-paths-the-stem-propagates)), so a database you just built locally is `<release>.db`, which step 2's exact-name match does not see. This step keeps the zero-flag workflow working in a directory you have just built in.
+
+Step 6 runs last deliberately: it cannot shadow a flag, env var, config entry, or canonically named file, so no resolution that succeeded before it existed changes behaviour. It only converts what used to be a "not found" error into a match.
 
 Explicit `--db <path>` always wins over the chain. The path may use `~` for `$HOME`.
 
@@ -67,6 +70,7 @@ No SNOMED CT database found. Searched (in order):
   ./snomed.db                              (does not exist)
   ~/.local/share/sct/data/snomed.db        (does not exist)
   ~/.local/share/sct/data/*.db (newest)    (no matches)
+  ./*.db (newest)                          (no matches)
 
 Build one with:
   sct trud download --edition uk_monolith --pipeline
@@ -84,6 +88,7 @@ For `sct semantic` and `sct mcp --embeddings`, the same five-step chain applies 
 3. `[paths] embeddings = "…"` from config
 4. `$SCT_DATA_HOME/data/snomed-embeddings.arrow`
 5. Newest `*.arrow` in `$SCT_DATA_HOME/data/`
+6. Newest `*.arrow` in the working directory
 
 The filename `snomed-embeddings.arrow` is the existing default produced by `sct embed`.
 
@@ -131,20 +136,43 @@ A `--config <path>` CLI flag is **not** added in this version. The env var cover
 
 ---
 
-## Write paths (unchanged)
+## Write paths: the stem propagates
 
-This spec covers **read** discovery only. Commands that write files keep their existing defaults:
+**Every build command names its output after its input**, so the release identity set at the top of the pipeline survives to the bottom:
+
+```text
+SnomedCT_MonolithRF2_PRODUCTION_20260701T120000Z.zip
+  └── sct ndjson   → snomedct-monolithrf2-production-20260701t120000z.ndjson
+        ├── sct sqlite   → snomedct-monolithrf2-production-20260701t120000z.db
+        ├── sct parquet  → snomedct-monolithrf2-production-20260701t120000z.parquet
+        ├── sct fst      → snomedct-monolithrf2-production-20260701t120000z.fst
+        └── sct embed    → snomedct-monolithrf2-production-...-embeddings.arrow
+```
 
 | Command | Default output | Set via |
 |---|---|---|
-| `sct sqlite` | `./snomed.db` | `--output` |
-| `sct ndjson` | `./snomed.ndjson` | `--output` |
-| `sct parquet` | `./snomed.parquet` | `--output` |
-| `sct embed` | `./snomed-embeddings.arrow` | `--output` |
+| `sct ndjson` | `<slug of first --rf2>.ndjson` | `--output` (`-` for stdout) |
+| `sct sqlite` | `<input stem>.db` | `--output` |
+| `sct parquet` | `<input stem>.parquet` | `--output` |
+| `sct fst build` | `<input stem>.fst` | `--output` |
+| `sct embed` | `<input stem>-embeddings.arrow` | `--output` |
+| `sct markdown` | `<input stem>-concepts/` | `--output` |
 | `sct trud download` | `$SCT_DATA_HOME/releases/<zip>` | `--output-dir` / `download_dir` in `[trud]` |
-| `sct trud download --pipeline` build artefacts | `$SCT_DATA_HOME/data/<…>.db` | `--data-dir` / `data_dir` in `[trud]` |
+| `sct trud download --pipeline` build artefacts | `$SCT_DATA_HOME/data/<slug>.{ndjson,db}` | `--data-dir` / `data_dir` in `[trud]` |
 
-Two write conventions remain - CWD for one-shot `sct sqlite` runs, data home for `sct trud` automation. Changing this is out of scope; the read-side spec makes the inconsistency invisible to downstream commands either way.
+Rules:
+
+- The stem comes from the input's file stem: `paths::derived_output`. `sct ndjson` slugifies its RF2 input (lowercase, non-alphanumerics to hyphens, `.zip` stripped) via `ndjson::slugify_path`; the `sct trud` pipeline uses the same function, so a TRUD-built workspace and a hand-built one are named identically.
+- **The canonical names are this rule applied to a canonical input.** `snomed.ndjson` yields `snomed.db`, `snomed.parquet`, `snomed-embeddings.arrow`. They are not a separate case, which is why `paths::CANONICAL_*` still describes what discovery looks for.
+- Output is always a **bare filename in the working directory**, never beside the input, which may live somewhere read-only. `sct trud` is the exception: it writes into the data home by design.
+- Input from stdin (`-`) has no name to inherit, so it falls back to the `snomed` stem.
+- A derived name is printed to stderr as `Output: <path>`. A name the user did not type must never be a surprise, and the next command in the pipeline needs to know what to consume.
+
+### FST index lookup
+
+`sct fst search`, `sct sayt`, and `sct serve --fst` have never had an env var or config entry, and still do not. When `--index`/`--fst` is omitted they call `paths::find_fst_index(dir)`, which prefers `snomed.fst` in that directory and otherwise takes the newest `*.fst` there - the same two final steps as the `--db` chain. `dir` is the working directory for `fst search` and `sayt`, and the database's directory for `serve`. Without this, naming an index after its input would have made `sct fst build` followed by a bare `sct fst search` fail.
+
+Two write locations remain - the working directory for one-shot runs, the data home for `sct trud` automation - and the read chain finds either.
 
 ---
 
@@ -190,7 +218,7 @@ pub struct Resolved {
 }
 
 pub enum Source {
-    Flag, Env(&'static str), Cwd, Config, DataHomeCanonical, DataHomeNewest,
+    Flag, Env(&'static str), Cwd, Config, DataHomeCanonical, DataHomeNewest, CwdNewest,
 }
 ```
 
@@ -209,7 +237,8 @@ The error message in `resolve_db` is the diagnostic block shown above. `tui.rs` 
 
 `paths::resolve_db` is pure I/O against the filesystem and env. Tests use `tempfile::tempdir()` for the data home and scoped env mutations. Coverage targets:
 
-- Every step of the chain wins in isolation (flag, env, cwd, config, data-home canonical, data-home newest)
+- Every step of the chain wins in isolation (flag, env, cwd, config, data-home canonical, data-home newest, cwd newest)
+- The cwd-newest step never outranks a populated data home
 - Env var set to a missing path → hard error, not fallthrough
 - Newest-by-mtime tiebreak is stable
 - `expand_tilde` round-trips `~/foo` and `~user/foo` (we currently only support `~/`; document the limitation)

--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -57,8 +57,13 @@ pub struct Args {
     pub ollama_url: String,
 
     /// Output Arrow IPC file.
-    #[arg(long, short, default_value = "snomed-embeddings.arrow", value_parser = crate::paths::tilde_pathbuf)]
-    pub output: PathBuf,
+    ///
+    /// Defaults to the input's name with an `-embeddings.arrow` suffix
+    /// (`uk-monolith-42.ndjson` → `uk-monolith-42-embeddings.arrow`), written
+    /// to the working directory. Reading from stdin gives
+    /// `snomed-embeddings.arrow`.
+    #[arg(long, short, value_parser = crate::paths::tilde_pathbuf)]
+    pub output: Option<PathBuf>,
 
     /// Number of concepts to embed per Ollama API call.
     #[arg(long, default_value = "64")]
@@ -85,6 +90,12 @@ struct EmbedResponse {
 // ---------------------------------------------------------------------------
 
 pub fn run(args: Args) -> Result<()> {
+    let output = crate::commands::resolve_output(
+        args.output.as_deref(),
+        &args.input,
+        crate::paths::suffix::EMBEDDINGS,
+    );
+
     // Open input
     let input: Box<dyn std::io::Read> = if args.input.as_os_str() == "-" {
         Box::new(std::io::stdin())
@@ -159,7 +170,7 @@ pub fn run(args: Args) -> Result<()> {
         &concepts,
         &all_embeddings,
         dim,
-        &args.output,
+        &output,
         prov.as_ref(),
         &args.model,
     )?;
@@ -168,7 +179,7 @@ pub fn run(args: Args) -> Result<()> {
         "Done. {} embeddings (dim={}) → {}",
         concepts.len(),
         dim,
-        args.output.display()
+        output.display()
     ));
 
     Ok(())

--- a/src/commands/fst.rs
+++ b/src/commands/fst.rs
@@ -50,8 +50,12 @@ struct BuildArgs {
     input: PathBuf,
 
     /// Output index file.
-    #[arg(long, short, default_value = "snomed.fst", value_parser = crate::paths::tilde_pathbuf)]
-    output: PathBuf,
+    ///
+    /// Defaults to the input's name with a `.fst` extension
+    /// (`uk-monolith-42.ndjson` → `uk-monolith-42.fst`), written to the working
+    /// directory. Reading from stdin gives `snomed.fst`.
+    #[arg(long, short, value_parser = crate::paths::tilde_pathbuf)]
+    output: Option<PathBuf>,
 
     /// Omit the display side-tables (preferred-term labels). Produces a smaller
     /// index for use alongside SQLite, where labels are resolved from the DB.
@@ -66,8 +70,12 @@ struct SearchArgs {
     query: String,
 
     /// Index file produced by `sct fst build`.
-    #[arg(long, default_value = "snomed.fst", value_parser = crate::paths::tilde_pathbuf)]
-    index: PathBuf,
+    ///
+    /// Defaults to `./snomed.fst`, then the newest `*.fst` in the working
+    /// directory - `sct fst build` names its index after its input, so it is
+    /// usually `<release>.fst`.
+    #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
+    index: Option<PathBuf>,
 
     /// Prefix (autocomplete) search instead of exact match.
     #[arg(long, conflicts_with_all = ["fuzzy", "words"])]
@@ -99,11 +107,17 @@ pub fn run(args: Args) -> Result<()> {
 }
 
 fn build(args: BuildArgs) -> Result<()> {
+    let output = crate::commands::resolve_output(
+        args.output.as_deref(),
+        &args.input,
+        crate::paths::suffix::FST,
+    );
+
     let (reader, pb) = crate::progress::ndjson_reader(&args.input)?;
     pb.set_message("Building FST index...");
 
-    let mut out = std::fs::File::create(&args.output)
-        .with_context(|| format!("creating {}", args.output.display()))?;
+    let mut out =
+        std::fs::File::create(&output).with_context(|| format!("creating {}", output.display()))?;
 
     let opts = index::BuildOptions {
         include_terms: !args.no_terms,
@@ -115,13 +129,11 @@ fn build(args: BuildArgs) -> Result<()> {
     let elapsed = started.elapsed();
     pb.finish_and_clear();
 
-    let size = std::fs::metadata(&args.output)
-        .map(|m| m.len())
-        .unwrap_or(0);
+    let size = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
 
     eprintln!(
         "Built {} in {:.2}s",
-        args.output.display(),
+        output.display(),
         elapsed.as_secs_f64()
     );
     eprintln!(
@@ -146,7 +158,16 @@ fn build(args: BuildArgs) -> Result<()> {
 }
 
 fn search(args: SearchArgs) -> Result<()> {
-    let idx = Index::open(&args.index)?;
+    let index_path = match args.index {
+        Some(p) => p,
+        None => crate::paths::find_fst_index(std::path::Path::new(".")).ok_or_else(|| {
+            anyhow::anyhow!(
+                "No FST index found in the current directory.\n\
+                 Build one with `sct fst build --ndjson <file>`, or pass --index <path>."
+            )
+        })?,
+    };
+    let idx = Index::open(&index_path)?;
 
     let started = Instant::now();
     let hits = if args.words {

--- a/src/commands/markdown.rs
+++ b/src/commands/markdown.rs
@@ -52,8 +52,12 @@ pub struct Args {
     pub input: PathBuf,
 
     /// Output directory for Markdown files.
-    #[arg(long, short, default_value = "snomed-concepts", value_parser = crate::paths::tilde_pathbuf)]
-    pub output: PathBuf,
+    ///
+    /// Defaults to the input's name with a `-concepts` suffix
+    /// (`uk-monolith-42.ndjson` → `uk-monolith-42-concepts/`), created in the
+    /// working directory. Reading from stdin gives `snomed-concepts/`.
+    #[arg(long, short, value_parser = crate::paths::tilde_pathbuf)]
+    pub output: Option<PathBuf>,
 
     /// Output grouping: one file per concept, or one file per hierarchy.
     #[arg(long, default_value = "concept")]
@@ -61,14 +65,20 @@ pub struct Args {
 }
 
 pub fn run(args: Args) -> Result<()> {
+    let output = crate::commands::resolve_output(
+        args.output.as_deref(),
+        &args.input,
+        crate::paths::suffix::MARKDOWN_DIR,
+    );
+
     let (reader, pb) = crate::progress::ndjson_reader(&args.input)?;
 
-    std::fs::create_dir_all(&args.output)
-        .with_context(|| format!("creating output directory {}", args.output.display()))?;
+    std::fs::create_dir_all(&output)
+        .with_context(|| format!("creating output directory {}", output.display()))?;
 
     match args.mode {
-        OutputMode::Concept => run_concept_mode(reader, &args.output, &pb),
-        OutputMode::Hierarchy => run_hierarchy_mode(reader, &args.output, &pb),
+        OutputMode::Concept => run_concept_mode(reader, &output, &pb),
+        OutputMode::Hierarchy => run_hierarchy_mode(reader, &output, &pb),
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -42,7 +42,25 @@ pub mod serve;
 
 use anyhow::Result;
 use rusqlite::Connection;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Settle a build command's output path: the `--output` flag if given, else a
+/// name derived from the input (see [`crate::paths::derived_output`]).
+///
+/// A derived name is announced on stderr, because a filename the user did not
+/// type should never be a surprise - and because the next command in the
+/// pipeline needs to know what to consume. An explicit `--output` is not
+/// announced; they already know where it went.
+pub(crate) fn resolve_output(flag: Option<&Path>, input: &Path, suffix: &str) -> PathBuf {
+    match flag {
+        Some(path) => path.to_path_buf(),
+        None => {
+            let derived = crate::paths::derived_output(input, suffix);
+            eprintln!("Output: {}", derived.display());
+            derived
+        }
+    }
+}
 
 /// Open a SNOMED CT SQLite database in read-only query mode.
 ///

--- a/src/commands/parquet.rs
+++ b/src/commands/parquet.rs
@@ -40,17 +40,27 @@ pub struct Args {
     pub input: PathBuf,
 
     /// Output Parquet file.
-    #[arg(long, short, default_value = "snomed.parquet", value_parser = crate::paths::tilde_pathbuf)]
-    pub output: PathBuf,
+    ///
+    /// Defaults to the input's name with a `.parquet` extension
+    /// (`uk-monolith-42.ndjson` → `uk-monolith-42.parquet`), written to the
+    /// working directory. Reading from stdin gives `snomed.parquet`.
+    #[arg(long, short, value_parser = crate::paths::tilde_pathbuf)]
+    pub output: Option<PathBuf>,
 }
 
 pub fn run(args: Args) -> Result<()> {
+    let output = crate::commands::resolve_output(
+        args.output.as_deref(),
+        &args.input,
+        crate::paths::suffix::PARQUET,
+    );
+
     let (reader, pb) = crate::progress::ndjson_reader(&args.input)?;
     pb.set_message("Writing Parquet...");
 
     let schema = Arc::new(parquet_schema());
-    let file = std::fs::File::create(&args.output)
-        .with_context(|| format!("creating {}", args.output.display()))?;
+    let file =
+        std::fs::File::create(&output).with_context(|| format!("creating {}", output.display()))?;
     let props = WriterProperties::builder().build();
     let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))
         .context("creating Parquet writer")?;
@@ -94,7 +104,7 @@ pub fn run(args: Args) -> Result<()> {
     pb.finish_with_message(format!(
         "Done. {} → {}",
         plural_count(total as u64, "concept"),
-        args.output.display()
+        output.display()
     ));
     Ok(())
 }

--- a/src/commands/sayt.rs
+++ b/src/commands/sayt.rs
@@ -23,8 +23,12 @@ use crate::index::query::Index;
 #[derive(Parser, Debug)]
 pub struct Args {
     /// FST index produced by `sct fst build`.
-    #[arg(long, default_value = "snomed.fst", value_parser = crate::paths::tilde_pathbuf)]
-    pub index: PathBuf,
+    ///
+    /// Defaults to `./snomed.fst`, then the newest `*.fst` in the working
+    /// directory - `sct fst build` names its index after its input, so it is
+    /// usually `<release>.fst`.
+    #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
+    pub index: Option<PathBuf>,
 
     /// Maximum number of results shown / returned.
     #[arg(long, short, default_value = "10")]
@@ -47,10 +51,19 @@ pub struct Args {
 }
 
 pub fn run(args: Args) -> Result<()> {
-    let index = Index::open(&args.index).with_context(|| {
+    let index_path = match args.index.clone() {
+        Some(p) => p,
+        None => crate::paths::find_fst_index(std::path::Path::new(".")).ok_or_else(|| {
+            anyhow::anyhow!(
+                "No FST index found in the current directory.\n\
+                 Build one with `sct fst build --ndjson <file>`, or pass --index <path>."
+            )
+        })?,
+    };
+    let index = Index::open(&index_path).with_context(|| {
         format!(
             "opening FST index {} - build one with `sct fst build`",
-            args.index.display()
+            index_path.display()
         )
     })?;
 

--- a/src/commands/serve/mod.rs
+++ b/src/commands/serve/mod.rs
@@ -135,14 +135,17 @@ fn resolve_pool_size(requested: usize) -> usize {
     (cores * 2).clamp(4, 64)
 }
 
-/// Resolve the FST index for `/autocomplete`: an explicit `--fst` path, else a
-/// `snomed.fst` sibling of the database if one exists (`None` otherwise).
+/// Resolve the FST index for `/autocomplete`: an explicit `--fst` path, else an
+/// index sitting beside the database (`None` if there is none).
+///
+/// Since `sct fst build` names its index after its input, the sibling is
+/// usually `<release>.fst` rather than `snomed.fst`; `find_fst_index` prefers
+/// the canonical name and falls back to the newest index in that directory.
 fn resolve_fst(explicit: Option<&FsPath>, db: &FsPath) -> Option<PathBuf> {
     if let Some(p) = explicit {
         return Some(p.to_path_buf());
     }
-    let sibling = db.parent().unwrap_or(FsPath::new(".")).join("snomed.fst");
-    sibling.exists().then_some(sibling)
+    crate::paths::find_fst_index(db.parent().unwrap_or(FsPath::new(".")))
 }
 
 /// Serve the FHIR router on an already-bound std listener, blocking. Shared by

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -37,8 +37,12 @@ pub struct Args {
     pub input: PathBuf,
 
     /// Output SQLite database file.
-    #[arg(long, short, default_value = "snomed.db", value_parser = crate::paths::tilde_pathbuf)]
-    pub output: PathBuf,
+    ///
+    /// Defaults to the input's name with a `.db` extension
+    /// (`uk-monolith-42.ndjson` → `uk-monolith-42.db`), written to the working
+    /// directory. Reading from stdin gives `snomed.db`.
+    #[arg(long, short, value_parser = crate::paths::tilde_pathbuf)]
+    pub output: Option<PathBuf>,
 
     /// Build the transitive closure table (concept_ancestors) after loading.
     ///
@@ -55,11 +59,17 @@ pub struct Args {
 }
 
 pub fn run(args: Args) -> Result<()> {
+    let output = crate::commands::resolve_output(
+        args.output.as_deref(),
+        &args.input,
+        crate::paths::suffix::DB,
+    );
+
     let (reader, pb) = crate::progress::ndjson_reader(&args.input)?;
 
-    pb.set_message(format!("Opening database {}...", args.output.display()));
-    let mut conn = Connection::open(&args.output)
-        .with_context(|| format!("opening database {}", args.output.display()))?;
+    pb.set_message(format!("Opening database {}...", output.display()));
+    let mut conn = Connection::open(&output)
+        .with_context(|| format!("opening database {}", output.display()))?;
 
     // Performance pragmas - safe for a build-time operation
     conn.execute_batch(
@@ -274,7 +284,7 @@ pub fn run(args: Args) -> Result<()> {
     pb.finish_with_message(format!(
         "Done. {} → {}",
         plural_count(n as u64, "concept"),
-        args.output.display()
+        output.display()
     ));
 
     if args.transitive_closure {

--- a/src/commands/trud.rs
+++ b/src/commands/trud.rs
@@ -1048,14 +1048,12 @@ fn run_pipeline_if_requested(
         return Ok(None);
     }
 
-    // Derive output filenames from the zip stem (lowercased)
-    let stem = zip_path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("snomed")
-        .to_lowercase();
+    // Name the artefacts after the release, using the same slug `sct ndjson`
+    // would pick for this zip, so a TRUD-built workspace and a hand-built one
+    // are named identically.
+    let stem = super::ndjson::slugify_path(zip_path);
     let ndjson_path = data_dir.join(format!("{stem}.ndjson"));
-    let db_path = data_dir.join(format!("{stem}.db"));
+    let db_path = data_dir.join(format!("{stem}{}", paths::suffix::DB));
 
     // --- sct ndjson ---
     println!("\n→ Running: sct ndjson");
@@ -1072,7 +1070,7 @@ fn run_pipeline_if_requested(
     println!("\n→ Running: sct sqlite");
     super::sqlite::run(super::sqlite::Args {
         input: ndjson_path.clone(),
-        output: db_path.clone(),
+        output: Some(db_path.clone()),
         transitive_closure: false,
         include_self: false,
     })
@@ -1089,12 +1087,12 @@ fn run_pipeline_if_requested(
 
         // --- sct embed (best-effort - skip if Ollama unavailable) ---
         println!("\n→ Running: sct embed");
-        let arrow_path = data_dir.join(format!("{stem}.arrow"));
+        let arrow_path = data_dir.join(format!("{stem}{}", paths::suffix::EMBEDDINGS));
         if let Err(e) = super::embed::run(super::embed::Args {
             input: ndjson_path.clone(),
             model: "nomic-embed-text".into(),
             ollama_url: "http://localhost:11434".into(),
-            output: arrow_path,
+            output: Some(arrow_path),
             batch_size: 64,
         }) {
             eprintln!("Warning: sct embed skipped - {e}");
@@ -2286,11 +2284,9 @@ default = \"json\"
                     api_key_file: None,
                 },
             };
-            let stem = fixture
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap()
-                .to_lowercase();
+            // Artefacts are named with the same slug `sct ndjson` would pick
+            // for this input, not a bare lowercased stem.
+            let stem = crate::commands::ndjson::slugify_path(&fixture);
             let db_path = run_pipeline_if_requested(&args, &fixture, data_dir.path())
                 .unwrap()
                 .expect("pipeline should return generated database path");

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -51,6 +51,78 @@ pub const DATA_SUBDIR: &str = "data";
 const CANONICAL_DB: &str = "snomed.db";
 const CANONICAL_EMBEDDINGS: &str = "snomed-embeddings.arrow";
 
+/// Stem used when no name can be derived from the input - piped stdin, or a
+/// path with no usable file name. Chosen so the canonical filenames above fall
+/// out of [`derived_output`] unchanged.
+const FALLBACK_STEM: &str = "snomed";
+
+/// Default output path for a build command, named after its input.
+///
+/// Every artefact-producing command names its output `<input stem><suffix>`, so
+/// a release identity set once at the top of the pipeline survives to the end:
+///
+/// ```text
+/// uk-monolith-42.ndjson  --->  uk-monolith-42.db
+///                              uk-monolith-42.parquet
+///                              uk-monolith-42-embeddings.arrow
+/// ```
+///
+/// The canonical names are the same rule applied to a canonical input:
+/// `snomed.ndjson` yields `snomed.db` and `snomed-embeddings.arrow`, which is
+/// what these commands defaulted to before the stem was propagated.
+///
+/// The result is always a bare filename, so output lands in the working
+/// directory rather than beside an input that may live somewhere read-only.
+/// `-` (stdin) and unusable names fall back to [`FALLBACK_STEM`].
+pub fn derived_output(input: &Path, suffix: &str) -> PathBuf {
+    let stem = if input.as_os_str() == "-" {
+        None
+    } else {
+        input.file_stem().and_then(|s| s.to_str())
+    }
+    .map(str::trim)
+    .filter(|s| !s.is_empty())
+    .unwrap_or(FALLBACK_STEM);
+
+    PathBuf::from(format!("{stem}{suffix}"))
+}
+
+/// Locate an FST index when `--index` is not supplied.
+///
+/// `sct fst build` names its output after its input, so the index next door is
+/// usually `<release>.fst` rather than the canonical `snomed.fst`. Prefer the
+/// canonical name, then fall back to the newest `*.fst` in the same directory -
+/// the same shape as the `--db` chain's last two steps, minus the env var and
+/// config entry an index has never had.
+///
+/// `dir` is the directory to search: the working directory for `sct fst search`
+/// and `sct sayt`, or the database's directory for `sct serve`.
+pub fn find_fst_index(dir: &Path) -> Option<PathBuf> {
+    let canonical = dir.join(CANONICAL_FST);
+    if canonical.exists() {
+        return Some(canonical);
+    }
+    newest_with_extension(dir, "fst")
+}
+
+/// Canonical FST index name, and the fallback stem's index name.
+const CANONICAL_FST: &str = "snomed.fst";
+
+/// Suffix each build command appends to the stem. Kept together so the set of
+/// artefact names is visible in one place.
+pub mod suffix {
+    /// `sct sqlite`
+    pub const DB: &str = ".db";
+    /// `sct parquet`
+    pub const PARQUET: &str = ".parquet";
+    /// `sct fst build`
+    pub const FST: &str = ".fst";
+    /// `sct embed` - matches the canonical `snomed-embeddings.arrow`.
+    pub const EMBEDDINGS: &str = "-embeddings.arrow";
+    /// `sct markdown` - a directory, not a file.
+    pub const MARKDOWN_DIR: &str = "-concepts";
+}
+
 /// Resolve the data root: `$SCT_DATA_HOME` → `$XDG_DATA_HOME/sct` →
 /// `~/.local/share/sct`.
 pub fn data_home() -> PathBuf {
@@ -242,6 +314,7 @@ pub enum Source {
     Config,
     DataHomeCanonical,
     DataHomeNewest,
+    CwdNewest,
 }
 
 impl Source {
@@ -253,6 +326,7 @@ impl Source {
             Source::Config => "config [paths]".into(),
             Source::DataHomeCanonical => "data home, canonical name".into(),
             Source::DataHomeNewest => "data home, newest".into(),
+            Source::CwdNewest => "cwd, newest".into(),
         }
     }
 }
@@ -414,6 +488,26 @@ pub fn resolve(kind: Kind, arg: Option<&Path>, cfg: &Config) -> Result<Resolved>
             });
         }
         None => tried.push((format!("{glob_label} (newest)"), "no matches")),
+    }
+
+    // 7. Newest *.<ext> in the working directory.
+    //
+    // Build commands name their output after their input (see `derived_output`),
+    // so a locally built artefact is usually `<release>.db` rather than the
+    // canonical `snomed.db` that step 3 looks for. This last-resort step keeps
+    // the zero-flag workflow working in a directory you just built in. It runs
+    // last deliberately: it can never shadow an explicit flag, env var, config
+    // entry, or a canonically named file, so no resolution that succeeds today
+    // changes.
+    let cwd_glob = format!("./*.{}", kind.extension());
+    match newest_with_extension(Path::new("."), kind.extension()) {
+        Some(p) => {
+            return Ok(Resolved {
+                path: p,
+                source: Source::CwdNewest,
+            });
+        }
+        None => tried.push((format!("{cwd_glob} (newest)"), "no matches")),
     }
 
     anyhow::bail!(format_not_found(kind, &tried))
@@ -629,6 +723,32 @@ mod tests {
         let r = resolve(Kind::Db, None, &Config::default()).unwrap();
         assert_eq!(r.path, newer);
         assert_eq!(r.source, Source::DataHomeNewest);
+
+        // ----- cwd newest is the last resort, and never shadows the data home -
+        //
+        // Build commands name their output after their input, so a locally
+        // built database is `<release>.db`, not the canonical `snomed.db` that
+        // step 3 looks for. It must still be found - but only once every
+        // earlier step has come up empty.
+        let local = cwd.path().join("locally-built.db");
+        touch(&local, 0);
+        let r = resolve(Kind::Db, None, &Config::default()).unwrap();
+        assert_eq!(
+            r.source,
+            Source::DataHomeNewest,
+            "a populated data home must still outrank the working directory"
+        );
+
+        // Empty the data home: now the local build is the only candidate.
+        fs::remove_file(&newer).unwrap();
+        fs::remove_file(&older).unwrap();
+        let r = resolve(Kind::Db, None, &Config::default()).unwrap();
+        assert_eq!(r.source, Source::CwdNewest);
+        assert_eq!(
+            r.path.file_name().unwrap(),
+            std::ffi::OsStr::new("locally-built.db")
+        );
+        fs::remove_file(&local).unwrap();
 
         // ----- restore --------------------------------------------------------
         if let Some(c) = old_cwd {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -161,9 +161,9 @@ fn info_format_json_emits_structured_output() {
 }
 
 #[test]
-fn sqlite_default_output_name_is_snomed_db() {
+fn sqlite_default_output_is_named_after_its_input() {
     let tmp = tempfile::tempdir().unwrap();
-    let ndjson = tmp.path().join("out.ndjson");
+    let ndjson = tmp.path().join("uk-monolith-42.ndjson");
     sct()
         .args(["ndjson", "--rf2"])
         .arg(rf2_fixture())
@@ -172,17 +172,121 @@ fn sqlite_default_output_name_is_snomed_db() {
         .assert()
         .success();
 
-    // No --output: `sct sqlite` defaults to `snomed.db` in the working directory.
+    // No --output: the input's stem carries through to the database name, and
+    // the derived name is announced so the next command can consume it.
+    sct()
+        .current_dir(tmp.path())
+        .args(["sqlite", "--ndjson"])
+        .arg(&ndjson)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Output: uk-monolith-42.db"));
+    assert!(
+        tmp.path().join("uk-monolith-42.db").exists(),
+        "database should be named after the NDJSON input"
+    );
+    assert!(
+        !tmp.path().join("snomed.db").exists(),
+        "the old fixed default must no longer be used"
+    );
+}
+
+#[test]
+fn canonical_input_name_still_yields_the_canonical_output_names() {
+    // The canonical names are the naming rule applied to a canonical input, not
+    // a separate case: snomed.ndjson still produces snomed.db.
+    let tmp = tempfile::tempdir().unwrap();
+    let ndjson = tmp.path().join("snomed.ndjson");
+    sct()
+        .args(["ndjson", "--rf2"])
+        .arg(rf2_fixture())
+        .arg("--output")
+        .arg(&ndjson)
+        .assert()
+        .success();
+
     sct()
         .current_dir(tmp.path())
         .args(["sqlite", "--ndjson"])
         .arg(&ndjson)
         .assert()
         .success();
-    assert!(
-        tmp.path().join("snomed.db").exists(),
-        "default snomed.db should be created in CWD"
-    );
+    assert!(tmp.path().join("snomed.db").exists());
+
+    sct()
+        .current_dir(tmp.path())
+        .args(["parquet", "--ndjson"])
+        .arg(&ndjson)
+        .assert()
+        .success();
+    assert!(tmp.path().join("snomed.parquet").exists());
+
+    sct()
+        .current_dir(tmp.path())
+        .args(["fst", "build", "--ndjson"])
+        .arg(&ndjson)
+        .assert()
+        .success();
+    assert!(tmp.path().join("snomed.fst").exists());
+}
+
+#[test]
+fn build_commands_name_every_artefact_after_the_input() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ndjson = tmp.path().join("uk-monolith-42.ndjson");
+    sct()
+        .args(["ndjson", "--rf2"])
+        .arg(rf2_fixture())
+        .arg("--output")
+        .arg(&ndjson)
+        .assert()
+        .success();
+
+    for (args, expected) in [
+        (vec!["parquet"], "uk-monolith-42.parquet"),
+        (vec!["markdown"], "uk-monolith-42-concepts"),
+    ] {
+        let mut cmd = sct();
+        cmd.current_dir(tmp.path());
+        cmd.args(&args).arg("--ndjson").arg(&ndjson);
+        cmd.assert().success();
+        assert!(
+            tmp.path().join(expected).exists(),
+            "{args:?} should have produced {expected}"
+        );
+    }
+
+    // `fst build` is a subcommand, so it does not fit the loop above.
+    sct()
+        .current_dir(tmp.path())
+        .args(["fst", "build", "--ndjson"])
+        .arg(&ndjson)
+        .assert()
+        .success();
+    assert!(tmp.path().join("uk-monolith-42.fst").exists());
+}
+
+#[test]
+fn stdin_input_falls_back_to_the_canonical_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ndjson = tmp.path().join("uk-monolith-42.ndjson");
+    sct()
+        .args(["ndjson", "--rf2"])
+        .arg(rf2_fixture())
+        .arg("--output")
+        .arg(&ndjson)
+        .assert()
+        .success();
+
+    // Piped input has no name to inherit, so the canonical stem is used.
+    sct()
+        .current_dir(tmp.path())
+        .args(["parquet", "--ndjson", "-"])
+        .pipe_stdin(&ndjson)
+        .unwrap()
+        .assert()
+        .success();
+    assert!(tmp.path().join("snomed.parquet").exists());
 }
 
 #[test]

--- a/tests/ecl_eval.rs
+++ b/tests/ecl_eval.rs
@@ -114,7 +114,7 @@ fn build_db() -> (PathBuf, tempfile::TempDir) {
     let db = dir.path().join("fixture.db");
     sqlite::run(sqlite::Args {
         input: ndjson,
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: false,
         include_self: false,
     })

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -44,7 +44,7 @@ fn build(locale: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
 
     sqlite::run(sqlite::Args {
         input: ndjson.clone(),
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: true,
         include_self: false,
     })
@@ -69,7 +69,7 @@ fn build_all(locale: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
     .unwrap();
     sqlite::run(sqlite::Args {
         input: ndjson.clone(),
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: false,
         include_self: false,
     })
@@ -267,7 +267,7 @@ fn sqlite_rebuild_replaces_all_ndjson_derived_data() {
 
     sqlite::run(sqlite::Args {
         input: inactive_ndjson,
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: true,
         include_self: false,
     })
@@ -286,7 +286,7 @@ fn sqlite_rebuild_replaces_all_ndjson_derived_data() {
     for _ in 0..2 {
         sqlite::run(sqlite::Args {
             input: active_ndjson.clone(),
-            output: db.clone(),
+            output: Some(db.clone()),
             transitive_closure: false,
             include_self: false,
         })

--- a/tests/sdk.rs
+++ b/tests/sdk.rs
@@ -30,7 +30,7 @@ fn build() -> (tempfile::TempDir, PathBuf) {
     .unwrap();
     sqlite::run(sqlite::Args {
         input: ndjson,
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: true,
         include_self: false,
     })
@@ -54,7 +54,7 @@ fn build_all() -> (tempfile::TempDir, PathBuf) {
     .unwrap();
     sqlite::run(sqlite::Args {
         input: ndjson,
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: false,
         include_self: false,
     })

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -42,7 +42,7 @@ fn build_db_all() -> (tempfile::TempDir, PathBuf) {
     .unwrap();
     sqlite::run(sqlite::Args {
         input: ndjson,
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: false,
         include_self: false,
     })
@@ -66,7 +66,7 @@ fn build_db_with(tct: bool) -> (tempfile::TempDir, PathBuf) {
     .unwrap();
     sqlite::run(sqlite::Args {
         input: ndjson,
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: tct,
         include_self: false,
     })

--- a/tests/transcode.rs
+++ b/tests/transcode.rs
@@ -33,7 +33,7 @@ fn build() -> (tempfile::TempDir, Connection) {
     .unwrap();
     sqlite::run(sqlite::Args {
         input: ndjson,
-        output: db.clone(),
+        output: Some(db.clone()),
         transitive_closure: false,
         include_self: false,
     })


### PR DESCRIPTION
## Summary

`sct ndjson` named its output after the RF2 release, then every downstream command threw that away:

```
SnomedCT_MonolithRF2_...zip  →  snomedct-monolithrf2-....ndjson  →  snomed.db
```

Three conventions were in play: `ndjson` slugified its input, the other builders had fixed `snomed.*` defaults, and the `sct trud` pipeline had a third, lowercased-stem derivation of its own.

Now there is one rule: **default output = input stem + the command's suffix**, in `paths::derived_output`.

| Input | Output |
|---|---|
| `--rf2 X.zip` | `<slug(X)>.ndjson` |
| `--ndjson X.ndjson` | `X.db`, `X.parquet`, `X.fst`, `X-embeddings.arrow`, `X-concepts/` |

The property that makes this safe: **the old constants are the same rule applied to a canonical input.** `snomed.ndjson` still yields `snomed.db`, `snomed.parquet`, `snomed-embeddings.arrow`, so `paths::CANONICAL_*` still describes what discovery looks for. Derived names print as `Output: <path>` on stderr - a name the user did not type should not be a surprise, and the next command needs to know what to consume. Output stays in the working directory rather than beside a possibly read-only input; stdin (`-`) has no name to inherit and falls back to the `snomed` stem.

## Keeping zero-flag discovery working

Propagating the stem collides with `paths::resolve`, whose CWD step matches `./snomed.db` *exactly*. Two follow-on changes were needed, both strictly additive:

- **`resolve()` gains a last-resort step**: newest `*.db` / `*.arrow` in the working directory. It runs after every existing step, so it cannot shadow a flag, env var, config entry, or canonically named file - it only converts what used to be a "not found" error into a match. `sct paths` reports it as `cwd, newest`.
- **`sct fst search`, `sct sayt`, and `sct serve`** resolve an omitted index via `paths::find_fst_index` (canonical `snomed.fst`, else newest `*.fst` in the relevant directory). Without this, `sct fst build` followed by a bare `sct fst search` would have failed - the audit didn't predict this one; it turned up while testing.

## Defects fixed in passing

All three surfaced during the audit:

- `sct trud`'s embed step wrote `<stem>.arrow`, which never matched `CANONICAL_EMBEDDINGS` and so was only ever found by the newest-file fallback. Now `<stem>-embeddings.arrow`.
- The TRUD pipeline had its own stem derivation that only lowercased, so its artefacts (`uk_sct2mo_41.6.0_...db`) were named differently from hand-built ones for the same release. Both now use `ndjson::slugify_path`.
- `spec/path-resolution.md` documented `sct ndjson` as defaulting to `./snomed.ndjson`, which was never true.

## Test plan

- [x] New CLI tests: derived name per command, canonical-input-gives-canonical-output, stdin fallback, the `Output:` line
- [x] New resolution test asserting the CWD step fires **only** once the data home is empty (it must never outrank a populated one)
- [x] `cargo fmt --all --check`; clippy clean on default, `serve`, `dmwb`, and the `python/` manifest
- [x] `cargo test` (17 suites) and `cargo test --features serve`, re-run after rebasing onto #81 since both touch `trud.rs`
- [x] Manual end-to-end: full pipeline with no `--output` anywhere produces five artefacts all carrying the release name, then bare `sct lookup` still resolves, with `sct paths` showing `cwd, newest`
- [x] Manual: `sct fst build` → bare `sct fst search` and `sayt --stdio` both find the derived index

## BREAKING CHANGE

Build commands no longer write fixed `snomed.*` filenames unless the input is itself canonically named. Scripts hardcoding `snomed.db` after building from a differently named NDJSON must pass `--output snomed.db` or read the printed `Output:` line. Interactive use is unaffected - the read chain finds the new names. Agreed for a **minor** version bump.

## Docs

`spec/path-resolution.md` gains the naming standard and the FST lookup rule; `docs/path-resolution.md`, the five per-command pages, `sayt.md`, and the README quickstart follow. The README previously demonstrated the exact seam this fixes: it built a long-named NDJSON in step 3 and then queried `snomed.db` in step 4.