### PR TITLE
feat(serve): add activeOnly to ValueSet/$expand (R16)

### DIFF
--- a/docs/commands/serve.md
+++ b/docs/commands/serve.md
@@ -106,7 +106,7 @@ curl 'http://localhost:8080/ValueSet/$expand?url=http://snomed.info/sct?fhir_vs&
 curl 'http://localhost:8080/ValueSet/$expand?url=http://snomed.info/sct?fhir_vs=ecl/%3C%3C404684003%20:%20363698007%20=%20%3C%3C39057004'
 ```
 
-`count` (default 100, max 1000) and `offset` paginate; malformed or negative values return HTTP 400, and the `expansion.total` reflects the full match set. `includeDesignations=true` adds FSN + synonyms to each entry.
+`count` (default 100, max 1000) and `offset` paginate; malformed or negative values return HTTP 400, and the `expansion.total` reflects the full match set. `includeDesignations=true` adds FSN + synonyms to each entry. `activeOnly` (default `true`) filters the expansion to active concepts; pass `activeOnly=false` to also see retired concepts (e.g. to look up a code from an old record). `activeOnly` applies to the implicit SNOMED ValueSet only - a stored `.codelist` ValueSet's fixed member list always returns every member regardless of this parameter.
 
 ### Stored ValueSets from `.codelist` files
 

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -14,7 +14,7 @@ Legend: `[ ]` not started, `[~]` in progress. The `R##` sequence was deliberatel
 
 An autonomous agent picks the **first unstarted item in this list**, rather than choosing freely from the roadmap. An item is listed here only if it is self-contained, has a written spec or unambiguous acceptance criteria, and is completable *and verifiable* in a single session.
 
-1. `R16` - the practical FHIR surface, **one parameter per pull request** (`activeOnly`, then `displayLanguage`, then designation/property filters). Do not attempt the whole item at once.
+1. `R16` - the practical FHIR surface, **one parameter per pull request** (`activeOnly` shipped; next up: `displayLanguage`, then designation/property filters). Do not attempt the whole item at once.
 2. `R12` - the two remaining compression pieces (straddling-exclusion push-down, then `^refset` cover clauses), specified with worked examples in [`commands/ecl-compress.md`](commands/ecl-compress.md).
 
 Everything else on this roadmap needs a human design decision, spans several sessions, depends on licensed content or an external account, or needs before/after benchmarks against a real release. Do not begin those autonomously; comment on the item or open an issue instead. When this queue is empty, say so rather than substituting unlisted work.
@@ -33,7 +33,7 @@ Everything else on this roadmap needs a human design decision, spans several ses
 
 - [ ] `R15` **Improve semantic-search result quality.** Benchmark per-synonym embeddings with max pooling, hybrid lexical/vector ranking, and clinically tuned models against the documented failure set (synonym dilution, hierarchy drift, and colloquial language) before selecting an implementation. See [`docs/commands/semantic.md`](../docs/commands/semantic.md#known-limitations) and [`spec/commands/embed.md`](commands/embed.md).
 
-- [ ] `R16` **Complete the practical FHIR terminology surface.** Add `$expand` parameters (`activeOnly`, `displayLanguage`, designation/property filters, system/value-set versions), CodeSystem resource read, optional stored-ValueSet canonical URL override/draft filtering, then the useful FHIR R5 additions. Keep multi-version routing and national syndication explicitly out of scope until there is a concrete consumer.
+- [~] `R16` **Complete the practical FHIR terminology surface.** Add `$expand` parameters (`activeOnly`, `displayLanguage`, designation/property filters, system/value-set versions), CodeSystem resource read, optional stored-ValueSet canonical URL override/draft filtering, then the useful FHIR R5 additions. Keep multi-version routing and national syndication explicitly out of scope until there is a concrete consumer.
 
 ## Browser SDK
 

--- a/src/commands/serve/mod.rs
+++ b/src/commands/serve/mod.rs
@@ -415,7 +415,7 @@ async fn expand(State(st): State<AppState>, headers: HeaderMap, RawQuery(q): Raw
         return r;
     }
     let params = parse_query(q.as_deref().unwrap_or(""));
-    let (count, offset, include_designations) = match pagination(&params) {
+    let (count, offset, include_designations, active_only) = match pagination(&params) {
         Ok(v) => v,
         Err(e) => return fhir_err(e),
     };
@@ -442,6 +442,7 @@ async fn expand(State(st): State<AppState>, headers: HeaderMap, RawQuery(q): Raw
             count,
             offset,
             include_designations,
+            active_only,
             Some(deadline),
         )
     })
@@ -501,7 +502,8 @@ async fn valueset_expand_id(
     };
     let members = vs.members.clone();
     let params = parse_query(q.as_deref().unwrap_or(""));
-    let (count, offset, include_designations) = match pagination(&params) {
+    // `activeOnly` is intentionally unused here - see `pagination`'s doc comment.
+    let (count, offset, include_designations, _active_only) = match pagination(&params) {
         Ok(v) => v,
         Err(e) => return fhir_err(e),
     };
@@ -691,7 +693,7 @@ fn run_operation(
             )),
         },
         "ValueSet/$expand" => {
-            let (count, offset, desig) = match pagination(&params) {
+            let (count, offset, desig, active_only) = match pagination(&params) {
                 Ok(v) => v,
                 Err(e) => return (e.status, e.outcome()),
             };
@@ -706,6 +708,7 @@ fn run_operation(
                     count,
                     offset,
                     desig,
+                    active_only,
                     Some(deadline),
                 )
             }
@@ -848,11 +851,14 @@ fn pagination_usize(
     }
 }
 
-/// Parse and validate the common `count` / `offset` /
-/// `includeDesignations` expansion params. `count` is capped centrally so all
-/// HTTP and batch routes report the same effective page size; `ops` retains its
-/// own cap as defence in depth.
-fn pagination(params: &[(String, String)]) -> Result<(usize, usize, bool), FhirError> {
+/// Parse and validate the common `count` / `offset` / `includeDesignations` /
+/// `activeOnly` expansion params. `count` is capped centrally so all HTTP and
+/// batch routes report the same effective page size; `ops` retains its own
+/// cap as defence in depth. `activeOnly` defaults to true, per
+/// `spec/commands/serve.md`; it applies only to the implicit SNOMED
+/// CodeSystem expansion (`ops::expand`) - a stored `.codelist` ValueSet's
+/// fixed member list (`ops::expand_members`) does not honour it yet.
+fn pagination(params: &[(String, String)]) -> Result<(usize, usize, bool, bool), FhirError> {
     let count =
         pagination_usize(params, "count", DEFAULT_EXPANSION_COUNT)?.min(MAX_EXPANSION_COUNT);
     let offset = pagination_usize(params, "offset", 0)?;
@@ -862,7 +868,10 @@ fn pagination(params: &[(String, String)]) -> Result<(usize, usize, bool), FhirE
     let include_designations = param(params, "includeDesignations")
         .map(|s| s.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
-    Ok((count, offset, include_designations))
+    let active_only = param(params, "activeOnly")
+        .map(|s| s.eq_ignore_ascii_case("true"))
+        .unwrap_or(true);
+    Ok((count, offset, include_designations, active_only))
 }
 
 fn params_all(params: &[(String, String)], key: &str) -> Vec<String> {
@@ -953,13 +962,13 @@ mod tests {
 
     #[test]
     fn pagination_defaults_caps_and_parses() {
-        assert_eq!(pagination(&[]).unwrap(), (100, 0, false));
+        assert_eq!(pagination(&[]).unwrap(), (100, 0, false, true));
         assert_eq!(
             pagination(&parse_query(
-                "count=5000&offset=42&includeDesignations=true"
+                "count=5000&offset=42&includeDesignations=true&activeOnly=false"
             ))
             .unwrap(),
-            (1000, 42, true)
+            (1000, 42, true, false)
         );
     }
 

--- a/src/commands/serve/ops.rs
+++ b/src/commands/serve/ops.rs
@@ -329,12 +329,16 @@ pub fn subsumes(conn: &Connection, code_a: &str, code_b: &str) -> Result<Value, 
 }
 
 /// `ValueSet/$expand` over an optional ECL constraint and/or text filter.
-/// `deadline`, when set, bounds the ECL/combined-filter evaluation path (see
-/// [`eval_ecl`], roadmap `R53`); server handlers pass `Instant::now() +
-/// REQUEST_TIMEOUT`, tests pass `None`. Always applies the production
-/// compound-result cap (`MAX_COMPOUND_ECL_RESULTS`) - see
-/// [`expand_with_cap_for_tests`] for the test-only variant with a
-/// caller-supplied cap.
+/// `active_only` (the FHIR `activeOnly` parameter) filters the expansion to
+/// active concepts when true; `sct serve` defaults this to true (see
+/// `spec/commands/serve.md`), matching the pre-`activeOnly` behaviour of the
+/// wildcard and text-filter paths. `deadline`, when set, bounds the
+/// ECL/combined-filter evaluation path (see [`eval_ecl`], roadmap `R53`);
+/// server handlers pass `Instant::now() + REQUEST_TIMEOUT`, tests pass
+/// `None`. Always applies the production compound-result cap
+/// (`MAX_COMPOUND_ECL_RESULTS`) - see [`expand_with_cap_for_tests`] for the
+/// test-only variant with a caller-supplied cap.
+#[allow(clippy::too_many_arguments)]
 pub fn expand(
     conn: &Connection,
     ecl: Option<&str>,
@@ -342,6 +346,7 @@ pub fn expand(
     count: usize,
     offset: usize,
     include_designations: bool,
+    active_only: bool,
     deadline: Option<Instant>,
 ) -> Result<Value, FhirError> {
     expand_inner(
@@ -351,6 +356,7 @@ pub fn expand(
         count,
         offset,
         include_designations,
+        active_only,
         deadline,
         MAX_COMPOUND_ECL_RESULTS,
     )
@@ -372,6 +378,7 @@ pub fn expand_with_cap_for_tests(
     count: usize,
     offset: usize,
     include_designations: bool,
+    active_only: bool,
     deadline: Option<Instant>,
     max_results: usize,
 ) -> Result<Value, FhirError> {
@@ -382,6 +389,7 @@ pub fn expand_with_cap_for_tests(
         count,
         offset,
         include_designations,
+        active_only,
         deadline,
         max_results,
     )
@@ -395,6 +403,7 @@ fn expand_inner(
     count: usize,
     offset: usize,
     include_designations: bool,
+    active_only: bool,
     deadline: Option<Instant>,
     max_results: usize,
 ) -> Result<Value, FhirError> {
@@ -444,6 +453,7 @@ fn expand_inner(
                         count,
                         offset,
                         include_designations,
+                        active_only,
                     );
                 }
             }
@@ -453,13 +463,18 @@ fn expand_inner(
     let matched: Vec<String> = match (ecl, filter) {
         // Entire implicit SNOMED ValueSet: paginate in SQL.
         (None, None) => {
+            let where_clause = if active_only { "WHERE active = 1" } else { "" };
             let total: i64 = conn
-                .query_row("SELECT COUNT(*) FROM concepts WHERE active = 1", [], |r| {
-                    r.get(0)
-                })
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM concepts {where_clause}"),
+                    [],
+                    |r| r.get(0),
+                )
                 .map_err(ex)?;
             let mut stmt = conn
-                .prepare("SELECT id FROM concepts WHERE active = 1 ORDER BY id LIMIT ?1 OFFSET ?2")
+                .prepare(&format!(
+                    "SELECT id FROM concepts {where_clause} ORDER BY id LIMIT ?1 OFFSET ?2"
+                ))
                 .map_err(ex)?;
             let ids: Vec<String> = stmt
                 .query_map([count as i64, offset as i64], |r| r.get(0))
@@ -469,13 +484,20 @@ fn expand_inner(
             let contains = build_contains(conn, &ids, include_designations)?;
             return Ok(value_set_expansion(total as usize, offset, count, contains));
         }
-        (Some(e), None) => eval_ecl(conn, e, deadline, max_results)?,
-        (None, Some(f)) => fts_ids(conn, f)?,
+        (Some(e), None) => {
+            let ids = eval_ecl(conn, e, deadline, max_results)?;
+            if active_only {
+                filter_active_ids(conn, ids)?
+            } else {
+                ids
+            }
+        }
+        (None, Some(f)) => fts_ids(conn, f, active_only)?,
         (Some(e), Some(f)) => {
             let set: HashSet<String> = eval_ecl(conn, e, deadline, max_results)?
                 .into_iter()
                 .collect();
-            fts_ids(conn, f)?
+            fts_ids(conn, f, active_only)?
                 .into_iter()
                 .filter(|id| set.contains(id))
                 .collect()
@@ -553,13 +575,14 @@ fn classify_ecl_error(error: anyhow::Error) -> FhirError {
 
 /// FTS5 ids ordered by relevance, capped. Plain text is wrapped as a phrase to
 /// avoid FTS5 parse errors on bare special characters.
-fn fts_ids(conn: &Connection, filter: &str) -> Result<Vec<String>, FhirError> {
+fn fts_ids(conn: &Connection, filter: &str, active_only: bool) -> Result<Vec<String>, FhirError> {
     let q = sanitise_fts(filter);
+    let active_and = if active_only { "AND c.active = 1" } else { "" };
     let mut stmt = conn
-        .prepare_cached(
+        .prepare_cached(&format!(
             "SELECT c.id FROM concepts_fts JOIN concepts c ON concepts_fts.rowid = c.rowid
-             WHERE concepts_fts MATCH ?1 AND c.active = 1 ORDER BY rank LIMIT 5000",
-        )
+             WHERE concepts_fts MATCH ?1 {active_and} ORDER BY rank LIMIT 5000"
+        ))
         .map_err(ex)?;
     let ids = stmt
         .query_map([q], |r| r.get::<_, String>(0))
@@ -567,6 +590,32 @@ fn fts_ids(conn: &Connection, filter: &str) -> Result<Vec<String>, FhirError> {
         .collect::<Result<_, _>>()
         .map_err(ex)?;
     Ok(ids)
+}
+
+/// Filter `ids` (already-materialised matches from the general ECL engine, which
+/// itself is `activeOnly`-agnostic - see [`eval_ecl`]) down to active concepts,
+/// preserving `ids`' order. Batches the membership check to stay well clear of
+/// SQLite's bound-parameter limit for large compound-ECL result sets.
+fn filter_active_ids(conn: &Connection, ids: Vec<String>) -> Result<Vec<String>, FhirError> {
+    if ids.is_empty() {
+        return Ok(ids);
+    }
+    const CHUNK: usize = 500;
+    let mut active: HashSet<String> = HashSet::with_capacity(ids.len());
+    for chunk in ids.chunks(CHUNK) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT id FROM concepts WHERE active = 1 AND id IN ({placeholders})");
+        let mut stmt = conn.prepare(&sql).map_err(ex)?;
+        let params: Vec<&dyn rusqlite::ToSql> =
+            chunk.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let rows = stmt
+            .query_map(params.as_slice(), |r| r.get::<_, String>(0))
+            .map_err(ex)?;
+        for r in rows {
+            active.insert(r.map_err(ex)?);
+        }
+    }
+    Ok(ids.into_iter().filter(|id| active.contains(id)).collect())
 }
 
 fn sanitise_fts(q: &str) -> String {
@@ -658,67 +707,128 @@ fn simple_op(expr: &Expr) -> Option<(Option<Op>, String)> {
 /// query orders by the id column, which for the transitive-closure cases is the
 /// second column of the `(ancestor_id, descendant_id)` index - so SQLite serves
 /// the page straight from the index with no sort.
-fn body_sql(op: Op, tct: bool) -> (String, String) {
+///
+/// When `active_only` is true, an inner join against `concepts` restricts both
+/// queries to active concepts (same join shape as [`ancestors`]'s TCT branch),
+/// trading the pure index-only scan for one indexed `concepts` probe per row -
+/// still index-backed, just no longer the single covering-index scan the
+/// `active_only: false` form gets.
+fn body_sql(op: Op, tct: bool, active_only: bool) -> (String, String) {
     match (op, tct) {
-        (Op::DescendantOf | Op::DescendantOrSelfOf, true) => (
-            "SELECT COUNT(*) FROM concept_ancestors WHERE ancestor_id = ?1 AND descendant_id != ?1"
-                .into(),
+        (Op::DescendantOf | Op::DescendantOrSelfOf, true) => {
             // concept_ancestors.descendant_id is INTEGER; CAST back to TEXT so
             // the row reader (shared with the TEXT concept_isa CTE path) sees a
             // string. ORDER BY is on the INTEGER column, so paging is numeric.
-            "SELECT CAST(descendant_id AS TEXT) FROM concept_ancestors
-             WHERE ancestor_id = ?1 AND descendant_id != ?1
-             ORDER BY descendant_id LIMIT ?2 OFFSET ?3"
-                .into(),
-        ),
+            let join = if active_only {
+                "JOIN concepts ac ON ac.id = CAST(ca.descendant_id AS TEXT) AND ac.active = 1"
+            } else {
+                ""
+            };
+            (
+                format!(
+                    "SELECT COUNT(*) FROM concept_ancestors ca {join}
+                     WHERE ca.ancestor_id = ?1 AND ca.descendant_id != ?1"
+                ),
+                format!(
+                    "SELECT CAST(ca.descendant_id AS TEXT) FROM concept_ancestors ca {join}
+                     WHERE ca.ancestor_id = ?1 AND ca.descendant_id != ?1
+                     ORDER BY ca.descendant_id LIMIT ?2 OFFSET ?3"
+                ),
+            )
+        }
         (Op::DescendantOf | Op::DescendantOrSelfOf, false) => {
             let cte = "WITH RECURSIVE d(id) AS (
                 SELECT child_id FROM concept_isa WHERE parent_id = ?1
                 UNION
                 SELECT ci.child_id FROM concept_isa ci JOIN d ON ci.parent_id = d.id)";
+            let join = if active_only {
+                "JOIN concepts ac ON ac.id = d.id AND ac.active = 1"
+            } else {
+                ""
+            };
             (
-                format!("{cte} SELECT COUNT(*) FROM d"),
-                format!("{cte} SELECT id FROM d ORDER BY id LIMIT ?2 OFFSET ?3"),
+                format!("{cte} SELECT COUNT(*) FROM d {join}"),
+                format!("{cte} SELECT d.id FROM d {join} ORDER BY d.id LIMIT ?2 OFFSET ?3"),
             )
         }
-        (Op::AncestorOf | Op::AncestorOrSelfOf, true) => (
-            "SELECT COUNT(*) FROM concept_ancestors WHERE descendant_id = ?1 AND ancestor_id != ?1"
-                .into(),
+        (Op::AncestorOf | Op::AncestorOrSelfOf, true) => {
             // See the descendant case: CAST INTEGER id back to TEXT for the
             // shared row reader; ORDER BY stays on the INTEGER column.
-            "SELECT CAST(ancestor_id AS TEXT) FROM concept_ancestors
-             WHERE descendant_id = ?1 AND ancestor_id != ?1
-             ORDER BY ancestor_id LIMIT ?2 OFFSET ?3"
-                .into(),
-        ),
+            let join = if active_only {
+                "JOIN concepts ac ON ac.id = CAST(ca.ancestor_id AS TEXT) AND ac.active = 1"
+            } else {
+                ""
+            };
+            (
+                format!(
+                    "SELECT COUNT(*) FROM concept_ancestors ca {join}
+                     WHERE ca.descendant_id = ?1 AND ca.ancestor_id != ?1"
+                ),
+                format!(
+                    "SELECT CAST(ca.ancestor_id AS TEXT) FROM concept_ancestors ca {join}
+                     WHERE ca.descendant_id = ?1 AND ca.ancestor_id != ?1
+                     ORDER BY ca.ancestor_id LIMIT ?2 OFFSET ?3"
+                ),
+            )
+        }
         (Op::AncestorOf | Op::AncestorOrSelfOf, false) => {
             let cte = "WITH RECURSIVE a(id) AS (
                 SELECT parent_id FROM concept_isa WHERE child_id = ?1
                 UNION
                 SELECT ci.parent_id FROM concept_isa ci JOIN a ON ci.child_id = a.id)";
+            let join = if active_only {
+                "JOIN concepts ac ON ac.id = a.id AND ac.active = 1"
+            } else {
+                ""
+            };
             (
-                format!("{cte} SELECT COUNT(*) FROM a"),
-                format!("{cte} SELECT id FROM a ORDER BY id LIMIT ?2 OFFSET ?3"),
+                format!("{cte} SELECT COUNT(*) FROM a {join}"),
+                format!("{cte} SELECT a.id FROM a {join} ORDER BY a.id LIMIT ?2 OFFSET ?3"),
             )
         }
-        (Op::ChildOf, _) => (
-            "SELECT COUNT(*) FROM concept_isa WHERE parent_id = ?1".into(),
-            "SELECT child_id FROM concept_isa WHERE parent_id = ?1
-             ORDER BY child_id LIMIT ?2 OFFSET ?3"
-                .into(),
-        ),
-        (Op::ParentOf, _) => (
-            "SELECT COUNT(*) FROM concept_isa WHERE child_id = ?1".into(),
-            "SELECT parent_id FROM concept_isa WHERE child_id = ?1
-             ORDER BY parent_id LIMIT ?2 OFFSET ?3"
-                .into(),
-        ),
-        (Op::MemberOf, _) => (
-            "SELECT COUNT(*) FROM refset_members WHERE refset_id = ?1".into(),
-            "SELECT referenced_component_id FROM refset_members WHERE refset_id = ?1
-             ORDER BY referenced_component_id LIMIT ?2 OFFSET ?3"
-                .into(),
-        ),
+        (Op::ChildOf, _) => {
+            let join = if active_only {
+                "JOIN concepts ac ON ac.id = ci.child_id AND ac.active = 1"
+            } else {
+                ""
+            };
+            (
+                format!("SELECT COUNT(*) FROM concept_isa ci {join} WHERE ci.parent_id = ?1"),
+                format!(
+                    "SELECT ci.child_id FROM concept_isa ci {join} WHERE ci.parent_id = ?1
+                     ORDER BY ci.child_id LIMIT ?2 OFFSET ?3"
+                ),
+            )
+        }
+        (Op::ParentOf, _) => {
+            let join = if active_only {
+                "JOIN concepts ac ON ac.id = ci.parent_id AND ac.active = 1"
+            } else {
+                ""
+            };
+            (
+                format!("SELECT COUNT(*) FROM concept_isa ci {join} WHERE ci.child_id = ?1"),
+                format!(
+                    "SELECT ci.parent_id FROM concept_isa ci {join} WHERE ci.child_id = ?1
+                     ORDER BY ci.parent_id LIMIT ?2 OFFSET ?3"
+                ),
+            )
+        }
+        (Op::MemberOf, _) => {
+            let join = if active_only {
+                "JOIN concepts ac ON ac.id = rm.referenced_component_id AND ac.active = 1"
+            } else {
+                ""
+            };
+            (
+                format!("SELECT COUNT(*) FROM refset_members rm {join} WHERE rm.refset_id = ?1"),
+                format!(
+                    "SELECT rm.referenced_component_id FROM refset_members rm {join}
+                     WHERE rm.refset_id = ?1
+                     ORDER BY rm.referenced_component_id LIMIT ?2 OFFSET ?3"
+                ),
+            )
+        }
     }
 }
 
@@ -727,6 +837,7 @@ fn body_sql(op: Op, tct: bool) -> (String, String) {
 /// reaches Rust. For the `-or-self` operators (`<<`, `>>`) and a bare concept,
 /// the focus concept is prepended to the result (FHIR does not mandate an
 /// ordering), shifting the body page by one slot.
+#[allow(clippy::too_many_arguments)]
 fn expand_simple(
     conn: &Connection,
     op: Option<Op>,
@@ -735,21 +846,25 @@ fn expand_simple(
     count: usize,
     offset: usize,
     include_designations: bool,
+    active_only: bool,
 ) -> Result<Value, FhirError> {
     let include_self = matches!(
         op,
         None | Some(Op::DescendantOrSelfOf) | Some(Op::AncestorOrSelfOf)
     );
-    // Only count/return self when it is an actual active concept.
+    // Self only counts/is returned when it exists, and (when `active_only`) is
+    // active - so `activeOnly=false` can surface an inactive focus concept
+    // (e.g. a bare `ecl/<inactive-id>` or `<<<inactive-id>`) that
+    // `activeOnly=true` (the default) correctly excludes.
     let self_active = include_self
         && fetch_concept(conn, concept_id)?
-            .map(|c| c.active)
+            .map(|c| !active_only || c.active)
             .unwrap_or(false);
 
     let body_count: i64 = match op {
         None => 0,
         Some(o) => {
-            let (count_sql, _) = body_sql(o, tct);
+            let (count_sql, _) = body_sql(o, tct, active_only);
             conn.query_row(&count_sql, [concept_id], |r| r.get(0))
                 .map_err(ex)?
         }
@@ -773,7 +888,7 @@ fn expand_simple(
     }
     if remaining > 0 {
         if let Some(o) = op {
-            let (_, page_sql) = body_sql(o, tct);
+            let (_, page_sql) = body_sql(o, tct, active_only);
             let mut stmt = conn.prepare(&page_sql).map_err(ex)?;
             let rows = stmt
                 .query_map(

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -53,6 +53,15 @@ fn build_db_all() -> (tempfile::TempDir, PathBuf) {
 /// Build the fixture DB, optionally with the transitive-closure table so the
 /// `$expand` fast path exercises its TCT SQL form.
 fn build_db_with(tct: bool) -> (tempfile::TempDir, PathBuf) {
+    build_db_with_inactive(tct, false)
+}
+
+/// Like [`build_db_with`], but optionally loads inactive concepts too - the
+/// fixture's `9468002` ("Inactive example disorder", `active=0`, an IS-A child
+/// of `404684003`) only appears in the DB when `include_inactive` is true, so
+/// `activeOnly` tests need this builder rather than the default (which always
+/// excludes it, independent of `activeOnly`).
+fn build_db_with_inactive(tct: bool, include_inactive: bool) -> (tempfile::TempDir, PathBuf) {
     let dir = tempfile::tempdir().unwrap();
     let ndjson = dir.path().join("syn.ndjson");
     let db = dir.path().join("syn.db");
@@ -60,7 +69,7 @@ fn build_db_with(tct: bool) -> (tempfile::TempDir, PathBuf) {
         rf2_dirs: vec![fixture_dir()],
         locale: "en-GB".to_string(),
         output: Some(ndjson.clone()),
-        include_inactive: false,
+        include_inactive,
         refsets: RefsetMode::Simple,
     })
     .unwrap();
@@ -261,14 +270,14 @@ fn expand_ecl_filter_and_combined() {
     let (_d, db) = build_db();
     let c = conn(&db);
 
-    let v = ops::expand(&c, Some("<<73211009"), None, 100, 0, false, None).unwrap();
+    let v = ops::expand(&c, Some("<<73211009"), None, 100, 0, false, true, None).unwrap();
     assert_eq!(v["resourceType"], "ValueSet");
     assert_eq!(v["expansion"]["total"], 3);
     let mut codes = contains_codes(&v);
     codes.sort();
     assert_eq!(codes, ["44054006", "46635009", "73211009"]);
 
-    let v = ops::expand(&c, None, Some("diabetes"), 100, 0, false, None).unwrap();
+    let v = ops::expand(&c, None, Some("diabetes"), 100, 0, false, true, None).unwrap();
     assert!(contains_codes(&v).contains(&"73211009".to_string()));
 
     // ECL ∩ text filter: clinical findings under root, filtered to "diabetes".
@@ -279,6 +288,7 @@ fn expand_ecl_filter_and_combined() {
         100,
         0,
         false,
+        true,
         None,
     )
     .unwrap();
@@ -296,7 +306,7 @@ fn expand_rejects_an_overflowing_sctid_as_invalid_ecl() {
         "<<999999999999999999999999",
         "999999999999999999999999 OR 73211009",
     ] {
-        let error = ops::expand(&c, Some(ecl), None, 100, 0, false, None).unwrap_err();
+        let error = ops::expand(&c, Some(ecl), None, 100, 0, false, true, None).unwrap_err();
         assert_eq!(error.status, 400, "{ecl}");
         assert_eq!(error.code, "invalid", "{ecl}");
     }
@@ -322,8 +332,8 @@ fn expand_caps_compound_ecl_materialisation_and_reports_too_costly() {
     // the unrelated 22298006).
     const ECL: &str = "<<73211009 OR 22298006";
 
-    let error =
-        ops::expand_with_cap_for_tests(&c, Some(ECL), None, 100, 0, false, None, 2).unwrap_err();
+    let error = ops::expand_with_cap_for_tests(&c, Some(ECL), None, 100, 0, false, true, None, 2)
+        .unwrap_err();
     assert_eq!(error.status, 403);
     assert_eq!(error.code, "too-costly");
     assert!(
@@ -335,7 +345,8 @@ fn expand_caps_compound_ecl_materialisation_and_reports_too_costly() {
     // Sanity: the identical expression succeeds once it fits under the cap -
     // proving the rejection above is really about the cap, not a broken
     // expression or an off-by-one in the check.
-    let ok = ops::expand_with_cap_for_tests(&c, Some(ECL), None, 100, 0, false, None, 10).unwrap();
+    let ok =
+        ops::expand_with_cap_for_tests(&c, Some(ECL), None, 100, 0, false, true, None, 10).unwrap();
     let mut codes = contains_codes(&ok);
     codes.sort();
     assert_eq!(codes, ["22298006", "44054006", "46635009", "73211009"]);
@@ -362,6 +373,7 @@ fn expand_deadline_interrupts_evaluation_before_returning_a_result() {
         100,
         0,
         false,
+        true,
         Some(overdue),
         usize::MAX,
     )
@@ -390,7 +402,7 @@ fn expand_deadline_also_bounds_the_simple_fast_path() {
 
     // Same expression, no deadline: takes the fast path and succeeds, so the
     // 408 below is attributable to the deadline and not to a broken query.
-    let ok = ops::expand(&c, Some("<<73211009"), None, 10, 0, false, None).unwrap();
+    let ok = ops::expand(&c, Some("<<73211009"), None, 10, 0, false, true, None).unwrap();
     assert!(
         ok["expansion"]["total"].as_u64().unwrap() > 0,
         "fast path should return the diabetes subtree: {ok}"
@@ -403,6 +415,7 @@ fn expand_deadline_also_bounds_the_simple_fast_path() {
         10,
         0,
         false,
+        true,
         Some(Instant::now() - Duration::from_secs(1)),
     )
     .unwrap_err();
@@ -413,7 +426,17 @@ fn expand_deadline_also_bounds_the_simple_fast_path() {
 #[test]
 fn expand_pagination() {
     let (_d, db) = build_db();
-    let v = ops::expand(&conn(&db), Some("<<73211009"), None, 2, 0, false, None).unwrap();
+    let v = ops::expand(
+        &conn(&db),
+        Some("<<73211009"),
+        None,
+        2,
+        0,
+        false,
+        true,
+        None,
+    )
+    .unwrap();
     assert_eq!(v["expansion"]["total"], 3); // total reflects the full set
     assert_eq!(contains_codes(&v).len(), 2); // page is capped at count
 }
@@ -423,7 +446,17 @@ fn expand_fast_path_with_tct_matches() {
     // Same hierarchy expansion against a DB that has the transitive-closure
     // table - exercises the TCT branch of the SQL fast path.
     let (_d, db) = build_db_with(true);
-    let v = ops::expand(&conn(&db), Some("<<73211009"), None, 100, 0, false, None).unwrap();
+    let v = ops::expand(
+        &conn(&db),
+        Some("<<73211009"),
+        None,
+        100,
+        0,
+        false,
+        true,
+        None,
+    )
+    .unwrap();
     assert_eq!(v["expansion"]["total"], 3);
     let mut codes = contains_codes(&v);
     codes.sort();
@@ -440,6 +473,7 @@ fn expand_refset_member_fast_path() {
         100,
         0,
         false,
+        true,
         None,
     )
     .unwrap();
@@ -460,10 +494,152 @@ fn expand_refinement_falls_back_to_engine() {
         100,
         0,
         false,
+        true,
         None,
     )
     .unwrap();
     assert_eq!(contains_codes(&v), ["22298006"]);
+}
+
+/// R16: `activeOnly` (default true) on the SQL fast path (`expand_simple` /
+/// `body_sql`), both without and with the transitive-closure table, so both
+/// the recursive-CTE and TCT-indexed branches are covered. `9468002` is the
+/// fixture's one inactive concept, an IS-A child of `404684003`.
+#[test]
+fn expand_active_only_filters_the_fast_path_descendant_body() {
+    for tct in [false, true] {
+        let (_d, db) = build_db_with_inactive(tct, true);
+        let c = conn(&db);
+
+        let default = ops::expand(&c, Some("<404684003"), None, 100, 0, false, true, None).unwrap();
+        assert!(
+            !contains_codes(&default).contains(&"9468002".to_string()),
+            "tct={tct}: activeOnly defaults to true, should exclude the inactive concept: {default}"
+        );
+
+        let opt_in = ops::expand(&c, Some("<404684003"), None, 100, 0, false, false, None).unwrap();
+        assert!(
+            contains_codes(&opt_in).contains(&"9468002".to_string()),
+            "tct={tct}: activeOnly=false should include the inactive concept: {opt_in}"
+        );
+        assert_eq!(
+            opt_in["expansion"]["total"].as_u64().unwrap(),
+            default["expansion"]["total"].as_u64().unwrap() + 1,
+            "tct={tct}: activeOnly=false should add exactly the one inactive concept"
+        );
+    }
+}
+
+/// R16: `activeOnly` on a bare-concept fast-path expand (`Op::None`, the
+/// `self`-only slot in `expand_simple`) - covers the case where the *focus*
+/// concept itself, not just a body member, is inactive.
+#[test]
+fn expand_active_only_filters_a_bare_inactive_concept() {
+    let (_d, db) = build_db_with_inactive(false, true);
+    let c = conn(&db);
+
+    let default = ops::expand(&c, Some("9468002"), None, 100, 0, false, true, None).unwrap();
+    assert_eq!(default["expansion"]["total"], 0);
+    assert!(contains_codes(&default).is_empty());
+
+    let opt_in = ops::expand(&c, Some("9468002"), None, 100, 0, false, false, None).unwrap();
+    assert_eq!(opt_in["expansion"]["total"], 1);
+    assert_eq!(contains_codes(&opt_in), ["9468002"]);
+}
+
+/// R16: `activeOnly` on the general (non fast-path) ECL engine - a boolean
+/// `OR` always falls through to `eval_ecl`, which is itself `activeOnly`-
+/// agnostic (shared with the CLI/SDK/MCP), so filtering happens afterwards
+/// via `filter_active_ids`.
+#[test]
+fn expand_active_only_filters_the_compound_ecl_path() {
+    let (_d, db) = build_db_with_inactive(false, true);
+    let c = conn(&db);
+    const ECL: &str = "<404684003 OR 22298006";
+
+    let default = ops::expand(&c, Some(ECL), None, 100, 0, false, true, None).unwrap();
+    assert!(!contains_codes(&default).contains(&"9468002".to_string()));
+
+    let opt_in = ops::expand(&c, Some(ECL), None, 100, 0, false, false, None).unwrap();
+    assert!(contains_codes(&opt_in).contains(&"9468002".to_string()));
+}
+
+/// R16: `activeOnly` on the implicit whole-CodeSystem wildcard expansion
+/// (`ecl=None, filter=None`).
+#[test]
+fn expand_active_only_filters_the_wildcard_path() {
+    let (_d, db) = build_db_with_inactive(false, true);
+    let c = conn(&db);
+
+    let default = ops::expand(&c, None, None, 1000, 0, false, true, None).unwrap();
+    assert!(!contains_codes(&default).contains(&"9468002".to_string()));
+
+    let opt_in = ops::expand(&c, None, None, 1000, 0, false, false, None).unwrap();
+    assert!(contains_codes(&opt_in).contains(&"9468002".to_string()));
+    assert_eq!(
+        opt_in["expansion"]["total"].as_u64().unwrap(),
+        default["expansion"]["total"].as_u64().unwrap() + 1
+    );
+}
+
+/// R16: `activeOnly` on the FTS5 text-filter path (`fts_ids`). `9468002`'s
+/// FSN is "Inactive example disorder (disorder)".
+#[test]
+fn expand_active_only_filters_the_text_filter_path() {
+    let (_d, db) = build_db_with_inactive(false, true);
+    let c = conn(&db);
+
+    let default = ops::expand(
+        &c,
+        None,
+        Some("inactive example"),
+        100,
+        0,
+        false,
+        true,
+        None,
+    )
+    .unwrap();
+    assert!(contains_codes(&default).is_empty());
+
+    let opt_in = ops::expand(
+        &c,
+        None,
+        Some("inactive example"),
+        100,
+        0,
+        false,
+        false,
+        None,
+    )
+    .unwrap();
+    assert_eq!(contains_codes(&opt_in), ["9468002"]);
+}
+
+/// R16, live over real HTTP: the `activeOnly` query parameter round-trips
+/// through `pagination()`/`expand()` on the production request path.
+#[test]
+fn http_expand_active_only_query_param_round_trip() {
+    let (_d, db) = build_db_with_inactive(false, true);
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        serve_listener(db, "/", None, None, 4, listener).unwrap();
+    });
+    let base = format!("http://127.0.0.1:{port}");
+    let ecl_param = "url=http://snomed.info/sct?fhir_vs=ecl/%3C404684003";
+
+    let default: Value = serde_json::from_str(&get_with_retry(&format!(
+        "{base}/ValueSet/$expand?{ecl_param}"
+    )))
+    .unwrap();
+    assert!(!contains_codes(&default).contains(&"9468002".to_string()));
+
+    let opt_in: Value = serde_json::from_str(&get_with_retry(&format!(
+        "{base}/ValueSet/$expand?{ecl_param}&activeOnly=false"
+    )))
+    .unwrap();
+    assert!(contains_codes(&opt_in).contains(&"9468002".to_string()));
 }
 
 /// Write a `codelists/` dir with a `diabetes` list (extensional) and a


### PR DESCRIPTION
## Summary

Roadmap `R16` ("the practical FHIR terminology surface") is queued in the autonomous nightly agent list as **one parameter per pull request**: `activeOnly`, then `displayLanguage`, then designation/property filters. This PR ships the first: `activeOnly` on `ValueSet/$expand`.

- Adds the FHIR `activeOnly` parameter, default `true` (matching what `spec/commands/serve.md` already documented as the intended behaviour).
- Threads `active_only: bool` through every `$expand` code path so the parameter is honoured consistently, not just on the paths that happened to hardcode `active = 1` already:
  - the wildcard whole-CodeSystem query
  - the FTS5 text-filter path (`fts_ids`)
  - the SQL fast path for a bare hierarchy/refset operator (`expand_simple`/`body_sql`), both the TCT-indexed and recursive-CTE branches, including the focus/self concept itself (so `activeOnly=false` can now surface an inactive focus concept, e.g. `ecl/<inactive-id>`, which was previously excluded unconditionally with no way to opt out)
  - the general ECL engine path (compound boolean/refinement expressions) - filtered *after* evaluation via a new `filter_active_ids` helper, rather than inside `eval_ecl` itself, since that evaluator is shared with the CLI/SDK/MCP and has no `activeOnly` concept of its own
- **Deliberately out of scope:** stored `.codelist` ValueSets (`expand_members`) don't honour `activeOnly` yet. That code path already has a considered design choice (retired members are kept with a fallback display) that conflicts with blanket active-filtering; reconciling it needs its own decision rather than a silent behaviour change bundled into this PR. Flagged in code comments and in `docs/commands/serve.md`.

## Verification

Per the roadmap's verification contract: validated against the committed synthetic RF2 fixture in `tests/fixtures/rf2/`, through the real `sct sqlite` schema, using the fixture's one inactive concept (`9468002`, "Inactive example disorder", an IS-A descendant of `404684003`).

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --features serve --all-targets -- -D warnings`
- `cargo clippy --features dmwb --all-targets -- -D warnings`
- `cargo test` and `cargo test --features serve` - all passing (315 lib tests, 28 serve integration tests including 6 new `activeOnly` tests covering the fast path with and without the transitive-closure table, a bare inactive focus concept, the compound-ECL path, the wildcard path, the text-filter path, and one live HTTP round-trip)
- `reuse lint` could not be run - not installed in this environment. No new files were added and all edited files retain their existing SPDX headers, so this should be low-risk, but flagging per the roadmap's "say so plainly" instruction.

Also updated `docs/commands/serve.md` to document the parameter, and `spec/roadmap.md` to mark `R16` in progress and note `activeOnly` as shipped so the next nightly run picks up `displayLanguage` instead of redoing this.

## Test plan

- [x] `cargo test --features serve` passes, including new `activeOnly` coverage
- [x] `cargo clippy` clean across `--all-targets`, `--features serve`, `--features dmwb`
- [x] `cargo fmt --all --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCNzdcWAQBGxarGbbtt7iy)_