### PR TITLE
refactor(ecl): unify CLI missing-TCT guidance into one helper (R8)

### DIFF
--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -40,7 +40,7 @@ Do these alongside or immediately after the SDK extraction: they define contract
 
 - [ ] `R7` **Make stdin (`-`) composable across read commands.** Add batch stdin paths to the natural single-value readers (`lookup`, `lexical`, `semantic`, and relevant refset operations), with deterministic line-oriented or structured output suitable for pipelines.
 
-- [ ] `R8` **Unify missing-TCT guidance.** Route recursive-CTE fallbacks through one helper so CLI callers receive the same stderr instruction and MCP callers receive an equivalent log/diagnostic notification; retain `sct size`'s explicit interactive build flow.
+- [~] `R8` **Unify missing-TCT guidance.** CLI side shipped: `sct size`'s bespoke fallback message now goes through the same `ecl::tct_fallback_note()` helper as `sct ecl`/`sct serve`/`sct codelist add --ecl`, so the wording and rebuild hint are identical everywhere a CLI command warns about it; `sct size`'s interactive build-TCT prompt is unchanged. Still open: MCP callers get no equivalent log/diagnostic notification today - the server has no logging/notification plumbing at all yet, so this needs its own design pass rather than a reuse of the CLI helper.
 
 - [ ] `R38` **Refresh `sct gui` as a clinical knowledge atlas.** Replace the experimental fixed dashboard with an offline, search-first, responsive terminology explorer whose stable knowledge graph, concept workspace, mappings/history, URL navigation, and accessibility are verified through a Playwright feedback loop. Follow the stable `GUI-1` through `GUI-8` delivery stages in [`gui.md`](gui.md); ship the polished search-to-concept vertical slice before expanding graph and specialist-query scope.
 

--- a/src/commands/size.rs
+++ b/src/commands/size.rs
@@ -211,10 +211,8 @@ pub fn run(args: Args) -> Result<()> {
         fmt_count(est.total_count)
     );
     if !has_tct {
-        eprintln!(
-            "\nwarning: no transitive-closure table found — subtree count used a recursive CTE.\n\
-             Build it once for fast estimates: `sct tct --db <db>`"
-        );
+        println!();
+        crate::ecl::tct_fallback_note("the subtree-size estimate");
     }
     println!();
     println!("{:<18} {:<16} Method", "Format", "Estimated size");

--- a/src/ecl/mod.rs
+++ b/src/ecl/mod.rs
@@ -60,23 +60,27 @@ pub fn expand_path(db: &Path, ecl: &str) -> Result<Vec<String>> {
     expand(&conn, ecl)
 }
 
-/// Print a one-line stderr hint when the database lacks the transitive-closure
-/// table (`concept_ancestors`). Without it, large `<<` / `>>` ECL evaluation
-/// falls back to recursive CTEs and is much slower. Call from command entry
-/// points that run ECL (`sct ecl`, `sct serve`, `sct codelist add --ecl`).
+/// Print the canonical one-line stderr hint for a query that fell back (or
+/// would fall back) to a recursive CTE because the transitive-closure table
+/// (`concept_ancestors`) is missing. `what` names the operation that is
+/// slower without it, e.g. `"large `<<` / `>>` ECL evaluation"` or `"the
+/// subtree-size estimate"` - phrase it so it reads naturally before "falls
+/// back to a slower recursive CTE". Every caller shares this wording and
+/// rebuild hint so the guidance is consistent everywhere it's printed.
+pub fn tct_fallback_note(what: &str) {
+    eprintln!(
+        "note: this database has no transitive-closure table, so {what} falls back to a \
+         slower recursive CTE.\n  Build it once for a big speed-up: \
+         `sct sqlite --transitive-closure` (or `sct tct --db <db>`)."
+    );
+}
+
+/// Print [`tct_fallback_note`] when the database lacks the transitive-closure
+/// table. Without it, large `<<` / `>>` ECL evaluation falls back to
+/// recursive CTEs and is much slower. Call from command entry points that
+/// run ECL (`sct ecl`, `sct serve`, `sct codelist add --ecl`).
 pub fn warn_if_no_tct(conn: &Connection) {
-    let has_tct = conn
-        .query_row(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='concept_ancestors'",
-            [],
-            |_| Ok(()),
-        )
-        .is_ok();
-    if !has_tct {
-        eprintln!(
-            "note: this database has no transitive-closure table, so large `<<` / `>>` ECL \
-             queries fall back to slower recursive CTEs.\n  Build it once for a big speed-up: \
-             `sct sqlite --transitive-closure` (or `sct tct --db <db>`)."
-        );
+    if !eval::has_tct(conn) {
+        tct_fallback_note("large `<<` / `>>` ECL evaluation");
     }
 }


### PR DESCRIPTION
## Summary

Picked up roadmap item `R8` ("Unify missing-TCT guidance") from `spec/roadmap.md` during nightly triage. This does the CLI-side half of that item:

- `sct size` had its own hand-rolled stderr message for the "no transitive-closure table, fell back to a recursive CTE" case, worded and formatted differently from the note `sct ecl` / `sct serve` / `sct codelist add --ecl` already print via `ecl::warn_if_no_tct`.
- Extracted the shared wording into a new `ecl::tct_fallback_note(what: &str)`, parameterised by what operation is slower, and had both call sites use it — so the message text and rebuild hint (`sct sqlite --transitive-closure` / `sct tct --db <db>`) are now identical everywhere a CLI command prints this.
- `ecl::warn_if_no_tct` (used by the other 5 call sites) is now a thin wrapper over the same helper, and no longer duplicates the `has_tct` SQL check that already lives in `ecl::eval::has_tct`.
- `sct size`'s interactive build-TCT prompt (`maybe_build_tct`) is untouched — this only changes the message printed when the user declines it (or in a non-interactive/`--build-tct`-failed context).

### Scope note — left open deliberately

R8 also asks for MCP callers to get "an equivalent log/diagnostic notification." I looked into this and it's a materially bigger, separate piece of work: the MCP server currently has no logging/notification plumbing at all (only `notifications/initialized`/`notifications/cancelled` exist), so this isn't a reuse of the CLI helper — it needs its own design decision on transport/log level. I've marked `R8` as in-progress (`[~]`) in the roadmap rather than done, with a note describing what's left.

I also deliberately did *not* touch a few other silent recursive-CTE fallback sites I found while scoping this (`get_subtree_size` callers in the TUI/GUI, `codelist.rs`'s `get_all_descendants`, the SDK's `query_descendants`) — printing a stderr note from a library call (SDK) or on every TUI/GUI redraw would be new, debatable behaviour rather than a wording unification, and `get_all_descendants` doesn't use the TCT even when present, so warning there would be misleading. Flagging these as candidates for a possible follow-up rather than folding them in here.

## Test plan

- [x] `cargo fmt --check` on the changed files
- [x] Manually traced both call sites (`sct size`, `ecl::warn_if_no_tct`'s 5 other callers) to confirm no signature changes and no other code/docs reference the old message text
- [ ] CI (this sandbox can't complete a local `cargo build`/`test` — pre-existing `libsqlite3-sys`/toolchain issue unrelated to this change, also noted on PR #40)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdZFgoyJrTeQDoi1A4RgKU)_