### PR TITLE
feat(codelist): wire sct ecl compress into codelist export --format ecl

### DIFF
--- a/docs/commands/codelist.md
+++ b/docs/commands/codelist.md
@@ -306,6 +306,9 @@ sct codelist export codelists/asthma.codelist --format csv --include-maps read2,
 
 # FHIR R4 ValueSet resource
 sct codelist export codelists/asthma.codelist --format fhir-json --output asthma.valueset.json
+
+# Compact ECL expression that exactly reproduces the active members
+sct codelist export codelists/asthma.codelist --format ecl --db snomed.db
 ```
 
 | Format | Description |
@@ -314,6 +317,7 @@ sct codelist export codelists/asthma.codelist --format fhir-json --output asthma
 | `opencodelists-csv` | `code,term` - OpenCodelists-compatible upload format |
 | `markdown` | Markdown table with front-matter metadata header |
 | `fhir-json` | A FHIR R4 `ValueSet` resource (extensional `compose.include.concept`) |
+| `ecl` | An intensional ECL expression, via [`sct ecl compress`](ecl.md)'s exact heuristic - needs `--db` |
 
 `--include-maps <terminologies>` (csv/markdown only) appends a column per terminology - `ctv3`, `read2`, `icd10`, `opcs4` - so a SNOMED codelist can be cross-walked to legacy and classification codes in one export. Maps are read from the general `crossmaps` table, with a fallback to the legacy `concept_maps` table for older CTV3/Read v2 databases. `sct trud download --multi-terminology` builds the full map set; manually, ICD-10 / OPCS-4 require [`sct ndjson --refsets all`](ndjson.md), and Read v2 requires [`sct read2 import`](read2.md) over TRUD item 9.
 

--- a/docs/commands/ecl.md
+++ b/docs/commands/ecl.md
@@ -92,6 +92,8 @@ sct ecl compress --codelist diabetes.codelist | sct ecl expand -
 
 This is a greedy heuristic, not a proof of minimum size; `--stats` reports how much was expressed intensionally. See [`spec/commands/ecl-compress.md`](https://github.com/pacharanero/sct/blob/main/spec/commands/ecl-compress.md).
 
+The same heuristic is available directly from a `.codelist` file via `sct codelist export --format ecl` (see [`codelist.md`](codelist.md)), with no separate `compress` step.
+
 ---
 
 ## Supported ECL

--- a/spec/commands/ecl-compress.md
+++ b/spec/commands/ecl-compress.md
@@ -1,6 +1,6 @@
 # `sct ecl compress` - refactor a concept set into minimal ECL
 
-**Status:** ✅ Shipped (slice 1: include roots + clean exclusions + exactness residual net + verification + `--stats` + `--codelist` input). Deferred: straddling-exclusion push-down (§4.2 step 4-5), `^refset` cover clauses, `codelist export --format ecl` wiring (§7 slices 2-3). Anticipated by `spec/ecl.md §9`.
+**Status:** ✅ Shipped (slice 1: include roots + clean exclusions + exactness residual net + verification + `--stats` + `--codelist` input; slice 3's `sct codelist export --format ecl` wiring). Deferred: straddling-exclusion push-down (§4.2 step 4-5), `^refset` cover clauses, and the FHIR `ValueSet.compose` emitter in `sct serve` (§7 slices 2-3). Anticipated by `spec/ecl.md §9`.
 **Scope:** Given an explicit set of SCTIDs (a codelist), synthesise a compact **ECL expression** that expands to *exactly* that set - the inverse of `ValueSet/$expand`. Runs against the local `sct` SQLite database.
 **Audience:** A coding agent (and Marcus) implementing this in the `sct` repo.
 **Provenance:** Idea harvested from the prior-art Python toolchain `cheethame2017/sct` (Apache-2.0), whose ECL/set browser can "refactor" a raw set of concepts into include/exclude constraints. Clean-room Rust reimplementation - ideas only, no code.
@@ -131,7 +131,7 @@ Input: every subtype of *Diabetes mellitus* (`<<73211009`) **except** the *Type 
 
 1. **Slice 1** - includes + clean exclusions (§4.1-4.2 steps 1-3) + the exactness residual net (§4.3) + verification + `--stats`. Correct and useful from day one; compact on the common "subtree minus subtrees" shape.
 2. **Slice 2** - straddling-exclusion push-down and bounded recursion (§4.2 step 4-5) for tighter expressions; `--pretty`, `|PT|` annotation.
-3. **Slice 3** - `^refset` clauses in the cover (recognise when `S` *is* a refset's membership and emit `^refsetId`); wiring into `sct codelist export --format ecl` and the FHIR `ValueSet.compose` emitter in `sct serve`.
+3. **Slice 3** - `^refset` clauses in the cover (recognise when `S` *is* a refset's membership and emit `^refsetId`); the FHIR `ValueSet.compose` emitter in `sct serve`. ✅ The `sct codelist export --format ecl` half of this slice is shipped: it reuses `compress_with_tct` unchanged, so it inherits the exactness guarantee and gets the `^refset` clauses "for free" the day step 3a lands its cover recognition.
 4. **Later** - MCP `snomed_compress` tool; attribute-refinement clauses in the cover (using `concept_relationships`) when a set aligns with an attribute value, e.g. `<<404684003 : 363698007 = <<39057004`.
 
 ---

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -16,7 +16,7 @@ Legend: `[ ]` not started, `[~]` in progress. The `R##` sequence was deliberatel
 
 - [ ] `R11` **Tell the complete inactive-concept story.** Using Snapshot concepts, Association history, and the inactivation-indicator AttributeValue refset, make lookup, MCP, and FHIR show inactive status, inactivation date/reason, and replacement targets with preferred terms; provide one coherent `history` view. True birth dates and years-in-service remain part of Full-RF2 temporal work (`R25`). See [`cross-terminology-mapping.md`](cross-terminology-mapping.md).
 
-- [ ] `R12` **Finish set-to-ECL compression.** Build on the shipped exact greedy compressor with straddling-exclusion push-down, `^refset` cover clauses, and `sct codelist export --format ecl`; preserve re-expansion exactness tests and explicit residuals where no compact exact expression exists.
+- [~] `R12` **Finish set-to-ECL compression.** Build on the shipped exact greedy compressor with straddling-exclusion push-down and `^refset` cover clauses; `sct codelist export --format ecl` is now wired up. Preserve re-expansion exactness tests and explicit residuals where no compact exact expression exists.
 
 - [ ] `R13` **Design multi-terminology codelists (format v2).** Allow first-class non-SNOMED source codes where SNOMED is not an honest canonical pivot, while preserving the current format and `--include-maps` workflow for SNOMED-canonical lists. Treat migration, validation, and FHIR export semantics as design gates rather than merely adding a `system` column.
 

--- a/src/commands/codelist.rs
+++ b/src/commands/codelist.rs
@@ -175,8 +175,10 @@ pub struct ExportArgs {
     /// Path to the .codelist file.
     #[arg(value_parser = crate::paths::tilde_pathbuf)]
     pub file: PathBuf,
-    /// Output format: csv (default), opencodelists-csv, markdown, or fhir-json
-    /// (a FHIR R4 ValueSet resource). RF2 is deferred; see issue #60.
+    /// Output format: csv (default), opencodelists-csv, markdown, fhir-json
+    /// (a FHIR R4 ValueSet resource), or ecl (a compact ECL expression that
+    /// exactly reproduces the active members, via `sct ecl compress`; needs
+    /// a database - see `--db`). RF2 is deferred; see issue #60.
     #[arg(long, default_value = "csv")]
     pub format: String,
     /// Write to file instead of stdout.
@@ -194,7 +196,9 @@ pub struct ExportArgs {
     /// `|`. Not supported for `opencodelists-csv`.
     #[arg(long, value_delimiter = ',')]
     pub include_maps: Vec<String>,
-    /// SNOMED CT SQLite database (required when `--include-maps` is set).
+    /// SNOMED CT SQLite database (required when `--include-maps` is set;
+    /// used to resolve the concept hierarchy for `--format ecl`, falling
+    /// back to standard discovery when omitted - `docs/path-resolution.md`).
     #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
     pub db: Option<PathBuf>,
     /// Registry directory bare-id `includes:` entries resolve against.
@@ -1703,6 +1707,30 @@ fn export_fhir_json(fm: &FrontMatter, active: &[(&str, &str)], url_base: Option<
     s
 }
 
+/// `--format ecl`: compress a codelist's active members into a compact,
+/// exact ECL expression via `sct ecl compress`'s heuristic (§7 slice 3 of
+/// `spec/commands/ecl-compress.md`). Always exact - literal residuals are
+/// appended for anything the subsumption heuristic cannot express cleanly.
+fn export_ecl(active: &[(&str, &str)], db: Option<&Path>) -> Result<String> {
+    let db_path = crate::paths::resolve_db(db)
+        .context("--format ecl needs a SNOMED CT database to resolve the concept hierarchy")?
+        .path;
+    let conn = open_db(&db_path)?;
+    let _snapshot = crate::ecl::eval::ReadSnapshot::begin(&conn)?;
+    let tct = crate::ecl::warn_if_tct_unusable(&conn, "codelist ECL export")?;
+
+    let mut target = crate::ecl::eval::IdSet::new();
+    for (id, _) in active {
+        let parsed: u64 = id
+            .parse()
+            .with_context(|| format!("codelist member {id:?} is not a valid SCTID"))?;
+        target.insert(parsed);
+    }
+
+    let result = crate::ecl::compress::compress_with_tct(&conn, &target, 32, true, true, tct)?;
+    Ok(format!("{}\n", result.expr))
+}
+
 fn cmd_export(args: ExportArgs) -> Result<()> {
     let cl = read_codelist(&args.file)?;
     let registry = crate::paths::codelist_registry(args.codelists.as_deref());
@@ -1736,7 +1764,7 @@ fn cmd_export(args: ExportArgs) -> Result<()> {
         Some(lookup_crosswalks(&conn, &sctids, &terminologies)?)
     };
 
-    if !terminologies.is_empty() && matches!(args.format.as_str(), "fhir-json" | "rf2") {
+    if !terminologies.is_empty() && matches!(args.format.as_str(), "fhir-json" | "rf2" | "ecl") {
         bail!("--include-maps is only supported for the csv and markdown formats");
     }
 
@@ -1747,6 +1775,7 @@ fn cmd_export(args: ExportArgs) -> Result<()> {
         }
         "opencodelists-csv" => export_opencodelists_csv(&active),
         "fhir-json" => export_fhir_json(&cl.front_matter, &active, args.url.as_deref()),
+        "ecl" => export_ecl(&active, args.db.as_deref())?,
         "rf2" => bail!(
             "`rf2` export is not yet implemented.\n\
              Emitting a codelist as an RF2 Simple Reference Set needs a real SNOMED CT \
@@ -1758,7 +1787,7 @@ fn cmd_export(args: ExportArgs) -> Result<()> {
         ),
         other => bail!(
             "unsupported export format: {other}\n\
-             Supported: csv, opencodelists-csv, markdown, fhir-json (RF2 is deferred; \
+             Supported: csv, opencodelists-csv, markdown, fhir-json, ecl (RF2 is deferred; \
              see https://github.com/pacharanero/sct/issues/60)."
         ),
     };
@@ -2908,6 +2937,131 @@ misuse: Not for clinical decision support.
             csv.contains(r#""He said ""yes"""#),
             "internal quotes must be doubled; got: {csv}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // export_ecl tests
+    // -----------------------------------------------------------------------
+
+    /// Same small hierarchy as `crate::ecl::compress`'s test fixture:
+    ///   1 ── 2 ── 4
+    ///     │    └─ 5
+    ///     └─ 3 ── 6
+    ///          └─ 7
+    fn ecl_export_fixture() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("snomed.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE concepts (id TEXT PRIMARY KEY, active INTEGER NOT NULL);
+             CREATE TABLE concept_isa (child_id TEXT NOT NULL, parent_id TEXT NOT NULL);",
+        )
+        .unwrap();
+        for id in ["1", "2", "3", "4", "5", "6", "7", "100"] {
+            conn.execute("INSERT INTO concepts (id, active) VALUES (?1, 1)", [id])
+                .unwrap();
+        }
+        for (c, p) in [
+            ("2", "1"),
+            ("3", "1"),
+            ("4", "2"),
+            ("5", "2"),
+            ("6", "3"),
+            ("7", "3"),
+        ] {
+            conn.execute(
+                "INSERT INTO concept_isa (child_id, parent_id) VALUES (?1, ?2)",
+                [c, p],
+            )
+            .unwrap();
+        }
+        drop(conn);
+        (dir, db_path)
+    }
+
+    #[test]
+    fn export_ecl_round_trips_a_clean_subtree() {
+        let (_dir, db_path) = ecl_export_fixture();
+        let active = vec![("1", "root"), ("2", "a"), ("3", "b")];
+        let out = export_ecl(&active, Some(&db_path)).unwrap();
+        assert_eq!(out, "<<1 MINUS <<4 MINUS <<5 MINUS <<6 MINUS <<7\n");
+
+        // Re-expanding the emitted ECL against the same database must yield
+        // exactly the input SCTIDs - the whole point of `--format ecl`.
+        let conn = Connection::open(&db_path).unwrap();
+        let reexpanded = crate::ecl::expand_set(&conn, out.trim()).unwrap();
+        let expected: crate::ecl::eval::IdSet =
+            active.iter().map(|(id, _)| id.parse().unwrap()).collect();
+        assert_eq!(reexpanded, expected);
+    }
+
+    #[test]
+    fn export_ecl_appends_literal_residual_for_a_straddling_exclusion() {
+        let (_dir, db_path) = ecl_export_fixture();
+        // Keep everything under 1 except 3 itself, but keep 3's child 7: `<<3`
+        // cannot be excluded (it would drop 7 too), so 3 must appear as a
+        // literal `MINUS 3` residual and the result must stay exact.
+        let active = vec![("1", "r"), ("2", "a"), ("4", "b"), ("5", "c"), ("7", "d")];
+        let out = export_ecl(&active, Some(&db_path)).unwrap();
+        assert!(
+            out.contains("MINUS 3"),
+            "expected a literal residual: {out}"
+        );
+
+        let conn = Connection::open(&db_path).unwrap();
+        let reexpanded = crate::ecl::expand_set(&conn, out.trim()).unwrap();
+        let expected: crate::ecl::eval::IdSet =
+            active.iter().map(|(id, _)| id.parse().unwrap()).collect();
+        assert_eq!(reexpanded, expected);
+    }
+
+    #[test]
+    fn export_ecl_without_a_resolvable_db_errors() {
+        // Serialise against sibling env/cwd-touching tests elsewhere in the
+        // crate (see `crate::paths::ENV_LOCK`'s doc comment).
+        let _guard = crate::paths::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let saved_home = std::env::var_os("HOME");
+        let saved_sct_db = std::env::var_os("SCT_DB");
+        let saved_sct_data_home = std::env::var_os("SCT_DATA_HOME");
+        let saved_xdg = std::env::var_os("XDG_DATA_HOME");
+        let saved_cwd = std::env::current_dir().unwrap();
+
+        let home = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", home.path());
+            std::env::remove_var("SCT_DB");
+            std::env::remove_var("SCT_DATA_HOME");
+            std::env::remove_var("XDG_DATA_HOME");
+        }
+        std::env::set_current_dir(cwd.path()).unwrap();
+
+        let result = export_ecl(&[("1", "root")], None);
+
+        std::env::set_current_dir(&saved_cwd).unwrap();
+        unsafe {
+            match saved_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match saved_sct_db {
+                Some(v) => std::env::set_var("SCT_DB", v),
+                None => std::env::remove_var("SCT_DB"),
+            }
+            match saved_sct_data_home {
+                Some(v) => std::env::set_var("SCT_DATA_HOME", v),
+                None => std::env::remove_var("SCT_DATA_HOME"),
+            }
+            match saved_xdg {
+                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+
+        assert!(result.is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Nightly roadmap pick: `R12` ("Finish set-to-ECL compression") lists three remaining pieces - straddling-exclusion push-down, `^refset` cover clauses, and wiring `sct ecl compress` into `sct codelist export --format ecl`. This PR ships the third piece, which was fully self-contained and needed no design decisions:

- Adds `--format ecl` to `sct codelist export`: exports a `.codelist`'s active members as a compact, exact ECL expression, by calling the existing `compress_with_tct` heuristic unchanged (so it inherits the residual-net exactness guarantee for free).
- Needs a SNOMED CT database to resolve the concept hierarchy - resolved via `--db` or standard discovery, same as `--include-maps`.
- Rejects `--include-maps` combined with `--format ecl` (not applicable), matching the existing `fhir-json`/`rf2` incompatibility checks.
- Updates `spec/commands/ecl-compress.md` and `spec/roadmap.md` to record this slice of `R12` as shipped, and `docs/commands/codelist.md` / `docs/commands/ecl.md` with the new format and a cross-reference.

Push-down and `^refset` cover clauses remain deferred - they're open-ended algorithmic work rather than a bounded, single-sitting task, so `R12` stays marked in-progress (`[~]`) rather than fully checked off.

## Test plan

- [x] `cargo +nightly test` - full suite green (280 lib tests + all integration suites; this sandbox's pinned stable `rustc` can't build `libsqlite3-sys` at all - pre-existing, unrelated to this change, already flagged in a prior automated review on #40 - so verification used `+nightly` instead)
- [x] `cargo +nightly clippy --lib --bins` - clean on the touched code (one pre-existing nightly-only lint elsewhere in `src/index/query.rs`, untouched by this change)
- [x] `cargo +nightly fmt`
- [x] Manual CLI smoke test against a real database built from the synthetic RF2 fixture (`tests/fixtures/rf2/...`): built a codelist covering a subtree with a straddling exclusion, exported it with `--format ecl`, and re-expanded the output with `sct ecl expand` to confirm an exact round-trip (`<<73211009 MINUS <<46635009` → back to the original 2 concepts)
- [x] New unit tests: clean-subtree round-trip, straddling-exclusion literal residual + round-trip, and the "no resolvable database" error path

---
_Generated by [Claude Code](https://claude.ai/code/session_016scHvo9s4ZMhxZfrAddWvj)_