### PR TITLE
feat(sdk): compute proximal primitive supertypes (R26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ For all further information see the full documentation by either exploring the [
 * [sct ecl](docs/commands/ecl.md) - evaluate an ECL expression and emit matching concept SCTIDs (pipe-friendly)
 * `sct lookup <code>` - look up a concept by SCTID, or reverse-resolve a CTV3 code
 * [sct diagram](docs/commands/diagram.md) - draw a concept's definition, ancestors, or descendants as a tree, DOT, or Mermaid diagram
+* [sct proximal-primitives](docs/commands/proximal-primitives.md) - compute a concept's most specific primitive ancestors, for classification and post-coordination QA
 * [sct refset](docs/commands/refset.md) - inspect SNOMED CT simple reference sets loaded into a SQLite database
 * [sct map](docs/commands/map.md) - map codes between SNOMED CT, Read v2, CTV3, ICD-10, and OPCS-4: `sct map <code>` shows all cross-terminology equivalents of a single code, `sct map --from read2 --to snomed` maps a stream (`sct trud download --multi-terminology` builds the full workspace). Aliases: `sct transcode`, `sct crosswalk`
 * `sct codelist` - build, compose, import, validate, and export clinical code lists; `add --ecl "<<73211009"` populates from an ECL query

--- a/docs/commands/proximal-primitives.md
+++ b/docs/commands/proximal-primitives.md
@@ -1,0 +1,48 @@
+# sct proximal-primitives
+
+Compute a concept's **proximal primitive supertypes**: the most specific primitive concepts that subsume it (or the concept itself, if it is primitive).
+
+**When to use:** classification and post-coordination QA, where a concept's necessary normal form is expressed in terms of its proximal primitive supertypes plus refinements. Every concept has at least one, since the root concept (`138875005`) is primitive and subsumes everything. For the full ancestor chain instead, use [`sct diagram --view ancestors`](diagram.md); for a raw subsumption test between two concepts, use the SDK's `Snomed::subsumes`.
+
+---
+
+## Usage
+
+```
+sct proximal-primitives <CONCEPT> [--db <FILE>] [-f text|json|yaml]
+```
+
+## Options
+
+| Argument / Flag | Default | Description |
+|---|---|---|
+| `<CONCEPT>` | *(required)* | Focus concept SCTID. |
+| `--db <FILE>` | discovered (see [Path resolution](../path-resolution.md)) | SQLite database produced by `sct sqlite`. |
+| `-f, --format <FMT>` | `text` | Output format: `text` (human), `json`, or `yaml`. |
+
+**Requires schema v6 or later** (the `definition_status` column, added alongside RF2 `definitionStatusId`). Rebuild an older database with `sct ndjson` then `sct sqlite` to add it.
+
+---
+
+## Examples
+
+```bash
+# Most specific primitive ancestors of a fully-defined concept
+sct proximal-primitives 22298006
+
+# Raw JSON for scripting
+sct proximal-primitives 22298006 --format json
+
+# Explicit database
+sct proximal-primitives 73211009 --db /data/snomed.db
+```
+
+Text output writes one `id<TAB>preferred_term` line per result, followed by a stderr summary line. A concept that is itself primitive returns only itself, since nothing in its ancestor set is more specific. A concept with multiple incomparable primitive ancestors (multiple inheritance from unrelated primitive branches) returns all of them.
+
+## Algorithm
+
+1. Collect the concept itself plus all of its transitive ancestors (using the transitive-closure table when present, otherwise a recursive CTE - see [`sct tct`](tct.md)).
+2. Filter to those with `definition_status = 900000000000074008` (primitive).
+3. Drop any primitive that is itself a proper ancestor of another primitive still in the set, leaving only the most specific ones.
+
+An error means either the database predates the `definition_status` column, or (for a database with the column but incomplete data - e.g. records carried over from schema v5) no primitive ancestor could be found for the concept.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
           - sct semantic: commands/semantic.md
           - sct ecl: commands/ecl.md
           - sct diagram: commands/diagram.md
+          - sct proximal-primitives: commands/proximal-primitives.md
           - sct refset: commands/refset.md
           - sct map: commands/map.md
           - sct size: commands/size.md

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -69,8 +69,6 @@ This work should reuse shared engine contracts rather than reimplementing them.
 
 - [ ] `R25` **Support point-in-time and through-time reporting.** Ingest Full RF2 to reconstruct terminology at an `effectiveTime` and report changes in ancestry, descendants, refset membership, and concept lifecycle across releases; extend the shipped two-release diff and Association forwarding rather than creating a separate temporal model.
 
-- [ ] `R26` **Compute proximal primitive supertypes.** Use definition status plus the TCT to expose the classification/normal-form primitive needed for subsumption and post-coordination QA, with typed SDK and CLI surfaces.
-
 - [ ] `R27` **Add named-set algebra over ECL results.** Let users name query results and combine them with AND/OR/NOT, feeding named sets into subsequent ECL/codelist work as transient refsets.
 
 - [ ] `R28` **Handle SCG and OWL axioms.** Parse and pretty-print Semantic Compositional Grammar and the OWL axiom refset so concept views can show the actual description-logic definition rather than only relationship rows.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod mcp;
 pub mod ndjson;
 pub mod parquet;
 pub mod paths;
+pub mod proximal_primitives;
 pub mod read2;
 pub mod refset;
 pub mod sayt;

--- a/src/commands/proximal_primitives.rs
+++ b/src/commands/proximal_primitives.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Marcus Baw and Baw Medical Ltd
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `sct proximal-primitives` - Compute a concept's proximal primitive
+//! supertypes: the most specific primitive concepts that subsume it.
+//!
+//! Every fully-defined concept is ultimately built on primitive ancestors
+//! somewhere up the IS-A hierarchy (the root concept, 138875005, is
+//! primitive by definition), so this always returns at least one concept.
+//! Useful for classification and post-coordination QA, where the necessary
+//! normal form of a concept is expressed in terms of its proximal primitive
+//! supertypes plus refinements.
+//!
+//! Requires a database built with `sct sqlite` from schema v6 onward (the
+//! `definition_status` column).
+
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+use crate::output::OutputFormat;
+use crate::sdk::Snomed;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Focus concept SCTID.
+    pub concept: String,
+
+    /// SNOMED CT SQLite database. See `docs/path-resolution.md` for discovery.
+    #[arg(long, value_parser = crate::paths::tilde_pathbuf)]
+    pub db: Option<PathBuf>,
+
+    /// Output format.
+    #[arg(long, short = 'f', value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+}
+
+pub fn run(args: Args) -> Result<()> {
+    let db = crate::paths::resolve_db(args.db.as_deref())?.path;
+    let snomed = Snomed::open(&db)?;
+
+    let supertypes = snomed.proximal_primitive_supertypes(&args.concept)?;
+
+    if let Some(rendered) = args.format.render(&supertypes)? {
+        println!("{rendered}");
+        return Ok(());
+    }
+
+    for supertype in &supertypes {
+        println!("{}\t{}", supertype.id, supertype.preferred_term);
+    }
+    eprintln!("{} proximal primitive supertype(s)", supertypes.len());
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,9 @@ enum Command {
     /// Look up a SNOMED CT concept by SCTID or CTV3 code.
     Lookup(commands::lookup::Args),
 
+    /// Compute a concept's proximal primitive supertypes (most specific primitive ancestors).
+    ProximalPrimitives(commands::proximal_primitives::Args),
+
     /// Keyword (FTS5) search over a SNOMED CT SQLite database.
     Lexical(commands::lexical::Args),
 
@@ -151,6 +154,7 @@ fn main() -> Result<()> {
         Command::Trud(args) => commands::trud::run(args),
         Command::Paths(args) => commands::paths::run(args),
         Command::Lookup(args) => commands::lookup::run(args),
+        Command::ProximalPrimitives(args) => commands::proximal_primitives::run(args),
         Command::Lexical(args) => commands::lexical::run(args),
         Command::Semantic(args) => commands::semantic::run(args),
         Command::Completions(args) => commands::completions::run(args, Cli::command()),

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -9,7 +9,7 @@
 //! than sharing a single connection concurrently.
 
 use indexmap::IndexMap;
-use rusqlite::{params, Connection, OpenFlags};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::fmt;
@@ -126,6 +126,17 @@ impl Snomed {
     /// Compare two concepts using reflexive SNOMED CT subsumption semantics.
     pub fn subsumes(&self, left: &str, right: &str) -> Result<Subsumption, SctError> {
         query_subsumption(&self.conn, left, right)
+    }
+
+    /// Return the proximal primitive supertypes of a concept: the most
+    /// specific primitive concepts that are the concept itself or one of its
+    /// ancestors. Every concept has at least one, since the root concept
+    /// (138875005) is primitive and subsumes everything.
+    ///
+    /// Requires a database built with `sct sqlite` from schema v6 onward
+    /// (the `definition_status` column); older databases return an error.
+    pub fn proximal_primitive_supertypes(&self, id: &str) -> Result<Vec<ConceptSummary>, SctError> {
+        query_proximal_primitive_supertypes(&self.conn, id)
     }
 
     /// Expand an ECL expression into sorted, deduplicated SCTIDs.
@@ -1162,6 +1173,83 @@ pub(crate) fn query_subsumption(
     }
 }
 
+/// RF2 `definitionStatusId` for primitive concepts.
+const PRIMITIVE_SCTID: &str = "900000000000074008";
+
+fn query_proximal_primitive_supertypes(
+    conn: &Connection,
+    id: &str,
+) -> Result<Vec<ConceptSummary>, SctError> {
+    let _snapshot = crate::ecl::eval::ReadSnapshot::begin(conn).map_err(anyhow_query)?;
+    let numeric_id = parse_sctid(id)?;
+    require_concept(conn, id)?;
+    if !has_definition_status_column(conn).map_err(SctError::query)? {
+        return Err(anyhow_query(anyhow::anyhow!(
+            "database has no 'definition_status' column; rebuild with a current sct \
+             (`sct ndjson` then `sct sqlite`) to compute proximal primitive supertypes"
+        )));
+    }
+
+    let tct = crate::ecl::eval::has_tct(conn).map_err(anyhow_query)?;
+    let mut candidates =
+        crate::ecl::eval::ancestors_with_tct(conn, numeric_id, tct).map_err(anyhow_query)?;
+    candidates.insert(numeric_id);
+
+    let mut primitive_ids = crate::ecl::IdSet::new();
+    for &candidate in &candidates {
+        if definition_status(conn, candidate)? == PRIMITIVE_SCTID {
+            primitive_ids.insert(candidate);
+        }
+    }
+
+    // Keep only the most specific primitives: drop any primitive that is a
+    // proper ancestor of another primitive still in the set.
+    let mut ancestors_of: std::collections::HashMap<u64, crate::ecl::IdSet> =
+        std::collections::HashMap::with_capacity(primitive_ids.len());
+    for &candidate in &primitive_ids {
+        let ancestors =
+            crate::ecl::eval::ancestors_with_tct(conn, candidate, tct).map_err(anyhow_query)?;
+        ancestors_of.insert(candidate, ancestors);
+    }
+    let proximal: crate::ecl::IdSet = primitive_ids
+        .iter()
+        .copied()
+        .filter(|&p| {
+            !primitive_ids
+                .iter()
+                .any(|&q| q != p && ancestors_of[&q].contains(&p))
+        })
+        .collect();
+
+    if proximal.is_empty() {
+        return Err(anyhow_query(anyhow::anyhow!(
+            "no primitive ancestors found for {id}; the database's \
+             definition_status data may be incomplete"
+        )));
+    }
+
+    query_summaries_for_ids(conn, proximal)
+}
+
+fn has_definition_status_column(conn: &Connection) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT 1 FROM pragma_table_info('concepts') WHERE name = 'definition_status'",
+        [],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+}
+
+fn definition_status(conn: &Connection, id: u64) -> Result<String, SctError> {
+    conn.query_row(
+        "SELECT definition_status FROM concepts WHERE id = ?1",
+        [id.to_string()],
+        |row| row.get::<_, String>(0),
+    )
+    .map_err(SctError::query)
+}
+
 fn query_summaries(
     conn: &Connection,
     sql: &str,
@@ -1499,5 +1587,101 @@ mod tests {
         conn.execute_batch(crate::ecl::eval::TCT_INVALIDATION_TRIGGERS_SQL)
             .unwrap();
         assert_eq!(query_descendants(&conn, "100", 1).unwrap()[0].id, "1");
+    }
+
+    fn primitive_hierarchy_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE concepts (
+                 id TEXT NOT NULL,
+                 preferred_term TEXT NOT NULL,
+                 fsn TEXT NOT NULL,
+                 definition_status TEXT NOT NULL
+             );
+             CREATE TABLE concept_isa (child_id TEXT NOT NULL, parent_id TEXT NOT NULL);
+             INSERT INTO concepts VALUES
+                 ('1', 'Root', 'Root', '900000000000074008'),
+                 ('2', 'Primitive mid', 'Primitive mid', '900000000000074008'),
+                 ('3', 'Defined leaf', 'Defined leaf', '900000000000073002'),
+                 ('4', 'Primitive branch A', 'Primitive branch A', '900000000000074008'),
+                 ('5', 'Primitive branch B', 'Primitive branch B', '900000000000074008'),
+                 ('6', 'Defined multi-parent', 'Defined multi-parent', '900000000000073002');
+             INSERT INTO concept_isa VALUES
+                 ('2', '1'), ('3', '2'),
+                 ('4', '1'), ('5', '1'),
+                 ('6', '4'), ('6', '5');",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn proximal_primitive_supertypes_prunes_less_specific_ancestors() {
+        let conn = primitive_hierarchy_db();
+        let result = query_proximal_primitive_supertypes(&conn, "3").unwrap();
+        assert_eq!(
+            result.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["2"]
+        );
+    }
+
+    #[test]
+    fn proximal_primitive_supertypes_of_a_primitive_concept_is_itself() {
+        let conn = primitive_hierarchy_db();
+        let result = query_proximal_primitive_supertypes(&conn, "2").unwrap();
+        assert_eq!(
+            result.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["2"]
+        );
+    }
+
+    #[test]
+    fn proximal_primitive_supertypes_keeps_incomparable_primitives() {
+        let conn = primitive_hierarchy_db();
+        let result = query_proximal_primitive_supertypes(&conn, "6").unwrap();
+        assert_eq!(
+            result.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["4", "5"]
+        );
+    }
+
+    #[test]
+    fn proximal_primitive_supertypes_errors_without_definition_status_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE concepts (
+                 id TEXT NOT NULL, preferred_term TEXT NOT NULL, fsn TEXT NOT NULL
+             );
+             CREATE TABLE concept_isa (child_id TEXT NOT NULL, parent_id TEXT NOT NULL);
+             INSERT INTO concepts VALUES ('1', 'Root', 'Root');",
+        )
+        .unwrap();
+
+        let error = query_proximal_primitive_supertypes(&conn, "1").unwrap_err();
+        assert!(format!("{error:?}").contains("definition_status"));
+    }
+
+    #[test]
+    fn proximal_primitive_supertypes_errors_when_data_is_incomplete() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE concepts (
+                 id TEXT NOT NULL, preferred_term TEXT NOT NULL, fsn TEXT NOT NULL,
+                 definition_status TEXT NOT NULL
+             );
+             CREATE TABLE concept_isa (child_id TEXT NOT NULL, parent_id TEXT NOT NULL);
+             INSERT INTO concepts VALUES ('1', 'Root', 'Root', '');",
+        )
+        .unwrap();
+
+        let error = query_proximal_primitive_supertypes(&conn, "1").unwrap_err();
+        assert!(format!("{error:?}").contains("no primitive ancestors"));
+    }
+
+    #[test]
+    fn proximal_primitive_supertypes_errors_for_missing_concept() {
+        let conn = primitive_hierarchy_db();
+        let error = query_proximal_primitive_supertypes(&conn, "999").unwrap_err();
+        assert!(matches!(error, SctError::ConceptNotFound { id } if id == "999"));
     }
 }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1241,12 +1241,17 @@ fn has_definition_status_column(conn: &Connection) -> rusqlite::Result<bool> {
     .map(|row| row.is_some())
 }
 
+/// Read a concept's `definition_status`. The column is nullable in the real
+/// schema (see `sct sqlite`'s `concepts` DDL), and databases migrated from an
+/// older schema can leave it unset, so NULL is read as "unknown" - which is
+/// simply not primitive - rather than surfacing a raw column-type error.
 fn definition_status(conn: &Connection, id: u64) -> Result<String, SctError> {
     conn.query_row(
         "SELECT definition_status FROM concepts WHERE id = ?1",
         [id.to_string()],
-        |row| row.get::<_, String>(0),
+        |row| row.get::<_, Option<String>>(0),
     )
+    .map(Option::unwrap_or_default)
     .map_err(SctError::query)
 }
 

--- a/tests/sdk.rs
+++ b/tests/sdk.rs
@@ -512,3 +512,92 @@ includes:\n\
             .unwrap_err();
     assert!(format!("{error:?}").contains("URL includes are unavailable"));
 }
+
+/// R26: proximal primitive supertypes, validated against the committed
+/// synthetic RF2 fixture and known concepts rather than a hand-built schema.
+///
+/// Every concept in the fixture is primitive, so the fixture alone cannot
+/// exercise the pruning path. The definition statuses are therefore flipped
+/// in place here to build the fully-defined cases, against the *real* schema
+/// produced by `sct sqlite`.
+#[test]
+fn proximal_primitive_supertypes_resolve_against_the_fixture_hierarchy() {
+    let (_dir, db) = build();
+
+    // Fixture IS-A chain: 46635009 -> 73211009 -> 404684003 -> 138875005.
+    // All fixture concepts are primitive, so each is its own proximal
+    // primitive supertype.
+    let snomed = Snomed::open(&db).unwrap();
+    for id in ["22298006", "46635009", "73211009", "138875005"] {
+        let result = snomed.proximal_primitive_supertypes(id).unwrap();
+        assert_eq!(
+            result.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+            vec![id],
+            "a primitive concept is its own proximal primitive supertype"
+        );
+    }
+    drop(snomed);
+
+    // Mark Type 1 diabetes mellitus fully-defined: its proximal primitive
+    // supertype becomes its nearest primitive ancestor, Diabetes mellitus.
+    set_defined(&db, &["46635009"]);
+    let snomed = Snomed::open(&db).unwrap();
+    let result = snomed.proximal_primitive_supertypes("46635009").unwrap();
+    assert_eq!(
+        result.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+        vec!["73211009"],
+        "46635009 (Type 1 diabetes mellitus) -> 73211009 (Diabetes mellitus)"
+    );
+    drop(snomed);
+
+    // Mark Diabetes mellitus fully-defined too: the walk must skip it and
+    // prune up to Clinical finding.
+    set_defined(&db, &["73211009"]);
+    let snomed = Snomed::open(&db).unwrap();
+    let result = snomed.proximal_primitive_supertypes("46635009").unwrap();
+    assert_eq!(
+        result.iter().map(|c| c.id.as_str()).collect::<Vec<_>>(),
+        vec!["404684003"],
+        "both diabetes concepts defined -> 404684003 (Clinical finding)"
+    );
+}
+
+/// A migrated database can leave `definition_status` NULL. That must produce
+/// the actionable "data may be incomplete" error, not a raw column-type error.
+#[test]
+fn proximal_primitive_supertypes_report_null_definition_status_cleanly() {
+    let (_dir, db) = build();
+    rusqlite::Connection::open(&db)
+        .unwrap()
+        .execute("UPDATE concepts SET definition_status = NULL", [])
+        .unwrap();
+
+    let snomed = Snomed::open(&db).unwrap();
+    let error = snomed
+        .proximal_primitive_supertypes("46635009")
+        .unwrap_err();
+    let rendered = format!("{error:?}");
+    assert!(
+        rendered.contains("may be incomplete"),
+        "expected an actionable error, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Invalid column type"),
+        "raw rusqlite column-type error leaked to the caller: {rendered}"
+    );
+}
+
+/// Flip concepts to fully-defined (`900000000000073002`) in an existing
+/// database, so the fixture's all-primitive hierarchy can exercise pruning.
+fn set_defined(db: &std::path::Path, ids: &[&str]) {
+    let conn = rusqlite::Connection::open(db).unwrap();
+    for id in ids {
+        let updated = conn
+            .execute(
+                "UPDATE concepts SET definition_status = '900000000000073002' WHERE id = ?1",
+                [id],
+            )
+            .unwrap();
+        assert_eq!(updated, 1, "expected {id} in the fixture database");
+    }
+}


### PR DESCRIPTION
## Summary

Nightly roadmap pickup (no mergeable Dependabot PRs and no other unmerged Claude PR waiting) - implements `spec/roadmap.md` item `R26`:

- `Snomed::proximal_primitive_supertypes(id)` (new typed SDK method in `src/sdk/mod.rs`): returns the most specific primitive concepts that subsume the given concept (or the concept itself, if it's primitive). Walks the concept's ancestors via the transitive-closure table when present (falling back to a recursive CTE otherwise), filters by `definition_status`, then prunes any primitive that is itself a proper ancestor of another primitive still in the set.
- `sct proximal-primitives <CONCEPT>` CLI command (`src/commands/proximal_primitives.rs`), wired into `src/main.rs`/`src/commands/mod.rs`, following the existing `--db`/`--format` conventions.
- Docs page `docs/commands/proximal-primitives.md` and a README entry.
- Removes the now-completed `R26` line from `spec/roadmap.md`.

Every concept has at least one proximal primitive supertype, since the root concept (`138875005`) is primitive and subsumes everything - useful for classification and post-coordination QA, where a concept's necessary normal form is expressed in terms of its proximal primitive supertypes plus refinements.

## Test plan

- [x] `cargo test --lib` (291 passed, including 6 new tests covering: pruning less-specific ancestors, a primitive concept returning itself, keeping incomparable multi-parent primitives, and error cases for a missing `definition_status` column / incomplete data / unknown concept)
- [x] `cargo fmt --check` clean on touched files
- [x] `cargo clippy --lib -- -D warnings` clean on touched files (one pre-existing, unrelated nightly-only lint in `src/index/query.rs` was excluded - not part of this change)
- [x] Manually exercised the built `sct proximal-primitives` binary against a hand-built SQLite fixture (text output, `--format json`, primitive-self case, multi-parent case, not-found error)

Note: this sandbox's toolchain can't build `rusqlite`'s bundled `libsqlite3-sys` (an unstable `cfg_select` macro use, pre-existing and unrelated to this PR - already flagged in earlier nightly reviews on #38/#40). Verification above used a temporary local-only swap to system-linked SQLite plus a nightly toolchain; that swap was reverted before committing and is not part of this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X55qN3v99fdjbu6P9BPnV9)_