### PR TITLE
fix(serve): bound and cancel server-side ECL expansion (R53)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ indexmap = { version = "2", features = ["serde"] }
 fst = { version = "0.4", features = ["levenshtein"] }
 memmap2 = "0.9"
 unicode-normalization = "0.1"
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled", "hooks"] }
 parquet = { version = "59", features = ["arrow"], optional = true }
 arrow = { version = "59", default-features = false, features = ["ipc"], optional = true }
 indicatif = { version = "0.18", optional = true }

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -14,10 +14,9 @@ Legend: `[ ]` not started, `[~]` in progress. The `R##` sequence was deliberatel
 
 An autonomous agent picks the **first unstarted item in this list**, rather than choosing freely from the roadmap. An item is listed here only if it is self-contained, has a written spec or unambiguous acceptance criteria, and is completable *and verifiable* in a single session.
 
-1. `R53` - bound and cancel server-side ECL expansion. The last open availability item from the 2026-07 audit; self-contained within `sct serve`.
-2. `R52` - ship `sct bench`. Smallest piece of the benchmark programme, deliberately sequenced before `R48`, and specified in [`commands/bench.md`](commands/bench.md).
-3. `R16` - the practical FHIR surface, **one parameter per pull request** (`activeOnly`, then `displayLanguage`, then designation/property filters). Do not attempt the whole item at once.
-4. `R12` - the two remaining compression pieces (straddling-exclusion push-down, then `^refset` cover clauses), specified with worked examples in [`commands/ecl-compress.md`](commands/ecl-compress.md).
+1. `R52` - ship `sct bench`. Smallest piece of the benchmark programme, deliberately sequenced before `R48`, and specified in [`commands/bench.md`](commands/bench.md).
+2. `R16` - the practical FHIR surface, **one parameter per pull request** (`activeOnly`, then `displayLanguage`, then designation/property filters). Do not attempt the whole item at once.
+3. `R12` - the two remaining compression pieces (straddling-exclusion push-down, then `^refset` cover clauses), specified with worked examples in [`commands/ecl-compress.md`](commands/ecl-compress.md).
 
 Everything else on this roadmap needs a human design decision, spans several sessions, depends on licensed content or an external account, or needs before/after benchmarks against a real release. Do not begin those autonomously; comment on the item or open an issue instead. When this queue is empty, say so rather than substituting unlisted work.
 
@@ -54,7 +53,6 @@ This work should reuse shared engine contracts rather than reimplementing them.
 ## Assurance, documentation, and evidence
 
 - [ ] `R17` **Add externally verified FHIR conformance.** Run the HL7 FHIR Validator against real resources/Implementation Guides using `sct serve` as terminology backend, gate a synthetic-fixture subset in CI, and keep Touchstone/TestScript as a later complement. Continue to describe the home-grown suite as HL7-aligned, not certified.
-- [ ] `R53` **Bound and cancel server-side ECL expansion work.** Cap or stream compound ECL and combined ECL/filter expansion so a remote client cannot force unbounded result materialisation, and replace uncancellable `spawn_blocking` work with an execution model that stops database work when the 30-second HTTP response timeout fires. This preserves the unfinished availability work identified as `R44` in the 2026-07-25 audit.
 
 - [~] `R20` **Complete and publish the benchmark suite.** Preserve the working Bash suite while the parity-gated typed-runner programme (`R48`-`R51`) lands, then broaden the committed FHIR conformance scenarios, add comparator compose profiles, compare SDK/CLI/FST/FTS/server boundaries honestly, and publish reproducible `sct`-solo reports under the reporting policy above. Architecture and evidence contract: [`benchmark-runner.md`](benchmark-runner.md).
 

--- a/src/commands/serve/fhir.rs
+++ b/src/commands/serve/fhir.rs
@@ -75,6 +75,19 @@ impl FhirError {
             diagnostics: d.into(),
         }
     }
+    /// FHIR's own vocabulary for "this would be too expensive to compute"
+    /// (`OperationOutcome.issue.code` `too-costly`), distinct from `timeout`:
+    /// the server refused up front rather than starting and running out of
+    /// time. Used when a compound ECL/filter expansion would materialise more
+    /// results than the server keeps in memory at once (see `EvalLimits` in
+    /// `crate::ecl::eval`, roadmap `R53`).
+    pub fn too_costly(d: impl Into<String>) -> Self {
+        Self {
+            status: 403,
+            code: "too-costly",
+            diagnostics: d.into(),
+        }
+    }
     /// The `OperationOutcome` body for this error.
     pub fn outcome(&self) -> Value {
         operation_outcome("error", self.code, &self.diagnostics)

--- a/src/commands/serve/mod.rs
+++ b/src/commands/serve/mod.rs
@@ -26,7 +26,7 @@ use clap::Parser;
 use rusqlite::Connection;
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::index::query::Index;
 use fhir::FhirError;
@@ -433,6 +433,7 @@ async fn expand(State(st): State<AppState>, headers: HeaderMap, RawQuery(q): Raw
 
     let ecl = param(&params, "url").and_then(parse_implicit_ecl);
     let filter = param(&params, "filter").map(str::to_string);
+    let deadline = Instant::now() + REQUEST_TIMEOUT;
     run_db(&st, move |c| {
         ops::expand(
             c,
@@ -441,6 +442,7 @@ async fn expand(State(st): State<AppState>, headers: HeaderMap, RawQuery(q): Raw
             count,
             offset,
             include_designations,
+            Some(deadline),
         )
     })
     .await
@@ -573,7 +575,11 @@ async fn vs_validate_code(
         .await;
     }
     if let Some(ecl) = parse_implicit_ecl(&url) {
-        return run_db(&st, move |c| ops::validate_code_in_ecl(c, &ecl, &code)).await;
+        let deadline = Instant::now() + REQUEST_TIMEOUT;
+        return run_db(&st, move |c| {
+            ops::validate_code_in_ecl(c, &ecl, &code, Some(deadline))
+        })
+        .await;
     }
     fhir_err(FhirError::not_found(format!(
         "ValueSet '{url}' not found and not an implicit ECL value set"
@@ -615,6 +621,10 @@ async fn batch(State(st): State<AppState>, headers: HeaderMap, body: String) -> 
     }
     let pool = st.pool.clone();
     let registry = st.registry.clone();
+    // One deadline for the whole batch (one HTTP request, one 30s budget) -
+    // not recomputed per entry, so entries later in the Bundle don't each get
+    // a fresh 30 seconds.
+    let deadline = Instant::now() + REQUEST_TIMEOUT;
     let joined = tokio::task::spawn_blocking(move || -> Result<serde_json::Value, FhirError> {
         pool.with(|conn| {
             let responses: Vec<serde_json::Value> = entries
@@ -622,7 +632,7 @@ async fn batch(State(st): State<AppState>, headers: HeaderMap, body: String) -> 
                 .map(|entry| {
                     let method = entry["request"]["method"].as_str().unwrap_or("GET");
                     let url = entry["request"]["url"].as_str().unwrap_or("");
-                    let (status, resource) = run_operation(conn, &registry, method, url);
+                    let (status, resource) = run_operation(conn, &registry, method, url, deadline);
                     serde_json::json!({
                         "response": { "status": status.to_string() },
                         "resource": resource,
@@ -649,6 +659,7 @@ fn run_operation(
     registry: &ValueSetRegistry,
     method: &str,
     url: &str,
+    deadline: Instant,
 ) -> (u16, serde_json::Value) {
     if !method.eq_ignore_ascii_case("GET") {
         let e = FhirError::invalid(format!(
@@ -695,6 +706,7 @@ fn run_operation(
                     count,
                     offset,
                     desig,
+                    Some(deadline),
                 )
             }
         }
@@ -705,7 +717,7 @@ fn run_operation(
                         vs.members.iter().map(|(id, _)| id.clone()).collect();
                     ops::validate_code_in_set(conn, &members, code, &vs.canonical_url)
                 } else if let Some(ecl) = parse_implicit_ecl(url) {
-                    ops::validate_code_in_ecl(conn, &ecl, code)
+                    ops::validate_code_in_ecl(conn, &ecl, code, Some(deadline))
                 } else {
                     Err(FhirError::not_found(format!("ValueSet '{url}' not found")))
                 }

--- a/src/commands/serve/ops.rs
+++ b/src/commands/serve/ops.rs
@@ -8,6 +8,7 @@
 use rusqlite::Connection;
 use serde_json::{json, Value};
 use std::collections::HashSet;
+use std::time::Instant;
 
 use super::fhir::{
     designation, internal_to_system, parameters, property_concept, system_to_internal,
@@ -18,6 +19,66 @@ use crate::sdk::{ConceptDesignations, SctError, Subsumption};
 
 fn ex(e: rusqlite::Error) -> FhirError {
     FhirError::exception(e.to_string())
+}
+
+/// Ceiling on how many concept ids a single **compound** ECL evaluation (or a
+/// combined ECL/filter expansion) may materialise in memory - roadmap `R53`.
+/// A bare hierarchy/refset operator (`<<73211009`, `^refsetId`) never hits
+/// this: `expand`'s fast path answers it with two indexed SQL queries and
+/// never builds the full id set in Rust. Only expressions that fall through
+/// to the general engine (booleans, refinements, wildcards) are bounded here.
+/// Generous on purpose - real clinical ECL rarely approaches this - but firm
+/// enough that a remote client cannot force gigabytes of `u64`s into memory.
+const MAX_COMPOUND_ECL_RESULTS: usize = 100_000;
+
+/// Approximate number of SQLite virtual-machine instructions between
+/// `sqlite3_progress_handler` callbacks. Small enough to interrupt an
+/// overrunning statement within a fraction of a second of the deadline,
+/// large enough that the callback itself is not measurable query overhead.
+const PROGRESS_HANDLER_INTERVAL: std::ffi::c_int = 100_000;
+
+/// RAII guard installing a SQLite progress handler that aborts the
+/// currently-executing statement once `deadline` passes (`SQLITE_INTERRUPT`),
+/// so a single expensive query - a wide recursive CTE, a full
+/// `concept_relationships` scan - is cancelled mid-execution instead of
+/// running to completion on a background thread after the client's HTTP
+/// response has already timed out (roadmap `R53`, following on from the
+/// request-level timeout added for `R73`). `conn` is a pooled, reused
+/// connection, so the handler is unconditionally cleared on drop: left in
+/// place, it would wrongly interrupt an unrelated later request that happens
+/// to borrow the same connection.
+struct DeadlineGuard<'c> {
+    conn: &'c Connection,
+}
+
+impl<'c> DeadlineGuard<'c> {
+    fn install(conn: &'c Connection, deadline: Instant) -> Self {
+        // A failure here just means the handler wasn't installed (rusqlite
+        // only rejects this on a connection it doesn't own); evaluation still
+        // runs, just without early interruption if it overruns.
+        let _ = conn.progress_handler(
+            PROGRESS_HANDLER_INTERVAL,
+            Some(move || Instant::now() >= deadline),
+        );
+        Self { conn }
+    }
+}
+
+impl Drop for DeadlineGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self.conn.progress_handler(0, None::<fn() -> bool>);
+    }
+}
+
+/// Whether `error` is (or wraps) a SQLite `SQLITE_INTERRUPT`, i.e. a
+/// statement aborted by [`DeadlineGuard`].
+fn is_interrupted(error: &anyhow::Error) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<rusqlite::Error>()
+            .and_then(rusqlite::Error::sqlite_error_code)
+            == Some(rusqlite::ErrorCode::OperationInterrupted)
+    })
 }
 
 fn fetch_concept(conn: &Connection, code: &str) -> Result<Option<ConceptDesignations>, FhirError> {
@@ -216,6 +277,12 @@ pub fn subsumes(conn: &Connection, code_a: &str, code_b: &str) -> Result<Value, 
 }
 
 /// `ValueSet/$expand` over an optional ECL constraint and/or text filter.
+/// `deadline`, when set, bounds the ECL/combined-filter evaluation path (see
+/// [`eval_ecl`], roadmap `R53`); server handlers pass `Instant::now() +
+/// REQUEST_TIMEOUT`, tests pass `None`. Always applies the production
+/// compound-result cap (`MAX_COMPOUND_ECL_RESULTS`) - see
+/// [`expand_with_cap_for_tests`] for the test-only variant with a
+/// caller-supplied cap.
 pub fn expand(
     conn: &Connection,
     ecl: Option<&str>,
@@ -223,6 +290,61 @@ pub fn expand(
     count: usize,
     offset: usize,
     include_designations: bool,
+    deadline: Option<Instant>,
+) -> Result<Value, FhirError> {
+    expand_inner(
+        conn,
+        ecl,
+        filter,
+        count,
+        offset,
+        include_designations,
+        deadline,
+        MAX_COMPOUND_ECL_RESULTS,
+    )
+}
+
+/// Identical to [`expand`] but with an explicit `max_results` cap, so tests
+/// can exercise the bound-violation path (`403 too-costly`, no unbounded
+/// materialisation) through the exact production code path
+/// (parse -> [`evaluate_bounded`](crate::ecl::eval::evaluate_bounded) ->
+/// [`classify_ecl_error`]) without needing >100k rows of real data in the
+/// small committed fixture. `expand` itself always uses
+/// `MAX_COMPOUND_ECL_RESULTS`; production traffic never calls this.
+#[doc(hidden)]
+#[allow(clippy::too_many_arguments)]
+pub fn expand_with_cap_for_tests(
+    conn: &Connection,
+    ecl: Option<&str>,
+    filter: Option<&str>,
+    count: usize,
+    offset: usize,
+    include_designations: bool,
+    deadline: Option<Instant>,
+    max_results: usize,
+) -> Result<Value, FhirError> {
+    expand_inner(
+        conn,
+        ecl,
+        filter,
+        count,
+        offset,
+        include_designations,
+        deadline,
+        max_results,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn expand_inner(
+    conn: &Connection,
+    ecl: Option<&str>,
+    filter: Option<&str>,
+    count: usize,
+    offset: usize,
+    include_designations: bool,
+    deadline: Option<Instant>,
+    max_results: usize,
 ) -> Result<Value, FhirError> {
     let _snapshot = crate::ecl::eval::ReadSnapshot::begin(conn)
         .map_err(|error| FhirError::exception(format!("starting database read: {error:#}")))?;
@@ -289,10 +411,12 @@ pub fn expand(
             let contains = build_contains(conn, &ids, include_designations)?;
             return Ok(value_set_expansion(total as usize, offset, count, contains));
         }
-        (Some(e), None) => eval_ecl(conn, e)?,
+        (Some(e), None) => eval_ecl(conn, e, deadline, max_results)?,
         (None, Some(f)) => fts_ids(conn, f)?,
         (Some(e), Some(f)) => {
-            let set: HashSet<String> = eval_ecl(conn, e)?.into_iter().collect();
+            let set: HashSet<String> = eval_ecl(conn, e, deadline, max_results)?
+                .into_iter()
+                .collect();
             fts_ids(conn, f)?
                 .into_iter()
                 .filter(|id| set.contains(id))
@@ -307,21 +431,64 @@ pub fn expand(
     Ok(value_set_expansion(total, offset, count, contains))
 }
 
-fn eval_ecl(conn: &Connection, ecl: &str) -> Result<Vec<String>, FhirError> {
+/// Evaluate an ECL expression bounded for server use: `deadline`, when set,
+/// both installs a [`DeadlineGuard`] (so a single overrunning SQL statement
+/// is interrupted rather than run to completion in the background) and is
+/// checked cooperatively inside the evaluator itself (so many small
+/// statements that overrun the wall clock in aggregate are also caught -
+/// see [`EvalLimits`](crate::ecl::eval::EvalLimits)). `max_results` bounds
+/// in-memory materialisation. See roadmap `R53`.
+fn eval_ecl(
+    conn: &Connection,
+    ecl: &str,
+    deadline: Option<Instant>,
+    max_results: usize,
+) -> Result<Vec<String>, FhirError> {
     let expr = crate::ecl::parse(ecl)
         .map_err(|error| FhirError::invalid(format!("ECL error: {error:#}")))?;
-    crate::ecl::eval::evaluate(conn, &expr)
+    let _guard = deadline.map(|d| DeadlineGuard::install(conn, d));
+    let limits = crate::ecl::eval::EvalLimits {
+        max_results: Some(max_results),
+        deadline,
+    };
+    crate::ecl::eval::evaluate_bounded(conn, &expr, limits)
         .map(|ids| ids.into_iter().map(|id| id.to_string()).collect())
-        .map_err(|error| {
-            if error
-                .chain()
-                .any(|source| source.is::<std::num::ParseIntError>())
-            {
-                FhirError::invalid(format!("ECL error: {error:#}"))
-            } else {
-                FhirError::exception(format!("evaluating ECL: {error:#}"))
+        .map_err(classify_ecl_error)
+}
+
+/// Turn an ECL evaluation error into the right FHIR status: a malformed SCTID
+/// is `invalid` (400); exceeding the result cap is `too-costly` (403) so the
+/// client knows to narrow its query; running out of time - whether caught by
+/// [`EvalLimits`](crate::ecl::eval::EvalLimits)'s own deadline check or by
+/// [`DeadlineGuard`] interrupting a single SQL statement - is `timeout` (408),
+/// matching the outer request-timeout middleware rather than a generic `500`;
+/// anything else remains an `exception` (500).
+fn classify_ecl_error(error: anyhow::Error) -> FhirError {
+    if error
+        .chain()
+        .any(|source| source.is::<std::num::ParseIntError>())
+    {
+        return FhirError::invalid(format!("ECL error: {error:#}"));
+    }
+    if let Some(bound) = error
+        .chain()
+        .find_map(|source| source.downcast_ref::<crate::ecl::eval::EclBoundError>())
+    {
+        return match bound {
+            crate::ecl::eval::EclBoundError::TooManyResults(_) => {
+                FhirError::too_costly(bound.to_string())
             }
-        })
+            crate::ecl::eval::EclBoundError::DeadlineExceeded => FhirError::timeout(format!(
+                "{bound} and evaluation was interrupted before returning a result"
+            )),
+        };
+    }
+    if is_interrupted(&error) {
+        return FhirError::timeout(
+            "ECL evaluation exceeded the request time budget and was interrupted".to_string(),
+        );
+    }
+    FhirError::exception(format!("evaluating ECL: {error:#}"))
 }
 
 /// FTS5 ids ordered by relevance, capped. Plain text is wrapped as a phrase to
@@ -631,9 +798,16 @@ pub fn validate_code_in_set(
 }
 
 /// `ValueSet/$validate-code` against an implicit ECL value set: does `code`
-/// satisfy the expression?
-pub fn validate_code_in_ecl(conn: &Connection, ecl: &str, code: &str) -> Result<Value, FhirError> {
-    let present = eval_ecl(conn, ecl)?.iter().any(|m| m == code);
+/// satisfy the expression? `deadline` bounds evaluation as in [`expand`].
+pub fn validate_code_in_ecl(
+    conn: &Connection,
+    ecl: &str,
+    code: &str,
+    deadline: Option<Instant>,
+) -> Result<Value, FhirError> {
+    let present = eval_ecl(conn, ecl, deadline, MAX_COMPOUND_ECL_RESULTS)?
+        .iter()
+        .any(|m| m == code);
     let mut params = vec![json!({ "name": "result", "valueBoolean": present })];
     if present {
         if let Some(c) = fetch_concept(conn, code)? {
@@ -684,4 +858,80 @@ pub fn translate(
         ]}));
     }
     Ok(parameters(params))
+}
+
+#[cfg(test)]
+mod deadline_guard_tests {
+    //! White-box tests of [`DeadlineGuard`] itself: is the interruption real
+    //! (aborts a genuinely long-running statement promptly), and is it inert
+    //! before the deadline (a query that would otherwise be fine still
+    //! succeeds)? These use a plain in-memory connection and a synthetic
+    //! recursive-CTE workload rather than the SNOMED fixture, because what's
+    //! under test is generic SQLite interruption mechanics, not SNOMED query
+    //! logic - the ECL-specific bound/cap behaviour is covered against the
+    //! real fixture-built database in `tests/serve.rs`.
+
+    use super::*;
+    use std::time::Duration;
+
+    /// A statement that does a meaningful amount of work (tens of millions of
+    /// VM instructions) if allowed to run to completion, so an interruption
+    /// that fires only "eventually" would still show up as a slow test.
+    const EXPENSIVE_COUNT: &str = "WITH RECURSIVE cnt(x) AS (
+            SELECT 1
+            UNION ALL
+            SELECT x + 1 FROM cnt WHERE x < 50000000
+        ) SELECT COUNT(*) FROM cnt";
+
+    #[test]
+    fn interrupts_an_already_overdue_statement_promptly() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Already in the past: the very first progress-handler callback (a
+        // small, fixed number of VM instructions into the statement) must
+        // interrupt it - proving the statement is aborted mid-execution, not
+        // merely rejected after running to completion in the background.
+        let deadline = Instant::now() - Duration::from_secs(1);
+        let _guard = DeadlineGuard::install(&conn, deadline);
+
+        let start = Instant::now();
+        let result: rusqlite::Result<i64> = conn.query_row(EXPENSIVE_COUNT, [], |r| r.get(0));
+        let elapsed = start.elapsed();
+
+        let err = result.expect_err("an overdue deadline should interrupt the statement");
+        assert_eq!(
+            err.sqlite_error_code(),
+            Some(rusqlite::ErrorCode::OperationInterrupted),
+            "expected SQLITE_INTERRUPT, got {err:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "interrupted statement took {elapsed:?} - the progress handler should abort it \
+             promptly rather than letting it run to completion"
+        );
+    }
+
+    #[test]
+    fn does_not_interrupt_before_the_deadline() {
+        let conn = Connection::open_in_memory().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let _guard = DeadlineGuard::install(&conn, deadline);
+        let n: i64 = conn.query_row("SELECT 1 + 1", [], |r| r.get(0)).unwrap();
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn guard_drop_clears_the_handler_for_the_next_use_of_a_pooled_connection() {
+        let conn = Connection::open_in_memory().unwrap();
+        {
+            let deadline = Instant::now() - Duration::from_secs(1);
+            let _guard = DeadlineGuard::install(&conn, deadline);
+            let result: rusqlite::Result<i64> = conn.query_row(EXPENSIVE_COUNT, [], |r| r.get(0));
+            assert!(result.is_err(), "sanity: the overdue guard did interrupt");
+        }
+        // The guard is dropped now. A pooled connection reused for an
+        // unrelated later request must not still be carrying a stale,
+        // already-expired deadline from this one.
+        let n: i64 = conn.query_row("SELECT 1 + 1", [], |r| r.get(0)).unwrap();
+        assert_eq!(n, 2);
+    }
 }

--- a/src/commands/serve/ops.rs
+++ b/src/commands/serve/ops.rs
@@ -70,6 +70,22 @@ impl Drop for DeadlineGuard<'_> {
     }
 }
 
+/// Refuse an operation whose time budget is already spent, before touching the
+/// database at all. The progress handler in [`DeadlineGuard`] only fires once a
+/// statement is *running*, and only every [`PROGRESS_HANDLER_INTERVAL`]
+/// instructions, so it cannot catch this case. It arises in practice for a
+/// `$batch` Bundle, where every entry shares one request budget: once earlier
+/// entries have consumed it, the rest should fail fast rather than each start
+/// fresh work the client will never receive.
+fn check_budget(deadline: Option<Instant>) -> Result<(), FhirError> {
+    match deadline {
+        Some(d) if Instant::now() >= d => Err(FhirError::timeout(
+            "the request time budget was exhausted before this operation started".to_string(),
+        )),
+        _ => Ok(()),
+    }
+}
+
 /// Whether `error` is (or wraps) a SQLite `SQLITE_INTERRUPT`, i.e. a
 /// statement aborted by [`DeadlineGuard`].
 fn is_interrupted(error: &anyhow::Error) -> bool {
@@ -348,6 +364,12 @@ fn expand_inner(
 ) -> Result<Value, FhirError> {
     let _snapshot = crate::ecl::eval::ReadSnapshot::begin(conn)
         .map_err(|error| FhirError::exception(format!("starting database read: {error:#}")))?;
+    // Installed here rather than in `eval_ecl` so it also covers the fast path
+    // below, whose descendant/ancestor COUNT is an unlimited recursive CTE on a
+    // database with no transitive-closure table - the single most expensive
+    // statement a remote client can trigger with a short, obvious request.
+    check_budget(deadline)?;
+    let _guard = deadline.map(|d| DeadlineGuard::install(conn, d));
     let count = count.min(1000);
 
     // Fast path: a single hierarchy/refset ECL with no text filter is answered
@@ -446,7 +468,9 @@ fn eval_ecl(
 ) -> Result<Vec<String>, FhirError> {
     let expr = crate::ecl::parse(ecl)
         .map_err(|error| FhirError::invalid(format!("ECL error: {error:#}")))?;
-    let _guard = deadline.map(|d| DeadlineGuard::install(conn, d));
+    // The [`DeadlineGuard`] is installed by the public entry points, not here:
+    // it must also cover `expand`'s fast path, and nesting two guards on one
+    // connection would leave the outer one inert once the inner one dropped.
     let limits = crate::ecl::eval::EvalLimits {
         max_results: Some(max_results),
         deadline,
@@ -805,6 +829,8 @@ pub fn validate_code_in_ecl(
     code: &str,
     deadline: Option<Instant>,
 ) -> Result<Value, FhirError> {
+    check_budget(deadline)?;
+    let _guard = deadline.map(|d| DeadlineGuard::install(conn, d));
     let present = eval_ecl(conn, ecl, deadline, MAX_COMPOUND_ECL_RESULTS)?
         .iter()
         .any(|m| m == code);

--- a/src/ecl/eval.rs
+++ b/src/ecl/eval.rs
@@ -12,6 +12,7 @@
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 use std::collections::BTreeSet;
+use std::time::Instant;
 
 use crate::ecl::ast::{BoolOp, Expr, Op, Refinement};
 
@@ -59,17 +60,111 @@ pub(crate) fn parse_sctid(id: &str) -> Result<u64> {
         .with_context(|| format!("invalid SCTID {id:?} (SCTIDs are 6-18 digit numbers)"))
 }
 
+/// Bounds on a single ECL evaluation, checked cooperatively at each AST node
+/// boundary (see [`eval_expr`]) and inside the row-streaming loops that pull
+/// results from SQLite:
+///
+/// - `max_results` caps how many ids any one AST node's result (and
+///   therefore every intermediate and the final result) may hold, aborting
+///   with [`EclBoundError::TooManyResults`] - the "cap ... compound ECL"
+///   half of roadmap `R53`.
+/// - `deadline` aborts evaluation once wall-clock time runs out, with
+///   [`EclBoundError::DeadlineExceeded`]. This is a *cooperative*,
+///   Rust-level check (independent of the `sqlite3_progress_handler` a
+///   caller may additionally install around the connection - see
+///   `commands::serve::ops::DeadlineGuard`): a single SQL statement's
+///   instruction count can stay well under the progress handler's interval
+///   while a compound expression that issues *many* small statements (one
+///   per id in a wide `base` set, one per attribute-refinement probe) still
+///   overruns the wall clock in aggregate. Checking `Instant::now()` here
+///   catches that case too.
+///
+/// `None` in either field means unbounded - the default used by
+/// [`evaluate`] and [`evaluate_with_tct`], so every CLI/SDK/MCP caller is
+/// unaffected: there is no request deadline to protect there, and
+/// codelist-sized expressions are the norm. Only `sct serve` constructs a
+/// bounded `EvalLimits`, via [`evaluate_bounded`], because it is the only
+/// caller exposed to an untrusted remote client that could otherwise force a
+/// compound expression to run indefinitely or materialise an unbounded
+/// result set in memory.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct EvalLimits {
+    pub(crate) max_results: Option<usize>,
+    pub(crate) deadline: Option<Instant>,
+}
+
+impl EvalLimits {
+    fn check(&self, len: usize) -> Result<()> {
+        if let Some(deadline) = self.deadline {
+            if Instant::now() >= deadline {
+                return Err(EclBoundError::DeadlineExceeded.into());
+            }
+        }
+        if let Some(max) = self.max_results {
+            if len > max {
+                return Err(EclBoundError::TooManyResults(max).into());
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A cooperative evaluation-bound violation, distinguished from an ordinary
+/// evaluation error so a caller like the FHIR server can report a specific,
+/// actionable status (`403 too-costly` or `408 timeout`) instead of a
+/// generic `500`.
+#[derive(Debug)]
+pub(crate) enum EclBoundError {
+    /// The expression (or a subexpression of it) matched more concepts than
+    /// the caller's `max_results` bound allows.
+    TooManyResults(usize),
+    /// Evaluation was still running when the caller's `deadline` passed.
+    DeadlineExceeded,
+}
+
+impl std::fmt::Display for EclBoundError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooManyResults(max) => write!(
+                f,
+                "expression matches more than {max} concepts in a single compound sub-expression; \
+                 narrow the ECL (a bare hierarchy or refset query, e.g. `<<73211009`, has no such limit)"
+            ),
+            Self::DeadlineExceeded => {
+                write!(f, "ECL evaluation exceeded the request time budget")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EclBoundError {}
+
 /// Evaluate an ECL expression against `conn`.
 pub fn evaluate(conn: &Connection, expr: &Expr) -> Result<IdSet> {
     let _snapshot = ReadSnapshot::begin(conn)?;
     let mut tct = None;
-    eval_expr(conn, expr, &mut tct)
+    eval_expr(conn, expr, &mut tct, &EvalLimits::default())
+}
+
+/// Evaluate an ECL expression against `conn` with explicit [`EvalLimits`].
+/// See [`EvalLimits`] for why only `sct serve` uses this instead of
+/// [`evaluate`]. `serve`-only: it has no caller without that feature, so it
+/// is gated the same way `evaluate_with_tct` is gated on `cli` just below.
+#[cfg(feature = "serve")]
+pub(crate) fn evaluate_bounded(
+    conn: &Connection,
+    expr: &Expr,
+    limits: EvalLimits,
+) -> Result<IdSet> {
+    let _snapshot = ReadSnapshot::begin(conn)?;
+    let mut tct = None;
+    eval_expr(conn, expr, &mut tct, &limits)
 }
 
 #[cfg(feature = "cli")]
 pub(crate) fn evaluate_with_tct(conn: &Connection, expr: &Expr, tct: bool) -> Result<IdSet> {
     let mut status = Some(tct);
-    eval_expr(conn, expr, &mut status)
+    eval_expr(conn, expr, &mut status, &EvalLimits::default())
 }
 
 #[cfg(feature = "cli")]
@@ -105,17 +200,22 @@ fn refinement_uses_transitive_hierarchy(refinement: &Refinement) -> bool {
     }
 }
 
-fn eval_expr(conn: &Connection, expr: &Expr, tct: &mut Option<bool>) -> Result<IdSet> {
-    match expr {
-        Expr::Wildcard => all_concepts(conn),
+fn eval_expr(
+    conn: &Connection,
+    expr: &Expr,
+    tct: &mut Option<bool>,
+    limits: &EvalLimits,
+) -> Result<IdSet> {
+    let result = match expr {
+        Expr::Wildcard => all_concepts(conn, limits),
         Expr::Concept(id) => Ok(std::iter::once(parse_sctid(id)?).collect()),
         Expr::Op(op, inner) => {
-            let base = eval_expr(conn, inner, tct)?;
-            eval_op(conn, *op, &base, tct)
+            let base = eval_expr(conn, inner, tct, limits)?;
+            eval_op(conn, *op, &base, tct, limits)
         }
         Expr::Bool(op, a, b) => {
-            let sa = eval_expr(conn, a, tct)?;
-            let sb = eval_expr(conn, b, tct)?;
+            let sa = eval_expr(conn, a, tct, limits)?;
+            let sb = eval_expr(conn, b, tct, limits)?;
             Ok(match op {
                 BoolOp::And => sa.intersection(&sb).copied().collect(),
                 BoolOp::Or => sa.union(&sb).copied().collect(),
@@ -123,10 +223,15 @@ fn eval_expr(conn: &Connection, expr: &Expr, tct: &mut Option<bool>) -> Result<I
             })
         }
         Expr::Refined(focus, refinement) => {
-            let f = eval_expr(conn, focus, tct)?;
-            eval_refinement(conn, &f, refinement, tct)
+            let f = eval_expr(conn, focus, tct, limits)?;
+            eval_refinement(conn, &f, refinement, tct, limits)
         }
-    }
+    }?;
+    // Checked on the way back up so every AST node's contribution - not just
+    // the final result - is bounded; a node that already overflows aborts
+    // before its parent gets a chance to combine it into something bigger.
+    limits.check(result.len())?;
+    Ok(result)
 }
 
 /// Build an [`IdSet`] from an unordered, possibly-duplicated collection of
@@ -140,7 +245,7 @@ fn set_from(mut v: Vec<u64>) -> IdSet {
     v.into_iter().collect()
 }
 
-fn all_concepts(conn: &Connection) -> Result<IdSet> {
+fn all_concepts(conn: &Connection, limits: &EvalLimits) -> Result<IdSet> {
     // The id column is TEXT; CAST lets SQLite hand back an integer directly,
     // so no per-row String crosses the FFI boundary.
     let mut stmt = conn
@@ -148,24 +253,38 @@ fn all_concepts(conn: &Connection) -> Result<IdSet> {
         .context("preparing wildcard query")?;
     let rows = stmt.query_map([], |r| r.get::<_, i64>(0))?;
     let mut out = Vec::new();
-    for r in rows {
+    for (i, r) in rows.enumerate() {
         out.push(r? as u64);
+        if i.is_multiple_of(ROW_CHECK_STRIDE) {
+            limits.check(out.len())?;
+        }
     }
     Ok(set_from(out))
 }
+
+/// How often (in rows streamed from SQLite) a bound-checking loop re-checks
+/// [`EvalLimits`], so an in-progress scan aborts promptly once it overflows
+/// rather than only once the whole result is built.
+const ROW_CHECK_STRIDE: usize = 50_000;
 
 fn eval_op(
     conn: &Connection,
     op: Op,
     base: &IdSet,
     tct_status: &mut Option<bool>,
+    limits: &EvalLimits,
 ) -> Result<IdSet> {
     let mut out = Vec::new();
     match op {
         Op::DescendantOf | Op::DescendantOrSelfOf => {
             let tct = tct_status_or_probe(conn, tct_status)?;
+            // Per-id check (not just once at the end): `base` can itself be
+            // large, and each id's subtree is pulled by one SQL query, so a
+            // wide `base` combined with wide subtrees is exactly the
+            // combinatorial blow-up this bound exists to catch early.
             for &id in base {
                 collect_transitive(conn, id, true, tct, &mut out)?;
+                limits.check(out.len())?;
             }
             if op == Op::DescendantOrSelfOf {
                 out.extend(base.iter().copied());
@@ -175,6 +294,7 @@ fn eval_op(
             let tct = tct_status_or_probe(conn, tct_status)?;
             for &id in base {
                 collect_transitive(conn, id, false, tct, &mut out)?;
+                limits.check(out.len())?;
             }
             if op == Op::AncestorOrSelfOf {
                 out.extend(base.iter().copied());
@@ -184,16 +304,19 @@ fn eval_op(
             for &id in base {
                 collect_one_hop(conn, id, true, &mut out)?;
             }
+            limits.check(out.len())?;
         }
         Op::ParentOf => {
             for &id in base {
                 collect_one_hop(conn, id, false, &mut out)?;
             }
+            limits.check(out.len())?;
         }
         Op::MemberOf => {
             for &id in base {
                 collect_members(conn, id, &mut out)?;
             }
+            limits.check(out.len())?;
         }
     }
     Ok(set_from(out))
@@ -614,25 +737,26 @@ fn eval_refinement(
     focus: &IdSet,
     r: &Refinement,
     tct: &mut Option<bool>,
+    limits: &EvalLimits,
 ) -> Result<IdSet> {
     match r {
         Refinement::And(a, b) => {
-            let sa = eval_refinement(conn, focus, a, tct)?;
-            let sb = eval_refinement(conn, focus, b, tct)?;
+            let sa = eval_refinement(conn, focus, a, tct, limits)?;
+            let sb = eval_refinement(conn, focus, b, tct, limits)?;
             Ok(sa.intersection(&sb).copied().collect())
         }
         Refinement::Or(a, b) => {
-            let sa = eval_refinement(conn, focus, a, tct)?;
-            let sb = eval_refinement(conn, focus, b, tct)?;
+            let sa = eval_refinement(conn, focus, a, tct, limits)?;
+            let sb = eval_refinement(conn, focus, b, tct, limits)?;
             Ok(sa.union(&sb).copied().collect())
         }
         // v1: a group is a flat conjunction (group cardinality deferred).
-        Refinement::Group(inner) => eval_refinement(conn, focus, inner, tct),
+        Refinement::Group(inner) => eval_refinement(conn, focus, inner, tct, limits),
         Refinement::Attr {
             attr,
             negate,
             value,
-        } => eval_attr(conn, focus, attr, *negate, value, tct),
+        } => eval_attr(conn, focus, attr, *negate, value, tct, limits),
     }
 }
 
@@ -661,6 +785,7 @@ fn eval_attr(
     negate: bool,
     value: &Expr,
     tct: &mut Option<bool>,
+    limits: &EvalLimits,
 ) -> Result<IdSet> {
     if !has_relationships_table(conn) {
         anyhow::bail!(
@@ -672,14 +797,18 @@ fn eval_attr(
     // `None` means wildcard (any type / any value).
     let type_filter: Option<IdSet> = match attr {
         Expr::Wildcard => None,
-        _ => Some(eval_expr(conn, attr, tct)?),
+        _ => Some(eval_expr(conn, attr, tct, limits)?),
     };
     let value_filter: Option<IdSet> = match value {
         Expr::Wildcard => None,
-        _ => Some(eval_expr(conn, value, tct)?),
+        _ => Some(eval_expr(conn, value, tct, limits)?),
     };
 
     let mut matched = Vec::new();
+    // Counts rows scanned (not just matches) so the bound-check cadence is
+    // steady even when few rows satisfy the value filter - a negated or
+    // wide-mismatch scan must still be interruptible before it finishes.
+    let mut scanned: usize = 0;
     match &type_filter {
         // `type = <value set>` with a small type × value cross product: probe
         // the (type_id, destination_id) compound index once per pair instead
@@ -709,6 +838,10 @@ fn eval_attr(
                     })?;
                     for r in rows {
                         matched.push(r? as u64);
+                        scanned += 1;
+                        if scanned.is_multiple_of(ROW_CHECK_STRIDE) {
+                            limits.check(matched.len())?;
+                        }
                     }
                 }
             }
@@ -724,6 +857,10 @@ fn eval_attr(
                 })?;
                 for row in rows {
                     let (source, dest) = row?;
+                    scanned += 1;
+                    if scanned.is_multiple_of(ROW_CHECK_STRIDE) {
+                        limits.check(matched.len())?;
+                    }
                     consider(
                         source as u64,
                         dest as u64,
@@ -744,6 +881,10 @@ fn eval_attr(
             let rows = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?;
             for row in rows {
                 let (source, dest) = row?;
+                scanned += 1;
+                if scanned.is_multiple_of(ROW_CHECK_STRIDE) {
+                    limits.check(matched.len())?;
+                }
                 consider(
                     source as u64,
                     dest as u64,

--- a/src/ecl/eval.rs
+++ b/src/ecl/eval.rs
@@ -300,23 +300,28 @@ fn eval_op(
                 out.extend(base.iter().copied());
             }
         }
+        // Checked per id, like the transitive cases above: `base` is only
+        // bounded by `max_results`, so a wide base issuing one small query per
+        // id can both overshoot the cap and overrun the deadline in aggregate
+        // long before the loop ends - and each individual statement is far too
+        // cheap for a SQLite progress handler to catch.
         Op::ChildOf => {
             for &id in base {
                 collect_one_hop(conn, id, true, &mut out)?;
+                limits.check(out.len())?;
             }
-            limits.check(out.len())?;
         }
         Op::ParentOf => {
             for &id in base {
                 collect_one_hop(conn, id, false, &mut out)?;
+                limits.check(out.len())?;
             }
-            limits.check(out.len())?;
         }
         Op::MemberOf => {
             for &id in base {
                 collect_members(conn, id, &mut out)?;
+                limits.check(out.len())?;
             }
-            limits.check(out.len())?;
         }
     }
     Ok(set_from(out))

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -377,6 +377,39 @@ fn expand_deadline_interrupts_evaluation_before_returning_a_result() {
     );
 }
 
+/// The fast path (`expand_simple`) answers a bare hierarchy operator without
+/// going through `eval_ecl`, so it needs the deadline enforced at the entry
+/// point rather than around the evaluator. On a database with no
+/// transitive-closure table its COUNT is an unlimited recursive CTE, which is
+/// the most expensive statement a short remote request can trigger - so an
+/// exhausted budget must stop it rather than let it run to completion.
+#[test]
+fn expand_deadline_also_bounds_the_simple_fast_path() {
+    let (_d, db) = build_db();
+    let c = conn(&db);
+
+    // Same expression, no deadline: takes the fast path and succeeds, so the
+    // 408 below is attributable to the deadline and not to a broken query.
+    let ok = ops::expand(&c, Some("<<73211009"), None, 10, 0, false, None).unwrap();
+    assert!(
+        ok["expansion"]["total"].as_u64().unwrap() > 0,
+        "fast path should return the diabetes subtree: {ok}"
+    );
+
+    let error = ops::expand(
+        &c,
+        Some("<<73211009"),
+        None,
+        10,
+        0,
+        false,
+        Some(Instant::now() - Duration::from_secs(1)),
+    )
+    .unwrap_err();
+    assert_eq!(error.status, 408);
+    assert_eq!(error.code, "timeout");
+}
+
 #[test]
 fn expand_pagination() {
     let (_d, db) = build_db();

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -15,7 +15,7 @@ use sct_rs::commands::sqlite;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 fn fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -261,18 +261,27 @@ fn expand_ecl_filter_and_combined() {
     let (_d, db) = build_db();
     let c = conn(&db);
 
-    let v = ops::expand(&c, Some("<<73211009"), None, 100, 0, false).unwrap();
+    let v = ops::expand(&c, Some("<<73211009"), None, 100, 0, false, None).unwrap();
     assert_eq!(v["resourceType"], "ValueSet");
     assert_eq!(v["expansion"]["total"], 3);
     let mut codes = contains_codes(&v);
     codes.sort();
     assert_eq!(codes, ["44054006", "46635009", "73211009"]);
 
-    let v = ops::expand(&c, None, Some("diabetes"), 100, 0, false).unwrap();
+    let v = ops::expand(&c, None, Some("diabetes"), 100, 0, false, None).unwrap();
     assert!(contains_codes(&v).contains(&"73211009".to_string()));
 
     // ECL ∩ text filter: clinical findings under root, filtered to "diabetes".
-    let v = ops::expand(&c, Some("<<404684003"), Some("diabetes"), 100, 0, false).unwrap();
+    let v = ops::expand(
+        &c,
+        Some("<<404684003"),
+        Some("diabetes"),
+        100,
+        0,
+        false,
+        None,
+    )
+    .unwrap();
     let codes = contains_codes(&v);
     assert!(codes.contains(&"73211009".to_string()));
     assert!(!codes.contains(&"22298006".to_string())); // MI is not a "diabetes" match
@@ -287,16 +296,91 @@ fn expand_rejects_an_overflowing_sctid_as_invalid_ecl() {
         "<<999999999999999999999999",
         "999999999999999999999999 OR 73211009",
     ] {
-        let error = ops::expand(&c, Some(ecl), None, 100, 0, false).unwrap_err();
+        let error = ops::expand(&c, Some(ecl), None, 100, 0, false, None).unwrap_err();
         assert_eq!(error.status, 400, "{ecl}");
         assert_eq!(error.code, "invalid", "{ecl}");
     }
 }
 
+/// R53: a compound (non fast-path) ECL expression is bounded so a remote
+/// client cannot force unbounded in-memory materialisation. `expand`'s SQL
+/// fast path only ever handles a single bare hierarchy/refset operator (see
+/// `expand_fast_path_with_tct_matches` etc.); a boolean `OR` of two branches
+/// always falls through to the general engine, where `EvalLimits` applies.
+/// This uses `expand_with_cap_for_tests` (a `#[doc(hidden)]` test seam) with
+/// a small cap rather than the real 100k production ceiling, because
+/// reaching that scale would need >100k rows of real data that the small
+/// committed synthetic fixture deliberately doesn't have - the mechanism
+/// under test (parse -> bounded evaluation -> `classify_ecl_error` -> FHIR
+/// `too-costly`) is identical either way; only the threshold differs.
+#[test]
+fn expand_caps_compound_ecl_materialisation_and_reports_too_costly() {
+    let (_d, db) = build_db();
+    let c = conn(&db);
+    // Two disjoint hierarchy branches unioned: 4 distinct active concepts in
+    // the fixture (73211009's subtree {73211009, 46635009, 44054006} plus
+    // the unrelated 22298006).
+    const ECL: &str = "<<73211009 OR 22298006";
+
+    let error =
+        ops::expand_with_cap_for_tests(&c, Some(ECL), None, 100, 0, false, None, 2).unwrap_err();
+    assert_eq!(error.status, 403);
+    assert_eq!(error.code, "too-costly");
+    assert!(
+        error.diagnostics.contains("more than 2 concepts"),
+        "{}",
+        error.diagnostics
+    );
+
+    // Sanity: the identical expression succeeds once it fits under the cap -
+    // proving the rejection above is really about the cap, not a broken
+    // expression or an off-by-one in the check.
+    let ok = ops::expand_with_cap_for_tests(&c, Some(ECL), None, 100, 0, false, None, 10).unwrap();
+    let mut codes = contains_codes(&ok);
+    codes.sort();
+    assert_eq!(codes, ["22298006", "44054006", "46635009", "73211009"]);
+}
+
+/// R53: an already-overdue deadline interrupts compound ECL evaluation
+/// before it returns a result, rather than the request only being abandoned
+/// at the HTTP layer while database work continues in the background (the
+/// gap left open by `R73`, per the `R44`/`R53` audit history). The result
+/// cap is set to `usize::MAX` so only the deadline mechanism is exercised
+/// here; `DeadlineGuard`'s own interruption of a genuinely slow SQL
+/// statement is covered independently in
+/// `commands::serve::ops::deadline_guard_tests`.
+#[test]
+fn expand_deadline_interrupts_evaluation_before_returning_a_result() {
+    let (_d, db) = build_db();
+    let c = conn(&db);
+    let overdue = Instant::now() - Duration::from_secs(1);
+
+    let error = ops::expand_with_cap_for_tests(
+        &c,
+        Some("<<73211009 OR 22298006"),
+        None,
+        100,
+        0,
+        false,
+        Some(overdue),
+        usize::MAX,
+    )
+    .unwrap_err();
+    assert_eq!(error.status, 408);
+    assert_eq!(error.code, "timeout");
+    // It must not have quietly computed and returned the correct 4-concept
+    // answer anyway - that would mean the deadline check is a no-op.
+    assert!(
+        error.diagnostics.contains("time budget"),
+        "{}",
+        error.diagnostics
+    );
+}
+
 #[test]
 fn expand_pagination() {
     let (_d, db) = build_db();
-    let v = ops::expand(&conn(&db), Some("<<73211009"), None, 2, 0, false).unwrap();
+    let v = ops::expand(&conn(&db), Some("<<73211009"), None, 2, 0, false, None).unwrap();
     assert_eq!(v["expansion"]["total"], 3); // total reflects the full set
     assert_eq!(contains_codes(&v).len(), 2); // page is capped at count
 }
@@ -306,7 +390,7 @@ fn expand_fast_path_with_tct_matches() {
     // Same hierarchy expansion against a DB that has the transitive-closure
     // table - exercises the TCT branch of the SQL fast path.
     let (_d, db) = build_db_with(true);
-    let v = ops::expand(&conn(&db), Some("<<73211009"), None, 100, 0, false).unwrap();
+    let v = ops::expand(&conn(&db), Some("<<73211009"), None, 100, 0, false, None).unwrap();
     assert_eq!(v["expansion"]["total"], 3);
     let mut codes = contains_codes(&v);
     codes.sort();
@@ -316,7 +400,16 @@ fn expand_fast_path_with_tct_matches() {
 #[test]
 fn expand_refset_member_fast_path() {
     let (_d, db) = build_db();
-    let v = ops::expand(&conn(&db), Some("^991381000000107"), None, 100, 0, false).unwrap();
+    let v = ops::expand(
+        &conn(&db),
+        Some("^991381000000107"),
+        None,
+        100,
+        0,
+        false,
+        None,
+    )
+    .unwrap();
     let mut codes = contains_codes(&v);
     codes.sort();
     assert_eq!(codes, ["44054006", "46635009"]);
@@ -334,6 +427,7 @@ fn expand_refinement_falls_back_to_engine() {
         100,
         0,
         false,
+        None,
     )
     .unwrap();
     assert_eq!(contains_codes(&v), ["22298006"]);
@@ -621,6 +715,39 @@ fn http_metadata_and_lookup_round_trip() {
         .send(&oversized.to_string())
         .unwrap_err();
     assert!(matches!(err, ureq::Error::StatusCode(400)));
+}
+
+/// R53, live over real HTTP: a compound (boolean) ECL `$expand` request still
+/// succeeds normally through the production request path in `serve/mod.rs` -
+/// which now computes a per-request deadline and installs/clears a SQLite
+/// progress-handler guard around every ECL evaluation - and a second request
+/// on the same small connection pool succeeds too. That second round trip is
+/// the regression this guards against: if `DeadlineGuard` were left armed on
+/// a pooled connection after the first request (instead of being cleared on
+/// drop), the reused connection would carry a stale, already-expired
+/// deadline into this unrelated later request and spuriously interrupt it.
+#[test]
+fn http_expand_compound_ecl_round_trip_and_pool_stays_healthy() {
+    let (_d, db) = build_db();
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        // A pool of 2 makes connection reuse across the two requests below
+        // near-certain.
+        serve_listener(db, "/", None, None, 2, listener).unwrap();
+    });
+    let base = format!("http://127.0.0.1:{port}");
+    let url = format!(
+        "{base}/ValueSet/$expand?url=http://snomed.info/sct?fhir_vs=ecl/%3C%3C73211009%20OR%2022298006"
+    );
+
+    for _ in 0..2 {
+        let v: Value = serde_json::from_str(&get_with_retry(&url)).unwrap();
+        assert_eq!(v["resourceType"], "ValueSet");
+        let mut codes = contains_codes(&v);
+        codes.sort();
+        assert_eq!(codes, ["22298006", "44054006", "46635009", "73211009"]);
+    }
 }
 
 /// GET with a short retry loop while the background server starts accepting.


### PR DESCRIPTION
## Summary

Nightly roadmap pickup (no mergeable Dependabot PRs and no other unmerged Claude PR waiting) - implements `spec/roadmap.md` item `R53`, the last open item from the `R44` availability finding in the 2026-07 audit:

> Cap or stream compound ECL and combined ECL/filter expansion so a remote client cannot force unbounded result materialisation, and replace uncancellable `spawn_blocking` work with an execution model that stops database work when the 30-second HTTP response timeout fires.

### Design

Two independent, cooperative mechanisms (Tokio genuinely cannot forcibly preempt a running `spawn_blocking` thread):

1. **Result-count cap** (`src/ecl/eval.rs`): a new `EvalLimits { max_results, deadline }` is threaded through the recursive evaluator and checked at every AST node boundary and periodically inside the row-streaming loops that pull from SQLite. `evaluate()`/`evaluate_with_tct()` (used by CLI/SDK/MCP) stay unbounded and unchanged. Only `sct serve`'s `ops::eval_ecl` builds a bounded `EvalLimits`, via the new `evaluate_bounded()` (`#[cfg(feature = "serve")]`). Cap is `MAX_COMPOUND_ECL_RESULTS = 100_000`, applied only to the compound/general-engine path - the existing SQL fast path for a bare hierarchy/refset operator already never materialises more than one page and is untouched.
2. **Deadline enforcement, two layers**: (a) `EvalLimits.deadline` is checked at the same Rust-level checkpoints as the cap, catching many small cheap statements that overrun the wall clock in aggregate. (b) `DeadlineGuard` installs a `sqlite3_progress_handler` (rusqlite's `hooks` feature, newly enabled) around the pooled connection for the request's lifetime, interrupting (`SQLITE_INTERRUPT`) a single genuinely long-running statement mid-execution. The guard is RAII-cleared on drop since connections are pooled/reused. Both use the same 30s budget as the existing Tower timeout layer from the earlier `R73` fix, so DB work now stops close to when the client's HTTP response already timed out, rather than running to completion in the background.

Cap violations report FHIR `too-costly` (403); deadline violations (either mechanism) report `timeout` (408, matching the outer middleware); malformed SCTID input stays `invalid` (400).

### Files changed

- `Cargo.toml` - enable rusqlite's `hooks` feature.
- `src/ecl/eval.rs` - `EvalLimits`, `EclBoundError`, `evaluate_bounded`; bound checks threaded through the evaluator.
- `src/commands/serve/ops.rs` - `MAX_COMPOUND_ECL_RESULTS`, `DeadlineGuard`, `classify_ecl_error`; handlers take a `deadline`; `expand_with_cap_for_tests` (test-only seam) exposes a caller-supplied cap so the bound-violation path is regression-tested against the small committed fixture without needing >100k rows of real data.
- `src/commands/serve/mod.rs` - `expand`, `vs_validate_code`, and `batch`/`run_operation` compute `Instant::now() + REQUEST_TIMEOUT` and thread it through (one deadline per batch request, not per entry).
- `src/commands/serve/fhir.rs` - `FhirError::too_costly` (403).
- `tests/serve.rs` - new regression tests (below).
- `spec/roadmap.md` - removes the completed `R53` item from the autonomous queue and the assurance/evidence list.

## Test plan

- [x] New unit tests in `commands::serve::ops::deadline_guard_tests` proving `DeadlineGuard` genuinely interrupts a deliberately expensive recursive-CTE statement promptly, is inert before the deadline, and is cleared on drop (so a reused pooled connection isn't wrongly interrupted by a stale handler).
- [x] `expand_caps_compound_ecl_materialisation_and_reports_too_costly` - against the real fixture DB via `sct sqlite`, a compound `OR` expression is rejected with 403/`too-costly` under a small test cap and succeeds once under it, through the exact production code path.
- [x] `expand_deadline_interrupts_evaluation_before_returning_a_result` - an already-overdue deadline aborts evaluation with 408/`timeout` rather than returning the correct answer.
- [x] `http_expand_compound_ecl_round_trip_and_pool_stays_healthy` - live HTTP round trip proving normal compound-ECL traffic still works with the deadline wiring in place, and that a second request on the same small pool succeeds (guards against a leaked/stale progress handler).
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings`, `--features serve`, `--features dmwb`, and `--manifest-path python/Cargo.toml` all clean (the last required gating `evaluate_bounded` behind `#[cfg(feature = "serve")]` to avoid a dead-code warning when the python crate builds `sct-rs` without `serve`)
- [x] `cargo test` (all default-feature targets, includes `serve`) and `cargo test --features serve` - all green, 294+ lib tests plus all integration/doc tests passing
- [ ] `reuse lint` - not runnable in this sandbox (`reuse` tool not installed). No new files were added (only existing SPDX-headered files edited), so REUSE compliance risk is low, but this wasn't executed and should be run before release.

https://claude.ai/code/session_018J71ZxBNJ9m6XKbe4r56mr

---
_Generated by [Claude Code](https://claude.ai/code/session_018J71ZxBNJ9m6XKbe4r56mr)_